### PR TITLE
Change submodule URL from git@ to https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sql-to-dbsp-compiler"]
 	path = sql-to-dbsp-compiler
-	url = git@github.com:feldera/sql2dbsp.git
+	url = https://github.com/feldera/sql2dbsp.git


### PR DESCRIPTION
git@ URLs don't work in the CI environment.