### PR TITLE
README.md: Fix search summary in doc output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![CI workflow](https://github.com/feldera/dbsp/actions/workflows/main.yml/badge.svg)](https://github.com/feldera/dbsp/actions)
-[![codecov](https://codecov.io/gh/feldera/dbsp/branch/main/graph/badge.svg?token=0wZcmD11gt)](https://codecov.io/gh/feldera/dbsp)
-
 # Database Stream Processor
 
 Database Stream Processor (DBSP) is a framework for computing over data streams
 that aims to be more expressive and performant than existing streaming engines.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![CI workflow](https://github.com/feldera/dbsp/actions/workflows/main.yml/badge.svg)](https://github.com/feldera/dbsp/actions)
+[![codecov](https://codecov.io/gh/feldera/dbsp/branch/main/graph/badge.svg?token=0wZcmD11gt)](https://codecov.io/gh/feldera/dbsp)
 
 ## DBSP Mission Statement
 


### PR DESCRIPTION
Without this change, if I type "dbsp" into the search box in `cargo doc` output, the summary that it shows is "License MIT CI workflow codecov". With this change, it shows "Database Stream Processor".