### PR TITLE
Progress on Earthly CI

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,0 +1,7 @@
+# Ignore target and other large directories.
+**/target
+**/deploy
+**/Dockerfile
+**/pipeline_data
+**/ldbc-graphalytics-data
+**/.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,29 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-files"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
-dependencies = [
- "actix-http",
- "actix-service",
- "actix-utils",
- "actix-web",
- "askama_escape",
- "bitflags 1.3.2",
- "bytes",
- "derive_more",
- "futures-core",
- "http-range",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
-]
-
-[[package]]
 name = "actix-http"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,12 +515,6 @@ name = "ascii_table"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75054ce561491263d7b80dc2f6f6c6f8cdfd0c7a7c17c5cf3b8117829fa72ae1"
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "async-trait"
@@ -1835,7 +1806,6 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "actix-cors",
- "actix-files",
  "actix-web",
  "actix-web-actors",
  "actix-web-static-files",
@@ -2486,12 +2456,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,19 +28,19 @@ dependencies = [
 
 [[package]]
 name = "actix-codec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+checksum = "617a8268e3537fe1d8c9ead925fca49ef6400927ee7bc26750e90ecee14ce4b8"
 dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-sink",
- "log",
  "memchr",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -272,7 +272,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.4.9",
- "time 0.3.20",
+ "time",
  "url",
 ]
 
@@ -301,8 +301,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2262160a7ae29e3415554a3f1fc04c764b1540c116aa524683208078b7a75bc9"
 dependencies = [
  "actix-router",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -324,8 +324,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -346,14 +346,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug",
 ]
 
 [[package]]
@@ -421,9 +420,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -460,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -470,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -522,9 +521,9 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -603,7 +602,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -657,8 +656,8 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "regex",
  "rustc-hash",
  "shlex",
@@ -688,9 +687,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 dependencies = [
  "serde",
 ]
@@ -736,7 +735,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
  "syn 1.0.109",
 ]
 
@@ -746,8 +745,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -757,8 +756,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -803,15 +802,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fe11640a23eb24562225322cd3e452b93a3d4091d62fab69c70542fcd17d1f"
+checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -820,12 +819,12 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
+checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -904,7 +903,7 @@ checksum = "751f7f4e7a091545e7f6c65bacc404eaee7e87bfb1f9ece234a1caa173dc16f2"
 dependencies = [
  "cached_proc_macro_types",
  "darling 0.13.4",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -961,20 +960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -983,15 +979,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
 dependencies = [
  "ciborium-io",
  "half",
@@ -999,11 +995,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1019,13 +1016,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -1036,9 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -1047,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.4"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1060,14 +1057,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -1078,9 +1075,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1108,16 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,15 +1123,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "d0525278dce688103060006713371cedbad27186c7d913f33d866b498da0f595"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1166,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.20",
+ "time",
  "version_check",
 ]
 
@@ -1347,7 +1334,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.23",
+ "clap 3.2.25",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -1497,7 +1484,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -1506,50 +1493,6 @@ name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
-
-[[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
-]
 
 [[package]]
 name = "daemonize"
@@ -1573,12 +1516,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
 ]
 
 [[package]]
@@ -1589,24 +1532,24 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "strsim",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "strsim",
- "syn 1.0.109",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1616,19 +1559,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.26",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.14.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
- "darling_core 0.14.4",
- "quote 1.0.26",
- "syn 1.0.109",
+ "darling_core 0.20.1",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1649,11 +1592,11 @@ name = "dataflow-jit"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "bitflags 2.1.0",
+ "bitflags 2.3.1",
  "bitvec",
  "cfg-if",
  "chrono",
- "clap 4.2.4",
+ "clap 4.2.7",
  "cranelift",
  "cranelift-codegen",
  "cranelift-jit",
@@ -1693,7 +1636,7 @@ dependencies = [
  "arcstr",
  "bincode",
  "bitvec",
- "clap 3.2.23",
+ "clap 3.2.25",
  "criterion",
  "crossbeam",
  "crossbeam-utils",
@@ -1720,7 +1663,7 @@ dependencies = [
  "size-of",
  "tar",
  "textwrap 0.15.2",
- "time 0.3.20",
+ "time",
  "typedmap",
  "uuid",
  "xxhash-rust",
@@ -1745,7 +1688,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "chrono",
- "clap 4.2.4",
+ "clap 4.2.7",
  "colored",
  "crossbeam",
  "csv 1.1.6",
@@ -1782,7 +1725,7 @@ dependencies = [
  "ascii_table",
  "bincode",
  "cached",
- "clap 3.2.23",
+ "clap 3.2.25",
  "csv 1.1.6",
  "dbsp",
  "hdrhist",
@@ -1797,7 +1740,7 @@ dependencies = [
  "serde",
  "serde_with",
  "size-of",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -1814,7 +1757,7 @@ dependencies = [
  "awc",
  "change-detection",
  "chrono",
- "clap 4.2.4",
+ "clap 4.2.7",
  "colored",
  "daemonize",
  "dbsp_adapters",
@@ -1886,8 +1829,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1984,8 +1927,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -2070,7 +2013,7 @@ dependencies = [
  "mime",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "time",
  "tokio",
  "url",
  "webdriver",
@@ -2105,12 +2048,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2230,9 +2173,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -2299,7 +2242,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2322,9 +2265,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
 dependencies = [
  "bytes",
  "fnv",
@@ -2365,11 +2308,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2543,12 +2486,11 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
@@ -2573,8 +2515,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -2597,8 +2539,17 @@ checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
  "number_prefix",
- "portable-atomic",
+ "portable-atomic 0.3.20",
  "unicode-width",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2674,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2691,7 +2642,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.0",
  "bytecount",
- "clap 4.2.4",
+ "clap 4.2.7",
  "fancy-regex",
  "fraction",
  "getrandom",
@@ -2706,7 +2657,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "time",
  "url",
  "uuid",
 ]
@@ -2731,9 +2682,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libloading"
@@ -2747,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "librocksdb-sys"
@@ -2767,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
 dependencies = [
  "cc",
  "libc",
@@ -2778,19 +2729,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "local-channel"
@@ -2924,6 +2866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,7 +2882,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -3019,8 +2970,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3103,8 +3054,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3136,16 +3087,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl"
-version = "0.10.51"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -3162,9 +3107,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -3175,9 +3120,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -3187,11 +3132,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a384337e997e6860ffbaa83708b2ef329fd8c54cb67a5f64d421e0f943254f"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
 dependencies = [
  "num-traits",
+ "rand",
  "serde",
 ]
 
@@ -3404,9 +3350,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plotters"
@@ -3438,9 +3384,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
+dependencies = [
+ "portable-atomic 1.3.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc59d1bcc64fc5d021d67521f818db868368028108d37f0e98d74e33f68297b5"
 
 [[package]]
 name = "postgres-protocol"
@@ -3527,8 +3482,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3539,8 +3494,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "version_check",
 ]
 
@@ -3555,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3630,8 +3585,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3658,11 +3613,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.58",
 ]
 
 [[package]]
@@ -3680,6 +3635,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -3699,6 +3655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]
@@ -3761,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.3.0+1.9.2"
+version = "4.4.0+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d222a401698c7f2010e3967353eae566d9934dcda49c29910da922414ab4e3f4"
+checksum = "87ac9d87c3aba1748e3112318459f2ac8bff80bfff7359e338e0463549590249"
 dependencies = [
  "cmake",
  "libc",
@@ -3868,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -3926,26 +3883,29 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.41"
+version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
+checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
 dependencies = [
+ "bitvec",
  "bytecheck",
  "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
  "seahash",
+ "tinyvec",
+ "uuid",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.41"
+version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1c672430eb41556291981f45ca900a0239ad007242d1cb4b4167af842db666"
+checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -3978,8 +3938,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -4001,8 +3961,8 @@ version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4e0f0ced47ded9a68374ac145edd65a6c1fa13a96447b873660b2a568a0fd7"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "rust-embed-utils",
  "shellexpand",
  "syn 1.0.109",
@@ -4070,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -4169,8 +4129,8 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "serde_derive_internals",
  "syn 1.0.109",
 ]
@@ -4180,12 +4140,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -4205,9 +4159,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -4218,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4234,22 +4188,22 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4258,8 +4212,8 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -4281,9 +4235,9 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4300,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331bb8c3bf9b92457ab7abecf07078c13f7d270ba490103e84e8b014490cd0b0"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -4311,19 +4265,19 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859011bddcc11f289f07f467cc1fe01c7a941daa4d8f6c40d4d1c92eb6d9319c"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
- "darling 0.14.4",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
+ "darling 0.20.1",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4416,7 +4370,7 @@ dependencies = [
  "hashbrown 0.13.2",
  "rust_decimal",
  "size-of-derive",
- "time 0.3.20",
+ "time",
  "xxhash-rust",
 ]
 
@@ -4426,8 +4380,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -4442,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "slice-group-by"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
+checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
@@ -4470,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -4568,8 +4522,8 @@ dependencies = [
  "either",
  "heck",
  "once_cell",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "sha2",
  "sqlx-core",
  "sqlx-rt",
@@ -4653,19 +4607,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "unicode-ident",
 ]
 
@@ -4688,9 +4642,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "tempfile"
@@ -4764,8 +4718,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cae91d1c7c61ec65817f1064954640ee350a50ae6548ff9a1bdd2489d6ffbb0"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "syn 1.0.109",
 ]
 
@@ -4784,9 +4738,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4801,20 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "serde",
@@ -4824,15 +4767,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -4887,9 +4830,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 2.0.15",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -4921,7 +4864,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2 0.5.2",
+ "socket2 0.5.3",
  "tokio",
  "tokio-util",
 ]
@@ -4939,9 +4882,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4950,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4973,15 +4916,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "92d964908cec0d030b812013af25a0e57fddfadb1e066ecc6681d86253129d4f"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -5009,20 +4952,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5041,9 +4984,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5197,8 +5140,8 @@ checksum = "6f2e33027986a4707b3f5c37ed01b33d0e5a53da30204b52ff18f80600f1d0ec"
 dependencies = [
  "lazy_static",
  "proc-macro-error",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
  "regex",
  "syn 1.0.109",
 ]
@@ -5221,9 +5164,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
 dependencies = [
  "getrandom",
 ]
@@ -5283,21 +5226,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5305,24 +5242,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5332,32 +5269,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
- "quote 1.0.26",
+ "quote 1.0.27",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.26",
- "syn 1.0.109",
+ "proc-macro2 1.0.58",
+ "quote 1.0.27",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
@@ -5372,9 +5309,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5394,7 +5331,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "time 0.3.20",
+ "time",
  "unicode-segmentation",
  "url",
 ]
@@ -5628,9 +5565,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
@@ -5685,9 +5622,9 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zip"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "aes",
  "byteorder",
@@ -5699,7 +5636,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.20",
+ "time",
  "zstd 0.11.2+zstd.1.5.2",
 ]
 

--- a/Earthfile
+++ b/Earthfile
@@ -13,8 +13,15 @@ install-deps:
     RUN apt-get update
     RUN apt-get install --yes build-essential curl libssl-dev build-essential pkg-config \
                               cmake git gcc clang libclang-dev python3-pip python3-plumbum \
-                              hub numactl cmake openjdk-19-jre-headless maven netcat jq \
+                              hub numactl openjdk-19-jre-headless maven netcat jq \
                               libsasl2-dev docker.io
+    RUN curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash -
+    RUN apt-get install --yes nodejs
+    RUN npm install --global yarn
+    RUN npm install --global openapi-typescript-codegen
+    COPY demo/demo_notebooks/requirements.txt demo/demo_notebooks/requirements.txt
+    RUN pip3 install -r demo/demo_notebooks/requirements.txt
+    RUN pip3 install openapi-python-client
 
 install-rust:
     FROM +install-deps
@@ -25,18 +32,14 @@ install-rust:
         --component clippy \
         --component rustfmt \
         --component llvm-tools-preview
-    RUN chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+    RUN rustup toolchain install nightly \
+        --component clippy \
+        --component rustfmt \
+        --component llvm-tools-preview
+    RUN cargo install --force cargo-make
     RUN rustup --version
     RUN cargo --version
     RUN rustc --version
-
-install-nextjs:
-    RUN sudo apt-get update
-    RUN sudo apt-get install git sudo curl
-    RUN curl -fsSL https://deb.nodesource.com/setup_19.x | sudo -E bash - &&\
-    RUN sudo apt-get install -y nodejs
-    RUN npm install --global yarn
-    RUN npm install --global openapi-typescript-codegen
 
 install-chef:
     FROM +install-rust
@@ -63,6 +66,7 @@ prepare-cache:
     COPY --keep-ts crates/dbsp/Cargo.toml crates/dbsp/
     COPY --keep-ts crates/adapters/Cargo.toml crates/adapters/
     COPY --keep-ts crates/pipeline_manager/Cargo.toml crates/pipeline_manager/
+    COPY --keep-ts web-ui web-ui
     #COPY --keep-ts crates/webui-tester/Cargo.toml crates/webui-tester/
 
     RUN mkdir -p crates/dataflow-jit/src && touch crates/dataflow-jit/src/lib.rs
@@ -83,9 +87,12 @@ prepare-cache:
     SAVE ARTIFACT --keep-ts --keep-own recipe.json
 
 build-cache:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
     FROM +install-chef
     COPY --keep-ts +prepare-cache/recipe.json ./
-    RUN cargo chef cook --workspace --all-targets
+    RUN cargo +$RUST_TOOLCHAIN chef cook --workspace --all-targets
+    RUN cargo +$RUST_TOOLCHAIN chef cook --release --package dbsp_pipeline_manager --all-targets
+    RUN cargo +$RUST_TOOLCHAIN chef cook --clippy --workspace
     # I have no clue why we need all these commands below to build all
     # dependencies (since we just did a build --workspace --all-targets). But if
     # we don't run all of them, it will go and compile dependencies during
@@ -99,24 +106,35 @@ build-cache:
     #
     # When using `RUST_LOG=cargo::ops::cargo_rustc::fingerprint=info` to debug,
     # it looks like the hash for the crates changes.
-    RUN cargo build
-    RUN cargo test --no-run
-    RUN cargo build --package dbsp
-    RUN cargo test --package dbsp --no-run
-    RUN cargo build --package dbsp_adapters
-    RUN cargo test --package dbsp_adapters --no-run
-    RUN cargo build --package dbsp_pipeline_manager
-    RUN cargo test --package dbsp_pipeline_manager --no-run
-    RUN cargo build --package dataflow-jit
-    RUN cargo test --package dataflow-jit --no-run
-    RUN cargo build --package dbsp_nexmark
-    RUN cargo test --package dbsp_nexmark --no-run
+    RUN cargo +$RUST_TOOLCHAIN build
+    RUN cargo +$RUST_TOOLCHAIN test --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_adapters
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_adapters --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_adapters
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_pipeline_manager
+    # Pipeline manager is the only one we compile in release mode from
+    # `start_manager.sh`.  As we add benchmarks and other targets that
+    # require release builds, we may want to make build profile an ARG.
+    RUN cargo +$RUST_TOOLCHAIN build --release --package dbsp_pipeline_manager
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_pipeline_manager --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_pipeline_manager
+    RUN cargo +$RUST_TOOLCHAIN build --package dataflow-jit
+    RUN cargo +$RUST_TOOLCHAIN test --package dataflow-jit --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dataflow-jit
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_nexmark
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_nexmark --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_nexmark
 
     SAVE ARTIFACT --keep-ts --keep-own $CARGO_HOME
     SAVE ARTIFACT --keep-ts --keep-own ./target
 
 build-dbsp:
-    FROM +build-cache
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-cache --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
     # Remove the skeleton created in build-cache
     RUN rm -rf crates/dbsp
@@ -124,8 +142,9 @@ build-dbsp:
     COPY --keep-ts --dir crates/dbsp crates/dbsp
     COPY --keep-ts README.md README.md
 
-    RUN cargo build --package dbsp
-    RUN cargo test --package dbsp --no-run
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp -- -D warnings
     # Update target folder for future tasks, the whole --keep-ts, --keep-own
     # args were an attempt in fixing the dependency problem (see build-cache)
     # but it doesn't seem to make a difference.
@@ -133,64 +152,89 @@ build-dbsp:
 
 
 build-adapters:
-    FROM +build-dbsp
-
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
     RUN rm -rf crates/adapters
     COPY --keep-ts --dir crates/adapters crates/adapters
 
-    RUN cargo build --package dbsp_adapters
-    RUN cargo test --package dbsp_adapters --no-run
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_adapters
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_adapters --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_adapters -- -D warnings
     SAVE ARTIFACT --keep-ts --keep-own ./target/* ./target
 
 build-manager:
-    FROM +build-adapters
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-adapters --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
     RUN rm -rf crates/pipeline_manager
     COPY --keep-ts --dir crates/pipeline_manager crates/pipeline_manager
+    COPY --keep-ts --dir web-ui web-ui
+    COPY --keep-ts python python
 
-    RUN cargo build --package dbsp_pipeline_manager
-    RUN cargo test --package dbsp_pipeline_manager --no-run
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_pipeline_manager
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_pipeline_manager --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_pipeline_manager -- -D warnings
+    RUN cargo make --cwd crates/pipeline_manager/ openapi_python
     SAVE ARTIFACT --keep-ts --keep-own ./target/* ./target
 
+build-sql:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-manager --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    COPY --keep-ts sql-to-dbsp-compiler sql-to-dbsp-compiler
+    RUN cd "sql-to-dbsp-compiler/SQL-compiler" && mvn -DskipTests package
+
 build-dataflow-jit:
-    FROM +build-dbsp
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
     RUN rm -rf crates/dataflow-jit
     COPY --keep-ts --dir crates/dataflow-jit crates/dataflow-jit
 
-    RUN cargo build --package dataflow-jit
-    RUN cargo test --package dataflow-jit --no-run
+    RUN cargo +$RUST_TOOLCHAIN build --package dataflow-jit
+    RUN cargo +$RUST_TOOLCHAIN test --package dataflow-jit --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dataflow-jit -- -D warnings
     SAVE ARTIFACT --keep-ts --keep-own ./target/* ./target
 
 build-nexmark:
-    FROM +build-dbsp
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
 
     RUN rm -rf crates/nexmark
     COPY --keep-ts --dir crates/nexmark crates/nexmark
 
-    RUN cargo build --package dbsp_nexmark
-    RUN cargo test --package dbsp_nexmark --no-run
+    RUN cargo +$RUST_TOOLCHAIN build --package dbsp_nexmark
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_nexmark --no-run
+    RUN cargo +$RUST_TOOLCHAIN clippy --package dbsp_nexmark -- -D warnings
     SAVE ARTIFACT --keep-ts --keep-own ./target/* ./target
 
 test-dbsp:
-    FROM +build-dbsp
-    RUN cargo test --package dbsp
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp
+
+test-nexmark:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    RUN cargo +$RUST_TOOLCHAIN test --package dbsp_nexmark
 
 test-dataflow-jit:
-    FROM +build-dataflow-jit
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-dataflow-jit --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
     # Tests use this demo directory
     COPY --keep-ts demo/project_demo01-TimeSeriesEnrich demo/project_demo01-TimeSeriesEnrich
-    RUN cargo test --package dataflow-jit
+    RUN cargo +$RUST_TOOLCHAIN test --package dataflow-jit
 
 test-adapters:
-    FROM +build-adapters
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-adapters --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
     WITH DOCKER --pull docker.redpanda.com/vectorized/redpanda:v22.3.11
         RUN docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v22.3.11 && \
-            cargo test --package dbsp_adapters
+            cargo +$RUST_TOOLCHAIN test --package dbsp_adapters
     END
 
 test-manager:
-    FROM +build-manager
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-manager --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
     ENV PGHOST=localhost
     ENV PGUSER=postgres
     ENV PGCLIENTENCODING=UTF8
@@ -202,5 +246,38 @@ test-manager:
             # Sleep until postgres is up (otherwise we get connection reset if we connect too early)
             # (See: https://github.com/docker-library/docs/blob/master/postgres/README.md#caveats)
             sleep 3 && \
-            cargo test --package dbsp_pipeline_manager
+            cargo +$RUST_TOOLCHAIN test --package dbsp_pipeline_manager
     END
+
+test-python:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    FROM +build-sql --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    COPY --keep-ts scripts scripts
+    COPY --keep-ts demo/demo_notebooks demo/demo_notebooks
+    ENV PGHOST=localhost
+    ENV PGUSER=postgres
+    ENV PGCLIENTENCODING=UTF8
+    ENV PGPORT=5432
+    ENV RUST_LOG=error
+    ENV WITH_POSTGRES=1
+    WITH DOCKER --pull postgres
+        # We just put the PGDATA in /dev/shm because the docker fs seems very slow (test time goes to 2min vs. shm 40s)
+        RUN docker run --shm-size=256MB -p 5432:5432 --name postgres -e POSTGRES_HOST_AUTH_METHOD=trust -e PGDATA=/dev/shm -d postgres && \
+            sleep 3 && \
+            cargo make --cwd crates/pipeline_manager/ python_test
+    END
+
+test-rust:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    BUILD +test-dbsp --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    BUILD +test-nexmark --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    BUILD +test-adapters --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    BUILD +test-dataflow-jit --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+    BUILD +test-manager --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
+
+test-rust-nightly:
+    BUILD +test-rust --RUST_TOOLCHAIN=nightly
+
+all-tests:
+    BUILD +test-rust
+    BUILD +test-python

--- a/Earthfile
+++ b/Earthfile
@@ -66,7 +66,6 @@ prepare-cache:
     COPY --keep-ts crates/dbsp/Cargo.toml crates/dbsp/
     COPY --keep-ts crates/adapters/Cargo.toml crates/adapters/
     COPY --keep-ts crates/pipeline_manager/Cargo.toml crates/pipeline_manager/
-    COPY --keep-ts web-ui web-ui
     #COPY --keep-ts crates/webui-tester/Cargo.toml crates/webui-tester/
 
     RUN mkdir -p crates/dataflow-jit/src && touch crates/dataflow-jit/src/lib.rs
@@ -228,7 +227,8 @@ test-adapters:
     ARG RUST_TOOLCHAIN=$RUST_VERSION
     FROM +build-adapters --RUST_TOOLCHAIN=$RUST_TOOLCHAIN
     WITH DOCKER --pull docker.redpanda.com/vectorized/redpanda:v22.3.11
-        RUN docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v22.3.11 && \
+        RUN docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v22.3.11 \
+            redpanda start --smp 2 && \
             cargo +$RUST_TOOLCHAIN test --package dbsp_adapters
     END
 

--- a/crates/adapters/Cargo.toml
+++ b/crates/adapters/Cargo.toml
@@ -46,9 +46,8 @@ tokio = { version = "1.25.0", features = ["sync", "macros"] }
 prometheus = "0.13.3"
 utoipa = { version = "3.0.1" }
 actix-codec = { version = "0.5.0", optional = true }
-chrono = "0.4.24"
+chrono = { version = "0.4.24", features = ["clock"], default-features = false }
 colored = "2.0.0"
-
 
 [dev-dependencies]
 serde_json = "1.0.89"

--- a/crates/adapters/src/controller/config.rs
+++ b/crates/adapters/src/controller/config.rs
@@ -31,8 +31,8 @@ pub struct PipelineConfig {
     #[schema(inline)]
     pub global: GlobalPipelineConfig,
 
-    // Pipeline name
-    pub name: String,
+    /// Pipeline name
+    pub name: Option<String>,
 
     /// Input endpoint configuration.
     pub inputs: BTreeMap<Cow<'static, str>, InputEndpointConfig>,

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -116,8 +116,7 @@ where
     })?;
 
     // Create env logger.
-    let pipeline_name = config.name.clone();
-    let pipeline_name = format!("[{pipeline_name}]").cyan();
+    let pipeline_name = format!("[{}]", config.name).cyan();
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(move |buf, record| {
             let t = chrono::Utc::now();

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -116,7 +116,7 @@ where
     })?;
 
     // Create env logger.
-    let pipeline_name = format!("[{}]", config.name).cyan();
+    let pipeline_name = format!("[{}]", config.name.clone().unwrap_or_default()).cyan();
     env_logger::Builder::from_env(Env::default().default_filter_or("info"))
         .format(move |buf, record| {
             let t = chrono::Utc::now();

--- a/crates/dbsp/benches/gdelt/personal_network.rs
+++ b/crates/dbsp/benches/gdelt/personal_network.rs
@@ -695,6 +695,20 @@ impl<'a, K, V, R, O> Cursor<K, V, (), R> for HashedKVCursor<'a, K, V, R, O> {
         todo!()
     }
 
+    fn seek_key_with<P>(&mut self, _predicate: P)
+    where
+        P: Fn(&K) -> bool + Clone,
+    {
+        todo!()
+    }
+
+    fn seek_key_with_reverse<P>(&mut self, _predicate: P)
+    where
+        P: Fn(&K) -> bool + Clone,
+    {
+        todo!()
+    }
+
     fn step_val(&mut self) {
         todo!()
     }

--- a/crates/dbsp/src/operator/group/lag.rs
+++ b/crates/dbsp/src/operator/group/lag.rs
@@ -24,6 +24,7 @@ where
     ///
     /// * `offset` - offset to the previous value.
     /// * `project` - projection function to apply to the delayed row.
+    #[allow(clippy::type_complexity)]
     pub fn lag<OV, PF>(
         &self,
         offset: usize,
@@ -56,6 +57,7 @@ where
     /// * `offset` - offset to the subsequent value.
     /// * `project` - projection function to apply to the subsequent row. The
     ///   argument is `None` for out-of-range values.
+    #[allow(clippy::type_complexity)]
     pub fn lead<OV, PF>(
         &self,
         offset: usize,

--- a/crates/dbsp/src/operator/group/topk.rs
+++ b/crates/dbsp/src/operator/group/topk.rs
@@ -12,6 +12,7 @@ where
     /// Pick `k` smallest values in each group.
     ///
     /// For each key in the input stream, removes all but `k` smallest values.
+    #[allow(clippy::type_complexity)]
     pub fn topk_asc(&self, k: usize) -> Stream<RootCircuit, OrdIndexedZSet<B::Key, B::Val, B::R>>
     where
         B::R: ZRingValue,
@@ -22,6 +23,7 @@ where
     /// Pick `k` largest values in each group.
     ///
     /// For each key in the input stream, removes all but `k` largest values.
+    #[allow(clippy::type_complexity)]
     pub fn topk_desc(&self, k: usize) -> Stream<RootCircuit, OrdIndexedZSet<B::Key, B::Val, B::R>>
     where
         B::R: ZRingValue,

--- a/crates/dbsp/src/trace/cursor/cursor_empty.rs
+++ b/crates/dbsp/src/trace/cursor/cursor_empty.rs
@@ -2,8 +2,15 @@ use crate::trace::cursor::Cursor;
 use std::marker::PhantomData;
 
 /// Cursor that contains no data.
+
 pub struct CursorEmpty<K, V, T, R> {
     phantom: PhantomData<(K, V, T, R)>,
+}
+
+impl<K, V, T, R> Default for CursorEmpty<K, V, T, R> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl<K, V, T, R> CursorEmpty<K, V, T, R> {

--- a/crates/dbsp/src/trace/layers/erased/vtable.rs
+++ b/crates/dbsp/src/trace/layers/erased/vtable.rs
@@ -265,7 +265,7 @@ where
             value.hash(hasher);
         }
 
-        unsafe extern "C" fn default<T>(_place: *mut u8) {
+        unsafe extern "C" fn default(_place: *mut u8) {
             unimplemented!()
         }
 
@@ -287,7 +287,7 @@ where
             type_id: TypeId::of::<Self>,
             type_name: type_name::<Self>,
             hash: hash::<Self>,
-            default: default::<Self>,
+            default,
         }
     };
 }

--- a/crates/dbsp/src/trace/ord/merge_batcher/mod.rs
+++ b/crates/dbsp/src/trace/ord/merge_batcher/mod.rs
@@ -90,6 +90,12 @@ struct MergeSorter<D: Ord, R: MonoidValue> {
     stash: Vec<Vec<(D, R)>>,
 }
 
+impl<D: Ord, R: MonoidValue> Default for MergeSorter<D, R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<D: Ord, R: MonoidValue> MergeSorter<D, R> {
     /// The maximum number of bytes we'd like our buffers to contain
     ///

--- a/crates/dbsp/src/trace/persistent/cursor.rs
+++ b/crates/dbsp/src/trace/persistent/cursor.rs
@@ -281,7 +281,7 @@ impl<'s, B: Batch> Cursor<B::Key, B::Val, B::Time, B::R> for PersistentTraceCurs
 
     fn seek_key_with_reverse<P>(&mut self, _predicate: P)
     where
-        P: Fn(&B::Key) -> bool + Clone
+        P: Fn(&B::Key) -> bool + Clone,
     {
         unimplemented!()
     }

--- a/crates/dbsp/src/trace/persistent/cursor.rs
+++ b/crates/dbsp/src/trace/persistent/cursor.rs
@@ -272,9 +272,16 @@ impl<'s, B: Batch> Cursor<B::Key, B::Val, B::Time, B::R> for PersistentTraceCurs
         }
     }
 
-    fn seek_key_with<P>(&mut self, predicate: P)
+    fn seek_key_with<P>(&mut self, _predicate: P)
     where
         P: Fn(&B::Key) -> bool + Clone,
+    {
+        unimplemented!()
+    }
+
+    fn seek_key_with_reverse<P>(&mut self, _predicate: P)
+    where
+        P: Fn(&B::Key) -> bool + Clone
     {
         unimplemented!()
     }

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+    [package.metadata.cargo-udeps.ignore]
+    development = ["pg-client-config"]
+
 [dependencies]
 dbsp_adapters = { path = "../adapters" }
 actix-web = "4.3"
 actix-web-static-files = "4.0.0"
 awc = "3.1.0"
 static-files = "0.2.3"
-actix-files = "0.6.2"
 actix-cors = "0.6.4"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 tokio = { version = "1.25.0", features = ["rt-multi-thread", "fs", "macros", "process", "io-util", "io-std"] }

--- a/crates/pipeline_manager/Makefile.toml
+++ b/crates/pipeline_manager/Makefile.toml
@@ -1,9 +1,13 @@
+[tasks.build-release]
+command = "cargo"
+args = ["build", "--release"]
+
 [tasks.openapi_json]
 description = "Dump OpenAPI specification of the REST API to 'openapi.json'"
 dependencies = ["build-release"]
 script = '''
 cd ../../
-cargo run --release --bin=dbsp_pipeline_manager -- --dump-openapi
+cargo run --release --package dbsp_pipeline_manager -- --dump-openapi
 '''
 
 [tasks.openapi_python]

--- a/crates/pipeline_manager/build.rs
+++ b/crates/pipeline_manager/build.rs
@@ -1,5 +1,6 @@
 use change_detection::ChangeDetection;
 use static_files::NpmBuild;
+use std::env;
 use std::path::Path;
 
 // These are touched during the build, so it would re-build every time if we
@@ -30,9 +31,9 @@ fn main() {
         .expect("Could not run `yarn install`. Follow set-up instructions in web-ui/README.md")
         .run("build")
         .expect("Could not run `yarn build`. Run it manually in web-ui/ to debug.")
-        .run("export")
-        .expect("Could not run `yarn export`. Run it manually in web-ui/ to debug.")
-        .target("../../web-ui/out")
+        .run("export-to-out")
+        .expect("Could not run `yarn export-to-out`. Run it manually in web-ui/ to debug.")
+        .target(env::var("OUT_DIR").unwrap())
         .to_resource_dir()
         .build()
         .unwrap();

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -1308,7 +1308,7 @@ impl ProjectDB {
         #[cfg(feature = "pg-embed")]
         return Ok(Self { pool, pg_inst });
         #[cfg(not(feature = "pg-embed"))]
-        return Ok(Self { pool: pool });
+        return Ok(Self { pool });
     }
 
     /// Attach connector to the config.

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -1018,7 +1018,7 @@ impl Storage for Mutex<DbModel> {
 
     async fn remove_pipeline_from_config(&self, config_id: super::ConfigId) -> anyhow::Result<()> {
         let mut s = self.lock().await;
-        if let Some(mut config) = s.configs.get_mut(&config_id) {
+        if let Some(config) = s.configs.get_mut(&config_id) {
             config.pipeline = None;
             Ok(())
         } else {
@@ -1043,7 +1043,7 @@ impl Storage for Mutex<DbModel> {
         let db_connectors = s.connectors.clone();
         let db_projects = s.projects.clone();
 
-        let mut c = s
+        let c = s
             .configs
             .get_mut(&config_id)
             .ok_or(anyhow::anyhow!(DBError::UnknownConfig(config_id)))?;

--- a/python/.earthlyignore
+++ b/python/.earthlyignore
@@ -1,0 +1,2 @@
+dbsp-api-client
+dbsp/__pycache__

--- a/web-ui/.earthlyignore
+++ b/web-ui/.earthlyignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -20,6 +20,7 @@
     "build": "next build",
     "start": "next start",
     "export": "next export",
+    "export-to-out": "next export -o $OUT_DIR",
     "lint": "eslint --max-warnings 0 --fix \"src/**/*.{js,jsx,ts,tsx}\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",


### PR DESCRIPTION
Small fixes + add the following tests to CI:

- Add support for nightly Rust tests
- cargo clippy
- cargo fmt
- Python tests