### PR TITLE
[JIT] Allow creating uninit values

### DIFF
--- a/crates/dataflow-jit/src/codegen/call.rs
+++ b/crates/dataflow-jit/src/codegen/call.rs
@@ -239,7 +239,7 @@ impl CodegenCtx<'_> {
 
         if self.debug_assertions() {
             // Assert that the string pointer is a valid pointer
-            self.assert_ptr_valid(string, align_of::<ThinStr>() as u32, builder);
+            self.assert_ptr_valid(string, ThinStr::ALIGN as u32, builder);
 
             // Assert that `truncated_length` is less than or equal to `isize::MAX`
             let less_than_max = builder.ins().icmp_imm(
@@ -427,7 +427,7 @@ impl CodegenCtx<'_> {
         builder.switch_to_block(set_string_length);
 
         // Assert that the string pointer is a valid pointer
-        self.debug_assert_ptr_valid(string, align_of::<ThinStr>() as u32, builder);
+        self.debug_assert_ptr_valid(string, ThinStr::ALIGN as u32, builder);
 
         // The string's length will be set to zero
         let new_length = builder.ins().iconst(self.pointer_type(), 0);

--- a/crates/dataflow-jit/src/codegen/index_by_column.rs
+++ b/crates/dataflow-jit/src/codegen/index_by_column.rs
@@ -388,11 +388,6 @@ impl CodegenCtx<'_> {
             .store(MemFlags::trusted(), output_value, dest_ptr, dest_offset);
     }
 
-    fn clone_string(&mut self, string: Value, builder: &mut FunctionBuilder<'_>) -> Value {
-        let clone_str = self.imports.get("string_clone", self.module, builder.func);
-        builder.call_fn(clone_str, &[string])
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn load_and_store_scalar(
         &mut self,

--- a/crates/dataflow-jit/src/codegen/layout.rs
+++ b/crates/dataflow-jit/src/codegen/layout.rs
@@ -200,7 +200,16 @@ pub enum BitSetType {
 }
 
 impl BitSetType {
-    pub const fn native_type(self) -> ClifType {
+    pub const fn native_type(self) -> NativeType {
+        match self {
+            Self::U8 => NativeType::U8,
+            Self::U16 => NativeType::U16,
+            Self::U32 => NativeType::U32,
+            Self::U64 => NativeType::U64,
+        }
+    }
+
+    pub const fn clif_type(self) -> ClifType {
         match self {
             Self::U8 => types::I8,
             Self::U16 => types::I16,
@@ -240,7 +249,7 @@ impl BitSetType {
             Self::U32 => !0u32 as i64,
             Self::U64 => !0u64 as i64,
         };
-        builder.ins().iconst(self.native_type(), value)
+        builder.ins().iconst(self.clif_type(), value)
     }
 }
 

--- a/crates/dataflow-jit/src/codegen/layout_cache.rs
+++ b/crates/dataflow-jit/src/codegen/layout_cache.rs
@@ -42,6 +42,14 @@ impl NativeLayoutCache {
         &self.layout_cache
     }
 
+    pub fn requires_nontrivial_clone(&self, layout_id: LayoutId) -> bool {
+        self.row_layout(layout_id).requires_nontrivial_clone()
+    }
+
+    pub fn is_zero_sized(&self, layout_id: LayoutId) -> bool {
+        self.row_layout(layout_id).is_zero_sized()
+    }
+
     /// Get both the [`NativeLayout`] and [`RowLayout`] for the given
     /// [`LayoutId`]
     pub fn get_layouts(&self, layout_id: LayoutId) -> (Ref<'_, NativeLayout>, Ref<'_, RowLayout>) {

--- a/crates/dataflow-jit/src/codegen/utils.rs
+++ b/crates/dataflow-jit/src/codegen/utils.rs
@@ -196,7 +196,7 @@ pub(super) fn column_non_null(
         builder.ins().icmp_imm(IntCC::Equal, string, 0)
     } else {
         let (bitset_ty, bitset_offset, bit_idx) = layout.nullability_of(column);
-        let bitset_ty = bitset_ty.native_type();
+        let bitset_ty = bitset_ty.clif_type();
 
         // Load the bitset containing the given column's nullability
         let bitset = builder
@@ -226,7 +226,7 @@ pub(super) fn set_column_null(
 ) {
     // If the value is null, set the cloned value to null
     let (bitset_ty, bitset_offset, bit_idx) = layout.nullability_of(column);
-    let bitset_ty = bitset_ty.native_type();
+    let bitset_ty = bitset_ty.clif_type();
 
     let bitset = if layout.bitset_occupants(column) == 1 {
         let null_ty = builder.value_type(is_null);

--- a/crates/dataflow-jit/src/codegen/vtable/clone.rs
+++ b/crates/dataflow-jit/src/codegen/vtable/clone.rs
@@ -339,7 +339,7 @@ fn clone_layout(
 
                 // If the value is null, set the cloned value to null
                 let (bitset_ty, bitset_offset, bit_idx) = layout.nullability_of(idx);
-                let bitset_ty = bitset_ty.native_type();
+                let bitset_ty = bitset_ty.clif_type();
 
                 let bitset = if layout.bitset_occupants(idx) == 1 {
                     let null_ty = builder.func.dfg.value_type(value_non_null);

--- a/crates/dataflow-jit/src/codegen/vtable/default.rs
+++ b/crates/dataflow-jit/src/codegen/vtable/default.rs
@@ -113,7 +113,7 @@ impl Codegen {
                             // Set all bitsets to null
                             MemoryEntry::BitSet { offset, ty, .. } => {
                                 let all_ones = builder.ins().iconst(
-                                    ty.native_type(),
+                                    ty.clif_type(),
                                     match ty {
                                         BitSetType::U8 => u8::MAX as i64,
                                         BitSetType::U16 => u16::MAX as i64,

--- a/crates/dataflow-jit/src/ir/function/passes/unit_ops.rs
+++ b/crates/dataflow-jit/src/ir/function/passes/unit_ops.rs
@@ -1,0 +1,133 @@
+use crate::ir::{
+    block::ParamType, exprs::ArgType, layout_cache::RowLayoutCache, ColumnType, Constant, Expr,
+    Function, RValue, Return, Terminator,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+impl Function {
+    // TODO: Eliminate unit basic block args
+    pub(super) fn remove_unit_memory_operations(&mut self, layout_cache: &RowLayoutCache) {
+        let mut unit_exprs = BTreeSet::new();
+        let mut row_exprs = BTreeMap::new();
+        for arg in &self.args {
+            row_exprs.insert(arg.id, arg.layout);
+        }
+
+        // FIXME: Doesn't work for back edges/loops
+        let mut stack = vec![self.entry_block];
+        while let Some(block_id) = stack.pop() {
+            let block = self.blocks.get_mut(&block_id).unwrap();
+
+            // Add all of the block's parameters
+            for &(param_id, ty) in block.params() {
+                match ty {
+                    ParamType::Row(layout) => {
+                        row_exprs.insert(param_id, layout);
+                    }
+                    ParamType::Column(ColumnType::Unit) => {
+                        unit_exprs.insert(param_id);
+                    }
+                    ParamType::Column(_) => {}
+                }
+            }
+
+            block.retain(|expr_id, expr| match expr {
+                Expr::Constant(Constant::Unit) => {
+                    unit_exprs.insert(expr_id);
+                    false
+                }
+                Expr::Constant(_) => true,
+
+                Expr::Load(load) => {
+                    let row_layout = row_exprs[&load.source()];
+                    let layout = layout_cache.get(row_layout);
+
+                    if layout.columns()[load.column()].is_unit() {
+                        unit_exprs.insert(expr_id);
+                        false
+                    } else {
+                        true
+                    }
+                }
+
+                Expr::Store(store) => {
+                    let row_layout = row_exprs[&store.target()];
+                    let layout = layout_cache.get(row_layout);
+                    !layout.columns()[store.column()].is_unit()
+                }
+
+                Expr::Copy(copy) => {
+                    if unit_exprs.contains(&copy.value()) {
+                        unit_exprs.insert(expr_id);
+                        false
+                    } else {
+                        true
+                    }
+                }
+
+                Expr::Select(select) => {
+                    if unit_exprs.contains(&select.if_true())
+                        || unit_exprs.contains(&select.if_false())
+                    {
+                        unit_exprs.insert(expr_id);
+                        false
+                    } else {
+                        true
+                    }
+                }
+
+                Expr::UninitRow(uninit) => {
+                    row_exprs.insert(expr_id, uninit.layout());
+                    !layout_cache.get(uninit.layout()).is_zero_sized()
+                }
+
+                Expr::NullRow(null) => {
+                    row_exprs.insert(expr_id, null.layout());
+                    !layout_cache.get(null.layout()).is_zero_sized()
+                }
+
+                Expr::CopyRowTo(copy_row) => !layout_cache.get(copy_row.layout()).is_zero_sized(),
+
+                Expr::Uninit(uninit) => match uninit.value() {
+                    ArgType::Row(layout) => {
+                        row_exprs.insert(expr_id, layout);
+                        !layout_cache.get(layout).is_zero_sized()
+                    }
+
+                    ArgType::Scalar(ColumnType::Unit) => {
+                        unit_exprs.insert(expr_id);
+                        false
+                    }
+                    ArgType::Scalar(_) => true,
+                },
+
+                // TODO: Eliminate/evaluate zst binops
+                // Expr::BinOp(binop) if binop.operand_ty().is_unit() =>  {
+                //
+                // },
+                Expr::BinOp(_) => true,
+
+                Expr::Call(_)
+                | Expr::Cast(_)
+                | Expr::IsNull(_)
+                | Expr::UnaryOp(_)
+                | Expr::SetNull(_) => true,
+            });
+
+            match block.terminator_mut() {
+                // Normalize unit returns to return unit contents
+                Terminator::Return(ret) => {
+                    if let &RValue::Expr(expr) = ret.value() {
+                        if unit_exprs.contains(&expr) {
+                            *ret = Return::new(RValue::Imm(Constant::Unit));
+                        }
+                    }
+                }
+
+                Terminator::Jump(jump) => stack.push(jump.target()),
+                Terminator::Branch(branch) => stack.extend([branch.truthy(), branch.falsy()]),
+                Terminator::Unreachable => {}
+            }
+        }
+    }
+}

--- a/crates/dataflow-jit/src/lib.rs
+++ b/crates/dataflow-jit/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod codegen;
 pub mod dataflow;
+pub mod facade;
 pub mod ir;
 pub mod row;
 pub mod sql_graph;
-pub mod facade;
 
 mod thin_str;
 mod utils;

--- a/crates/dataflow-jit/src/thin_str/mod.rs
+++ b/crates/dataflow-jit/src/thin_str/mod.rs
@@ -49,6 +49,11 @@ pub struct ThinStr {
 }
 
 impl ThinStr {
+    /// The alignment of the allocation pointed to by the `ThinStr`
+    ///
+    /// Note that this is different than `align_of::<ThinStr>()`
+    pub const ALIGN: usize = 16;
+
     #[inline]
     pub fn new() -> Self {
         Self {
@@ -264,7 +269,7 @@ impl ThinStr {
 
         let header = Layout::new::<StrHeader>();
 
-        let bytes = Layout::from_size_align(capacity, 16)
+        let bytes = Layout::from_size_align(capacity, Self::ALIGN)
             .unwrap_or_else(|_| failed_thinstr_layout(capacity));
 
         let (layout, _) = header
@@ -292,7 +297,7 @@ impl ThinStr {
 
         let align = align_of::<usize>();
         debug_assert!(Layout::from_size_align(capacity, align).is_ok());
-        let bytes = Layout::from_size_align_unchecked(capacity, 16);
+        let bytes = Layout::from_size_align_unchecked(capacity, Self::ALIGN);
         let (layout, _) = header.extend(bytes).unwrap_unchecked();
 
         // Pad out the layout
@@ -329,7 +334,7 @@ impl ThinStr {
         );
         // We align our strings to 16 bytes, so we can always take advantage of that
         // "extra" capacity we'll allocate
-        let capacity = next_multiple_of(capacity, 16);
+        let capacity = next_multiple_of(capacity, Self::ALIGN);
 
         // For sigil values, allocate
         if self.capacity() == 0 {

--- a/crates/dbsp/src/operator/group/lag.rs
+++ b/crates/dbsp/src/operator/group/lag.rs
@@ -421,8 +421,8 @@ struct Retraction<K, R> {
     ///
     /// * `None` - key hasn't been encountered yet
     /// * `Some(None)` - key does not occur in the input trace.
-    /// * `Some(Some(n))` - key is `n` steps away from the previous key
-    ///   from `retractions` that is present in the input trace.
+    /// * `Some(Some(n))` - key is `n` steps away from the previous key from
+    ///   `retractions` that is present in the input trace.
     offset: Option<Option<usize>>,
 }
 

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -341,8 +341,8 @@ impl std::convert::From<EitherError> for AnyError {
     }
 }
 
-// The goal for these methods is to avoid multiple DB interactions as much as possible
-// and if not, use transactions
+// The goal for these methods is to avoid multiple DB interactions as much as
+// possible and if not, use transactions
 #[async_trait]
 impl Storage for ProjectDB {
     async fn reset_project_status(&self) -> AnyResult<()> {


### PR DESCRIPTION
Allows creating uninitialized values with the `Uninit` expression, fixes #117

Creating an uninit row value (equivalent to `UninitRow`, should be used in place of it since `UninitRow` is now deprecated)
```json
{
  "Uninit": {
    "Row": 1,
  }
}
```

Creating an uninit scalar value
```json
{
  "Uninit": {
    "Scalar": "I32",
  }
}
```