### PR TITLE
adapters: Add some developer documentation for transports.

### DIFF
--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -9,6 +9,11 @@
 //! formats (CSV, bincode, JSON, etc.) into the DBSP input and output
 //! pipelines.
 //!
+//! This crate is primarily for use in general-purpose applications to
+//! support users plugging in a variety of inputs and outputs in a flexible
+//! way.  It is likely to be more than needed for simple applications that
+//! support specific inputs and outputs.
+//!
 //! ## Overview
 //!
 //! The data ingestion pipeline consists of two kinds of adapters: **data

--- a/crates/adapters/src/transport/file.rs
+++ b/crates/adapters/src/transport/file.rs
@@ -20,7 +20,9 @@ use utoipa::ToSchema;
 
 const SLEEP_MS: u64 = 200;
 
-/// `InputTransport` implementation that reads data from file.
+/// [`InputTransport`] implementation that reads data from a file.
+///
+/// The input transport factory gives this transport the name `file`.
 pub struct FileInputTransport;
 
 impl InputTransport for FileInputTransport {
@@ -28,6 +30,10 @@ impl InputTransport for FileInputTransport {
         Cow::Borrowed("file")
     }
 
+    /// Creates a new [`InputEndpoint`] for reading a file, interpreting
+    /// `config` as a [`FileInputConfig`].
+    ///
+    /// See [`InputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         _name: &str,
@@ -41,16 +47,17 @@ impl InputTransport for FileInputTransport {
     }
 }
 
+/// Configuration for reading data from a file with [`FileInputTransport`].
 #[derive(Deserialize, ToSchema)]
 pub struct FileInputConfig {
     /// File path.
-    path: String,
+    pub path: String,
 
     /// Read buffer size.
     ///
     /// Default: when this parameter is not specified, a platform-specific
     /// default is used.
-    buffer_size_bytes: Option<usize>,
+    pub buffer_size_bytes: Option<usize>,
 
     /// Enable file following.
     ///
@@ -59,7 +66,7 @@ pub struct FileInputConfig {
     /// endpoint will keep watching the file and outputting any new content
     /// appended to it.
     #[serde(default)]
-    follow: bool,
+    pub follow: bool,
 }
 
 struct FileInputEndpoint {
@@ -176,7 +183,9 @@ impl Drop for FileInputEndpoint {
     }
 }
 
-/// `OutputTransport` implementation that writes data to file.
+/// [`OutputTransport`] implementation that writes data to a file.
+///
+/// The output transport factory gives this transport the name `file`.
 pub struct FileOutputTransport;
 
 impl OutputTransport for FileOutputTransport {
@@ -184,6 +193,10 @@ impl OutputTransport for FileOutputTransport {
         Cow::Borrowed("file")
     }
 
+    /// Creates a new [`OutputEndpoint`] for writing a file, interpreting
+    /// `config` as a [`FileOutputConfig`].
+    ///
+    /// See [`OutputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         _name: &str,
@@ -197,10 +210,11 @@ impl OutputTransport for FileOutputTransport {
     }
 }
 
+/// Configuration for writing data to a file with [`FileOutputTransport`].
 #[derive(Deserialize, ToSchema)]
 pub struct FileOutputConfig {
     /// File path.
-    path: String,
+    pub path: String,
 }
 
 struct FileOutputEndpoint {

--- a/crates/adapters/src/transport/http/input.rs
+++ b/crates/adapters/src/transport/http/input.rs
@@ -29,8 +29,12 @@ use utoipa::ToSchema;
 static INPUT_HTTP_ENDPOINTS: Lazy<RwLock<BTreeMap<String, HttpInputEndpoint>>> =
     Lazy::new(|| RwLock::new(BTreeMap::new()));
 
-/// `InputTransport` implementation that receives data from an HTTP endpoint
-/// via a websocket.
+/// [`InputTransport`] implementation that reads data from a websocket.
+///
+/// This input transport is only available if the crate is configured with the
+/// `server` feature.
+///
+/// The input transport factory gives this transport the name `http`.
 pub struct HttpInputTransport;
 
 impl InputTransport for HttpInputTransport {
@@ -38,6 +42,13 @@ impl InputTransport for HttpInputTransport {
         Cow::Borrowed("http")
     }
 
+    /// Creates a new [`InputEndpoint`] for receiving data from a websocket.
+    /// There is no configuration (`_config` is ignored).  Rather, the
+    /// client connects a websocket by issuing a GET request to the
+    /// `/input_endpoint/<name>` endpoint, where `name` is the argument passed
+    /// here.
+    ///
+    /// See [`InputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         name: &str,
@@ -74,6 +85,10 @@ impl HttpInputTransport {
     }
 }
 
+/// Configuration for reading data from a websocket with `HttpOutputTransport`.
+///
+/// This is an empty struct because this kind of transport doesn't accept any
+/// configuration.
 #[derive(Clone, Deserialize, ToSchema)]
 pub struct HttpInputConfig;
 

--- a/crates/adapters/src/transport/http/output.rs
+++ b/crates/adapters/src/transport/http/output.rs
@@ -22,7 +22,12 @@ use utoipa::ToSchema;
 static OUTPUT_HTTP_ENDPOINTS: Lazy<RwLock<BTreeMap<String, HttpOutputEndpoint>>> =
     Lazy::new(|| RwLock::new(BTreeMap::new()));
 
-/// `OutputTransport` implementation that sends data to websockets.
+/// [`OutputTransport`] implementation that writes data to a websocket.
+///
+/// This output transport is only available if the crate is configured with the
+/// `server` feature.
+///
+/// The output transport factory gives this transport the name `http`.
 pub struct HttpOutputTransport;
 
 impl OutputTransport for HttpOutputTransport {
@@ -30,6 +35,13 @@ impl OutputTransport for HttpOutputTransport {
         Cow::Borrowed("http")
     }
 
+    /// Creates a new [`OutputEndpoint`] for sending data to a websocket.  There
+    /// is no configuration (`_config` is ignored).  Rather, the client
+    /// connects a websocket by issuing a GET request to the
+    /// `/output_endpoint/<name>` endpoint, where `name` is the argument passed
+    /// here.
+    ///
+    /// See [`OutputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         name: &str,
@@ -66,6 +78,10 @@ impl HttpOutputTransport {
     }
 }
 
+/// Configuration for writing data to a websocket with `HttpOutputTransport`.
+///
+/// This is an empty struct because this kind of transport doesn't accept any
+/// configuration.
 #[derive(Clone, Deserialize, ToSchema)]
 pub struct HttpOutputConfig;
 

--- a/crates/adapters/src/transport/kafka/input.rs
+++ b/crates/adapters/src/transport/kafka/input.rs
@@ -38,8 +38,13 @@ const fn default_group_join_timeout_secs() -> u32 {
     10
 }
 
-/// `InputTransport` implementation that reads data from one or more
+/// [`InputTransport`] implementation that reads data from one or more
 /// Kafka topics.
+///
+/// This input transport is only available if the crate is configured with
+/// `with-kafka` feature.
+///
+/// The input transport factory gives this transport the name `kafka`.
 pub struct KafkaInputTransport;
 
 impl InputTransport for KafkaInputTransport {
@@ -47,6 +52,10 @@ impl InputTransport for KafkaInputTransport {
         Cow::Borrowed("kafka")
     }
 
+    /// Creates a new [`InputEndpoint`] for reading from Kafka topics,
+    /// interpreting `config` as a [`KafkaInputConfig`].
+    ///
+    /// See [`InputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         _name: &str,
@@ -59,7 +68,7 @@ impl InputTransport for KafkaInputTransport {
     }
 }
 
-/// Input endpoint configuration.
+/// Configuration for reading data from Kafka topics with [`InputTransport`].
 #[derive(Deserialize, Debug)]
 pub struct KafkaInputConfig {
     /// Options passed directly to `rdkafka`.
@@ -71,21 +80,21 @@ pub struct KafkaInputConfig {
     /// * "enable.auto.commit", if present, must be set to "false",
     /// * "enable.auto.offset.store", if present, must be set to "false"
     #[serde(flatten)]
-    kafka_options: BTreeMap<String, String>,
+    pub kafka_options: BTreeMap<String, String>,
 
     /// List of topics to subscribe to.
-    topics: Vec<String>,
+    pub topics: Vec<String>,
 
     /// The log level of the client.
     ///
     /// If not specified, the log level will be calculated based on the global
     /// log level of the `log` crate.
-    log_level: Option<KafkaLogLevel>,
+    pub log_level: Option<KafkaLogLevel>,
 
     /// Maximum timeout in seconds to wait for the endpoint to join the Kafka
     /// consumer group during initialization.
     #[serde(default = "default_group_join_timeout_secs")]
-    group_join_timeout_secs: u32,
+    pub group_join_timeout_secs: u32,
 }
 
 // The auto-derived implementation gets confused by the flattened

--- a/crates/adapters/src/transport/kafka/output.rs
+++ b/crates/adapters/src/transport/kafka/output.rs
@@ -21,7 +21,12 @@ use utoipa::{
 
 const OUTPUT_POLLING_INTERVAL: Duration = Duration::from_millis(100);
 
-/// `OutputTransport` implementation that writes to a Kafka topic.
+/// [`OutputTransport`] implementation that writes data to a Kafka topic.
+///
+/// This output transport is only available if the crate is configured with
+/// `with-kafka` feature.
+///
+/// The output transport factory gives this transport the name `kafka`.
 pub struct KafkaOutputTransport;
 
 impl OutputTransport for KafkaOutputTransport {
@@ -29,6 +34,10 @@ impl OutputTransport for KafkaOutputTransport {
         Cow::Borrowed("kafka")
     }
 
+    /// Creates a new [`OutputEndpoint`] fpor writing to a Kafka topic,
+    /// interpreting `config` as a [`KafkaOutputConfig`].
+    ///
+    /// See [`OutputTransport::new_endpoint()`] for more information.
     fn new_endpoint(
         &self,
         _name: &str,
@@ -46,7 +55,7 @@ const fn default_max_inflight_messages() -> u32 {
     1000
 }
 
-/// Output endpoint configuration.
+/// Configuration for writing data to a Kafka topic with [`OutputTransport`].
 #[derive(Deserialize, Debug)]
 pub struct KafkaOutputConfig {
     /// Options passed directly to `rdkafka`.
@@ -54,16 +63,16 @@ pub struct KafkaOutputConfig {
     /// See [`librdkafka` options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
     /// used to configure the Kafka producer.
     #[serde(flatten)]
-    kafka_options: BTreeMap<String, String>,
+    pub kafka_options: BTreeMap<String, String>,
 
     /// Topic to write to.
-    topic: String,
+    pub topic: String,
 
     /// The log level of the client.
     ///
     /// If not specified, the log level will be calculated based on the global
     /// log level of the `log` crate.
-    log_level: Option<KafkaLogLevel>,
+    pub log_level: Option<KafkaLogLevel>,
 
     /// Maximum number of unacknowledged messages buffered by the Kafka
     /// producer.
@@ -76,7 +85,7 @@ pub struct KafkaOutputConfig {
     ///
     /// Defaults to 1000.
     #[serde(default = "default_max_inflight_messages")]
-    max_inflight_messages: u32,
+    pub max_inflight_messages: u32,
 }
 
 impl KafkaOutputConfig {

--- a/crates/adapters/src/transport/mod.rs
+++ b/crates/adapters/src/transport/mod.rs
@@ -1,3 +1,38 @@
+//! Data transports.
+//!
+//! Data transport adapters implement support for a specific streaming
+//! technology like Kafka.  A transport adapter carries data without
+//! interpreting it (data interpretation is the job of **data format** adapters
+//! found in [dbsp_adapters::format](crate::format)).
+//!
+//! Both input and output data transport adapters exist.  Every current form of
+//! transport has both an input and an output adapter, but transports added in
+//! the future might only be suitable for input or for output.
+//!
+//! Data transports are created and configured through Yaml, with a string name
+//! that designates a transport and a transport-specific Yaml object to
+//! configure it.  Transport configuration is encapsulated in
+//! [`dbsp_adapters::TransportConfig`](crate::TransportConfig).
+//!
+//! The following transports are currently supported:
+//!
+//!   * `file`, for input from a file via [`FileInputTransport`] or output to a
+//!     file via [`FileOutputTransport`].
+//!
+//!   * `http`, for input from a websocket via [`HttpInputTransport`] or output
+//!     to a websocket via [`HttpOutputTransport`], if the `server` feature is
+//!     enabled.
+//!
+//!   * `kafka`, for input from [Kafka](https://kafka.apache.org/) via
+//!     [`KafkaInputTransport`] or output to Kafka via [`KafkaOutputTransport`],
+//!     if the `with-kafka` feature is enabled.
+//!
+//! To obtain a transport and create an endpoint with it:
+//!
+//! ```ignore
+//! let transport = <dyn InputTransport>::get_transport(transport_name).unwrap();
+//! let endpoint = transport.new_endpoint(endpoint_name, &config, consumer);
+//! ```
 use anyhow::{Error as AnyError, Result as AnyResult};
 use once_cell::sync::Lazy;
 use serde_yaml::Value as YamlValue;
@@ -100,7 +135,8 @@ pub trait InputTransport: Send + Sync {
 }
 
 impl dyn InputTransport {
-    /// Lookup input transport by name.
+    /// Lookup input transport by `name`, which should be e.g. `file` for a file
+    /// transport.
     pub fn get_transport(name: &str) -> Option<&'static dyn InputTransport> {
         INPUT_TRANSPORT.get(name).map(|f| &**f)
     }


### PR DESCRIPTION
I fell into a rabbit hole thinking that I needed dbsp_adapters to parse csv (which definitely isn't true), so I spent a little time adding some more documentation.

The only non-comment changes here are that I made the members of the *Config structs `pub`, because otherwise the readers of the documentation can't tell what configuration settings are available.