### PR TITLE
dbsp: Allow constructor function to fail when building a circuit.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,6 +1692,7 @@ dependencies = [
 name = "dataflow-jit"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "bitflags 2.1.0",
  "bitvec",

--- a/crates/adapters/src/deinput.rs
+++ b/crates/adapters/src/deinput.rs
@@ -459,7 +459,7 @@ mod test {
             let (input, input_handle) = circuit.add_input_stream::<TestStruct>();
             let output_handle = input.output();
 
-            (input_handle, output_handle)
+            Ok((input_handle, output_handle))
         })
         .unwrap();
 
@@ -536,11 +536,11 @@ mod test {
                 let set_output = set.output();
                 let map_output = map.output();
 
-                (
+                Ok((
                     (zset_handle, zset_output),
                     (set_handle, set_output),
                     (map_handle, map_output),
-                )
+                ))
             })
             .unwrap();
 

--- a/crates/adapters/src/test/mod.rs
+++ b/crates/adapters/src/test/mod.rs
@@ -102,7 +102,7 @@ pub fn test_circuit(workers: usize) -> (DBSPHandle, Catalog) {
         let (input, hinput) = circuit.add_input_zset::<TestStruct, i32>();
 
         let houtput = input.output();
-        (hinput, houtput)
+        Ok((hinput, houtput))
     })
     .unwrap();
 

--- a/crates/dataflow-jit/Cargo.toml
+++ b/crates/dataflow-jit/Cargo.toml
@@ -12,6 +12,7 @@ name = "dataflow-jit"
 required-features = ["binary"]
 
 [dependencies]
+anyhow = "1.0.57"
 csv = "1.2.1"
 libm = "0.2.6"
 paste = "1.0.9"

--- a/crates/dataflow-jit/src/dataflow/mod.rs
+++ b/crates/dataflow-jit/src/dataflow/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     },
     row::{row_from_literal, Row, UninitRow},
 };
+use anyhow::Result as AnyResult;
 use cranelift_jit::JITModule;
 use cranelift_module::FuncId;
 use dbsp::{
@@ -1019,7 +1020,7 @@ impl CompiledDataflow {
         )
     }
 
-    pub fn construct(mut self, circuit: &mut RootCircuit) -> (Inputs, Outputs) {
+    pub fn construct(mut self, circuit: &mut RootCircuit) -> AnyResult<(Inputs, Outputs)> {
         let mut streams = BTreeMap::<NodeId, RowStream<RootCircuit>>::new();
 
         let mut inputs = BTreeMap::new();
@@ -1457,7 +1458,7 @@ impl CompiledDataflow {
             }
         }
 
-        (inputs, outputs)
+        Ok((inputs, outputs))
     }
 
     fn subgraph(

--- a/crates/dbsp/benches/fraud.rs
+++ b/crates/dbsp/benches/fraud.rs
@@ -294,8 +294,7 @@ impl FraudBenchmark {
                         is_fraud: tran.is_fraud,
                     },
                 );
-
-            (hdemographics, htransactions)
+            Ok((hdemographics, htransactions))
         })
         .unwrap();
 

--- a/crates/dbsp/benches/galen.rs
+++ b/crates/dbsp/benches/galen.rs
@@ -255,6 +255,7 @@ fn main() -> Result<()> {
                     assert_eq!(zs.len(), 16595494);
                 }
             });
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/benches/gdelt/main.rs
+++ b/crates/dbsp/benches/gdelt/main.rs
@@ -125,7 +125,7 @@ fn main() {
                 }
             });
 
-        handle
+        Ok(handle)
     })
     .unwrap();
 

--- a/crates/dbsp/benches/ldbc-graphalytics/main.rs
+++ b/crates/dbsp/benches/ldbc-graphalytics/main.rs
@@ -203,6 +203,7 @@ fn main() {
 
                 Args::ListDatasets { .. } | Args::ListDownloaded { .. } => unreachable!(),
             }
+            Ok(())
         })
         .unwrap().0;
 

--- a/crates/dbsp/benches/path.rs
+++ b/crates/dbsp/benches/path.rs
@@ -116,6 +116,7 @@ fn main() {
                     println!("paths: {}", zs.len())
                 }
             });
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/examples/degrees.rs
+++ b/crates/dbsp/examples/degrees.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
         // Count the number of nodes with each out-degree.
         let distribution = degrees.map(|(_src, count)| *count).weighted_count();
 
-        (hedges, degrees.output(), distribution.output())
+        Ok((hedges, degrees.output(), distribution.output()))
     })
     .unwrap();
 

--- a/crates/dbsp/examples/orgchart.rs
+++ b/crates/dbsp/examples/orgchart.rs
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
                 employee: m2.employee,
             });
 
-        (hmanages, skiplevels.output())
+        Ok((hmanages, skiplevels.output()))
     })
     .unwrap();
 

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -120,6 +120,7 @@ impl Runtime {
     ///
     ///     let root = RootCircuit::build(move |circuit| {
     ///         // Populate `circuit` with operators.
+    ///         Ok(())
     ///     })
     ///     .unwrap()
     ///     .0;
@@ -382,6 +383,7 @@ mod tests {
                         runtime.sequence_next(Runtime::worker_index())
                     }))
                     .inspect(move |n: &usize| data_clone.borrow_mut().push(*n));
+                Ok(())
             })
             .unwrap()
             .0;
@@ -428,6 +430,7 @@ mod tests {
                         Ok((|| Ok(false), ()))
                     })
                     .unwrap();
+                Ok(())
             })
             .unwrap()
             .0;

--- a/crates/dbsp/src/error.rs
+++ b/crates/dbsp/src/error.rs
@@ -1,4 +1,5 @@
 use crate::{RuntimeError, SchedulerError};
+use anyhow::Error as AnyError;
 use std::{
     fmt::{Display, Error as FmtError, Formatter},
     io::Error as IOError,
@@ -9,6 +10,7 @@ pub enum Error {
     Scheduler(SchedulerError),
     Runtime(RuntimeError),
     IO(IOError),
+    Constructor(AnyError),
     Custom(String),
 }
 
@@ -23,6 +25,9 @@ impl Display for Error {
             }
             Self::IO(error) => {
                 write!(f, "IO error: '{error}'")
+            }
+            Self::Constructor(error) => {
+                write!(f, "construction error: '{error}'")
             }
             Self::Custom(error) => f.write_str(error),
         }

--- a/crates/dbsp/src/operator/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/aggregate/mod.rs
@@ -721,6 +721,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use anyhow::Result as AnyResult;
+
     use std::{
         cell::RefCell,
         rc::Rc,
@@ -738,7 +740,10 @@ mod test {
 
     type TestZSet = OrdZSet<(usize, isize), isize>;
 
-    fn aggregate_test_circuit(circuit: &mut RootCircuit, inputs: Vec<Vec<TestZSet>>) {
+    fn aggregate_test_circuit(
+        circuit: &mut RootCircuit,
+        inputs: Vec<Vec<TestZSet>>,
+    ) -> AnyResult<()> {
         let mut inputs = inputs.into_iter();
 
         circuit
@@ -881,6 +886,7 @@ mod test {
                 ))
             })
             .unwrap();
+        Ok(())
     }
 
     use proptest::{collection, prelude::*};
@@ -989,7 +995,7 @@ mod test {
                         *sum_distinct_output.lock().unwrap() = batch.clone();
                     }
                 });
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/apply2.rs
+++ b/crates/dbsp/src/operator/apply2.rs
@@ -161,6 +161,7 @@ mod test {
             source1
                 .apply2(&source2, |x, y| *x + *y)
                 .inspect(|z| assert_eq!(*z, 0));
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/communication/exchange.rs
+++ b/crates/dbsp/src/operator/communication/exchange.rs
@@ -361,6 +361,7 @@ where
 ///             assert_eq!(&vec![round; WORKERS], v);
 ///             round += 1;
 ///         });
+///         Ok(())
 ///     })
 ///     .unwrap()
 ///     .0;
@@ -713,6 +714,7 @@ mod tests {
                             assert_eq!(&vec![round; workers], v);
                             round += 1;
                         });
+                    Ok(())
                 })
                 .unwrap()
                 .0;

--- a/crates/dbsp/src/operator/communication/shard.rs
+++ b/crates/dbsp/src/operator/communication/shard.rs
@@ -294,6 +294,7 @@ mod tests {
                             assert_eq!(batch.len(), 0);
                         }
                     });
+                Ok(())
             })
             .unwrap()
             .0;

--- a/crates/dbsp/src/operator/condition.rs
+++ b/crates/dbsp/src/operator/condition.rs
@@ -238,6 +238,7 @@ mod test {
                 assert_eq!(r, &zset! { 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 1, 6 => 1})
             });
             reachable2.inspect(|r| assert_eq!(r, &zset! { 1 => 1, 2 => 1, 4 => 1, 5 => 1, 6 => 1}));
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/count.rs
+++ b/crates/dbsp/src/operator/count.rs
@@ -139,11 +139,11 @@ mod test {
                 let expected_twos = expected_ones.map_index(|(&_k, &v)| (2, v)).delay();
                 let expected_counts = expected_ones.plus(&expected_twos);
 
-                (
+                Ok((
                     counts.output(),
                     stream_counts.output(),
                     expected_counts.output(),
-                )
+                ))
             })
             .unwrap();
 
@@ -206,7 +206,7 @@ mod test {
                 circuit.add_source(Generator::new(move || iter.next().unwrap_or_default()));
             let counts = source.differentiate().distinct_count().integrate();
             let stream_counts = source.stream_distinct_count();
-            (counts.output(), stream_counts.output())
+            Ok((counts.output(), stream_counts.output()))
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/csv.rs
+++ b/crates/dbsp/src/operator/csv.rs
@@ -129,6 +129,7 @@ mod test {
                 .inspect(move |data: &OrdZSet<(usize, usize, usize), isize>| {
                     assert_eq!(data, &expected)
                 });
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -727,6 +727,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use anyhow::Result as AnyResult;
+
     use std::{
         cell::RefCell,
         rc::Rc,
@@ -813,6 +815,7 @@ mod test {
                     ))
                 })
                 .unwrap();
+            Ok(())
         })
         .unwrap()
         .0;
@@ -853,7 +856,7 @@ mod test {
                     }
                 });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 
@@ -931,7 +934,7 @@ mod test {
     fn distinct_test_circuit(
         circuit: &mut RootCircuit,
         inputs: Vec<TestZSet>,
-    ) -> (OutputHandle<TestZSet>, OutputHandle<TestZSet>) {
+    ) -> AnyResult<(OutputHandle<TestZSet>, OutputHandle<TestZSet>)> {
         let mut inputs = inputs.into_iter();
 
         let input = circuit.add_source(Generator::new(Box::new(move || {
@@ -945,13 +948,13 @@ mod test {
         let distinct_inc = input.distinct().output();
         let distinct_noninc = input.integrate().stream_distinct().differentiate().output();
 
-        (distinct_inc, distinct_noninc)
+        Ok((distinct_inc, distinct_noninc))
     }
 
     fn distinct_indexed_test_circuit(
         circuit: &mut RootCircuit,
         inputs: Vec<TestIndexedZSet>,
-    ) -> (OutputHandle<TestIndexedZSet>, OutputHandle<TestIndexedZSet>) {
+    ) -> AnyResult<(OutputHandle<TestIndexedZSet>, OutputHandle<TestIndexedZSet>)> {
         let mut inputs = inputs.into_iter();
 
         let input = circuit.add_source(Generator::new(Box::new(move || {
@@ -965,13 +968,13 @@ mod test {
         let distinct_inc = input.distinct().output();
         let distinct_noninc = input.integrate().stream_distinct().differentiate().output();
 
-        (distinct_inc, distinct_noninc)
+        Ok((distinct_inc, distinct_noninc))
     }
 
     fn distinct_indexed_nested_test_circuit(
         circuit: &mut RootCircuit,
         inputs: Vec<Vec<TestIndexedZSet>>,
-    ) {
+    ) -> AnyResult<()> {
         let mut inputs = inputs.into_iter();
 
         circuit
@@ -1021,6 +1024,7 @@ mod test {
                 ))
             })
             .unwrap();
+        Ok(())
     }
 
     proptest! {

--- a/crates/dbsp/src/operator/filter_map.rs
+++ b/crates/dbsp/src/operator/filter_map.rs
@@ -863,6 +863,7 @@ mod test {
             i_sqr_pos_indexed.inspect(move |n| {
                 assert_eq!(*n, i_sqr_pos_indexed_output.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 

--- a/crates/dbsp/src/operator/group/test.rs
+++ b/crates/dbsp/src/operator/group/test.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     CollectionHandle, DBData, DBWeight, OrdIndexedZSet, OutputHandle, RootCircuit, Runtime,
 };
+use anyhow::Result as AnyResult;
 use proptest::{collection::vec, prelude::*};
 
 fn input_trace(
@@ -127,43 +128,43 @@ where
 
 fn topk_test_circuit(
     circuit: &mut RootCircuit,
-) -> (
+) -> AnyResult<(
     CollectionHandle<i32, (i32, i32)>,
     OutputHandle<OrdIndexedZSet<i32, i32, i32>>,
     OutputHandle<OrdIndexedZSet<i32, i32, i32>>,
-) {
+)> {
     let (input_stream, input_handle) = circuit.add_input_indexed_zset::<i32, i32, i32>();
 
     let topk_asc_handle = input_stream.topk_asc(5).integrate().output();
     let topk_desc_handle = input_stream.topk_desc(5).integrate().output();
 
-    (input_handle, topk_asc_handle, topk_desc_handle)
+    Ok((input_handle, topk_asc_handle, topk_desc_handle))
 }
 
 fn lag_test_circuit(
     circuit: &mut RootCircuit,
-) -> (
+) -> AnyResult<(
     CollectionHandle<i32, (i32, i32)>,
     OutputHandle<OrdIndexedZSet<i32, (i32, Option<i32>), i32>>,
-) {
+)> {
     let (input_stream, input_handle) = circuit.add_input_indexed_zset::<i32, i32, i32>();
 
     let lag_handle = input_stream.lag(3, |v| v.cloned()).integrate().output();
 
-    (input_handle, lag_handle)
+    Ok((input_handle, lag_handle))
 }
 
 fn lead_test_circuit(
     circuit: &mut RootCircuit,
-) -> (
+) -> AnyResult<(
     CollectionHandle<i32, (i32, i32)>,
     OutputHandle<OrdIndexedZSet<i32, (i32, Option<i32>), i32>>,
-) {
+)> {
     let (input_stream, input_handle) = circuit.add_input_indexed_zset::<i32, i32, i32>();
 
     let lead_handle = input_stream.lead(3, |v| v.cloned()).integrate().output();
 
-    (input_handle, lead_handle)
+    Ok((input_handle, lead_handle))
 }
 
 proptest! {

--- a/crates/dbsp/src/operator/index.rs
+++ b/crates/dbsp/src/operator/index.rs
@@ -262,6 +262,7 @@ mod test {
                    .index()
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
+            Ok(())
         })
         .unwrap().0;
 
@@ -295,6 +296,7 @@ mod test {
                    .index_with(|&(k, v)| (k, v))
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
+            Ok(())
         })
         .unwrap().0;
 

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -952,6 +952,7 @@ mod test {
         zset, CollectionHandle, InputHandle, OrdIndexedZSet, OrdZSet, RootCircuit, Runtime,
         UpsertHandle,
     };
+    use anyhow::Result as AnyResult;
     use std::iter::once;
 
     fn input_batches() -> Vec<OrdZSet<usize, isize>> {
@@ -981,7 +982,7 @@ mod test {
     fn input_test_circuit(
         circuit: &RootCircuit,
         nworkers: usize,
-    ) -> InputHandle<OrdZSet<usize, isize>> {
+    ) -> AnyResult<InputHandle<OrdZSet<usize, isize>>> {
         let (stream, handle) = circuit.add_input_stream::<OrdZSet<usize, isize>>();
 
         let mut expected_batches = input_batches()
@@ -1000,7 +1001,7 @@ mod test {
             }
         });
 
-        handle
+        Ok(handle)
     }
 
     #[test]
@@ -1057,7 +1058,7 @@ mod test {
         input_test_mt(4);
     }
 
-    fn zset_test_circuit(circuit: &RootCircuit) -> CollectionHandle<usize, isize> {
+    fn zset_test_circuit(circuit: &RootCircuit) -> AnyResult<CollectionHandle<usize, isize>> {
         let (stream, handle) = circuit.add_input_zset::<usize, isize>();
 
         let mut expected_batches = input_batches()
@@ -1070,7 +1071,7 @@ mod test {
             }
         });
 
-        handle
+        Ok(handle)
     }
 
     #[test]
@@ -1163,7 +1164,9 @@ mod test {
             .collect()
     }
 
-    fn indexed_zset_test_circuit(circuit: &RootCircuit) -> CollectionHandle<usize, (usize, isize)> {
+    fn indexed_zset_test_circuit(
+        circuit: &RootCircuit,
+    ) -> AnyResult<CollectionHandle<usize, (usize, isize)>> {
         let (stream, handle) = circuit.add_input_indexed_zset::<usize, usize, isize>();
 
         let mut expected_batches = input_indexed_batches()
@@ -1175,7 +1178,7 @@ mod test {
             }
         });
 
-        handle
+        Ok(handle)
     }
 
     #[test]
@@ -1245,7 +1248,7 @@ mod test {
         ]
     }
 
-    fn set_test_circuit(circuit: &RootCircuit) -> UpsertHandle<usize, bool> {
+    fn set_test_circuit(circuit: &RootCircuit) -> AnyResult<UpsertHandle<usize, bool>> {
         let (stream, handle) = circuit.add_input_set::<usize, isize>();
 
         let mut expected_batches = output_set_updates().into_iter();
@@ -1256,7 +1259,7 @@ mod test {
             }
         });
 
-        handle
+        Ok(handle)
     }
 
     #[test]
@@ -1338,7 +1341,7 @@ mod test {
         ]
     }
 
-    fn map_test_circuit(circuit: &RootCircuit) -> UpsertHandle<usize, Option<usize>> {
+    fn map_test_circuit(circuit: &RootCircuit) -> AnyResult<UpsertHandle<usize, Option<usize>>> {
         let (stream, handle) = circuit.add_input_map::<usize, usize, isize>();
 
         let mut expected_batches = output_map_updates().into_iter();
@@ -1349,7 +1352,7 @@ mod test {
             }
         });
 
-        handle
+        Ok(handle)
     }
 
     #[test]

--- a/crates/dbsp/src/operator/inspect.rs
+++ b/crates/dbsp/src/operator/inspect.rs
@@ -30,6 +30,7 @@ where
     ///     }));
     ///     // Print all values in `stream`.
     ///     stream.inspect(|n| println!("inspect: {}", n));
+    ///     Ok(())
     /// })
     /// .unwrap();
     /// ```

--- a/crates/dbsp/src/operator/integrate.rs
+++ b/crates/dbsp/src/operator/integrate.rs
@@ -60,6 +60,7 @@ where
     ///         assert_eq!(*n, counter2);
     ///         counter2 += 1;
     ///     });
+    ///     Ok(())
     /// })
     /// .unwrap()
     /// .0;
@@ -184,6 +185,7 @@ mod test {
                 counter += 1;
                 assert_eq!(*n, counter);
             });
+            Ok(())
         })
         .unwrap()
         .0;
@@ -224,6 +226,7 @@ mod test {
                 assert_eq!(s, &<OrdZSet<_, _>>::from_keys((), batch));
                 counter3 += 1;
             });
+            Ok(())
         })
         .unwrap()
         .0;
@@ -280,6 +283,7 @@ mod test {
                 })
                 .unwrap();
             integral.inspect(move |n| assert_eq!(*n, expected_outer_integrals.next().unwrap()));
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/join.rs
+++ b/crates/dbsp/src/operator/join.rs
@@ -1014,6 +1014,7 @@ mod test {
                         assert_eq!(fm, &inc_outputs2.next().unwrap())
                     }
                 });
+            Ok(())
         })
         .unwrap()
         .0;
@@ -1110,6 +1111,7 @@ mod test {
             paths.integrate().stream_distinct().inspect(move |ps| {
                 assert_eq!(*ps, outputs.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 
@@ -1243,6 +1245,7 @@ mod test {
             propagate(circuit, &edges, &labels).inspect(move |labeled| {
                 assert_eq!(*labeled, outputs.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 
@@ -1329,6 +1332,7 @@ mod test {
             result.consolidate().inspect(move |res: &OrdZSet<Label, isize>| {
                 assert_eq!(*res, outputs.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 
@@ -1353,7 +1357,7 @@ mod test {
                 }
             });
 
-            (input_handle1, input_handle2)
+            Ok((input_handle1, input_handle2))
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/join_range.rs
+++ b/crates/dbsp/src/operator/join_range.rs
@@ -287,6 +287,7 @@ mod test {
             output1
                 .index()
                 .apply2(&output2, |o1, o2| assert_eq!(o1, o2));
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/neg.rs
+++ b/crates/dbsp/src/operator/neg.rs
@@ -97,14 +97,12 @@ mod test {
                 .neg()
                 .plus(&source)
                 .inspect(|s| assert_eq!(s, &<OrdZSet<_, _> as HasZero>::zero()));
-            source
+            Ok(source)
         };
 
-        let circuit = RootCircuit::build(move |circuit| {
-            build_circuit(circuit);
-        })
-        .unwrap()
-        .0;
+        let circuit = RootCircuit::build(move |circuit| build_circuit(circuit))
+            .unwrap()
+            .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -288,7 +288,7 @@ mod test {
             let (zset, zset_handle) = circuit.add_input_zset::<u64, isize>();
             let zset_output = zset.output();
 
-            (zset_handle, zset_output)
+            Ok((zset_handle, zset_output))
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/plus.rs
+++ b/crates/dbsp/src/operator/plus.rs
@@ -45,6 +45,7 @@ where
     ///     }));
     ///     // Compute pairwise sums of values in the stream; the output stream will contain zeros.
     ///     source1.plus(&source2).inspect(|n| assert_eq!(*n, 0));
+    ///     Ok(())
     /// })
     /// .unwrap()
     /// .0;
@@ -238,6 +239,7 @@ mod test {
                 res
             }));
             source1.plus(&source2).inspect(|n| assert_eq!(*n, 100));
+            Ok(())
         })
         .unwrap()
         .0;
@@ -291,6 +293,7 @@ mod test {
         let circuit = RootCircuit::build(move |circuit| {
             build_plus_circuit(circuit);
             build_minus_circuit(circuit);
+            Ok(())
         })
         .unwrap()
         .0;
@@ -313,6 +316,7 @@ mod test {
                 &source3,
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
+            Ok(())
         })
         .unwrap()
         .0;
@@ -336,6 +340,7 @@ mod test {
                 &source4,
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
+            Ok(())
         })
         .unwrap()
         .0;
@@ -369,6 +374,7 @@ mod test {
                 &source4,
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/recursive.rs
+++ b/crates/dbsp/src/operator/recursive.rs
@@ -245,6 +245,7 @@ where
     ///     labels.inspect(move |ls| {
     ///         assert_eq!(*ls, expected_outputs.next().unwrap());
     ///     });
+    ///     Ok(())
     /// })
     /// .unwrap().0;
     ///
@@ -351,6 +352,7 @@ mod test {
             paths.integrate().stream_distinct().inspect(move |ps| {
                 assert_eq!(*ps, outputs.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 
@@ -423,6 +425,7 @@ mod test {
             reverse_paths.map(|(x, y)| (*y, *x)).integrate().stream_distinct().inspect(move |ps: &OrdZSet<_,_>| {
                 assert_eq!(*ps, outputs2.next().unwrap());
             });
+            Ok(())
         })
         .unwrap().0;
 

--- a/crates/dbsp/src/operator/sum.rs
+++ b/crates/dbsp/src/operator/sum.rs
@@ -170,6 +170,7 @@ mod test {
         // Allow `Sum` to consume all streams by value.
         let circuit = RootCircuit::build(move |circuit| {
             build_circuit(circuit);
+            Ok(())
         })
         .unwrap()
         .0;
@@ -186,6 +187,7 @@ mod test {
                 &source1,
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
+            Ok(())
         })
         .unwrap()
         .0;
@@ -212,6 +214,7 @@ mod test {
                 &source3,
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
+            Ok(())
         })
         .unwrap()
         .0;

--- a/crates/dbsp/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -468,7 +468,7 @@ mod test {
                     );
                 });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/time_series/radix_tree/tree_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/radix_tree/tree_aggregate.rs
@@ -292,7 +292,7 @@ mod test {
                     );
                 });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -774,7 +774,7 @@ mod test {
                 assert_eq!(expected, actual)
             });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap()
     }

--- a/crates/dbsp/src/operator/time_series/watermark.rs
+++ b/crates/dbsp/src/operator/time_series/watermark.rs
@@ -92,7 +92,7 @@ mod tests {
                         assert_eq!(watermark, &expected_watermarks.next().unwrap());
                     }
                 });
-            handle
+            Ok(handle)
         })
         .unwrap();
 

--- a/crates/dbsp/src/operator/time_series/window.rs
+++ b/crates/dbsp/src/operator/time_series/window.rs
@@ -300,6 +300,7 @@ mod test {
             index1
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
+            Ok(())
         })
         .unwrap()
         .0;
@@ -363,6 +364,7 @@ mod test {
             index1
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
+            Ok(())
         })
         .unwrap().0;
 
@@ -442,6 +444,7 @@ mod test {
             index1
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
+            Ok(())
         })
         .unwrap().0;
 
@@ -470,7 +473,7 @@ mod test {
                     ()
                 });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/benches/nexmark/run_queries.rs
+++ b/crates/nexmark/benches/nexmark/run_queries.rs
@@ -74,7 +74,7 @@ macro_rules! run_queries {
             // handle like the other queries.
             side_input_handle.append(&mut q13_side_input());
 
-            input_handle
+            Ok(input_handle)
         }
     };
     (@circuit $query:ident) => {
@@ -85,7 +85,7 @@ macro_rules! run_queries {
 
             output.inspect(move |_zs| ());
 
-            input_handle
+            Ok(input_handle)
         }
     };
 

--- a/crates/nexmark/src/lib.rs
+++ b/crates/nexmark/src/lib.rs
@@ -309,7 +309,7 @@ pub mod tests {
             stream.inspect(move |data: &OrdZSet<Event, isize>| {
                 assert_eq!(data, &expected_zset);
             });
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q0.rs
+++ b/crates/nexmark/src/queries/q0.rs
@@ -92,7 +92,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q1.rs
+++ b/crates/nexmark/src/queries/q1.rs
@@ -135,7 +135,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q12.rs
+++ b/crates/nexmark/src/queries/q12.rs
@@ -131,7 +131,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q13.rs
+++ b/crates/nexmark/src/queries/q13.rs
@@ -167,7 +167,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            (input_handle, side_input_handle)
+            Ok((input_handle, side_input_handle))
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -187,7 +187,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q15.rs
+++ b/crates/nexmark/src/queries/q15.rs
@@ -644,7 +644,7 @@ mod tests {
                 }
             });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q16.rs
+++ b/crates/nexmark/src/queries/q16.rs
@@ -825,7 +825,7 @@ mod tests {
                 }
             });
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q17.rs
+++ b/crates/nexmark/src/queries/q17.rs
@@ -334,7 +334,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q18.rs
+++ b/crates/nexmark/src/queries/q18.rs
@@ -384,7 +384,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q19.rs
+++ b/crates/nexmark/src/queries/q19.rs
@@ -288,7 +288,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q2.rs
+++ b/crates/nexmark/src/queries/q2.rs
@@ -100,7 +100,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q20.rs
+++ b/crates/nexmark/src/queries/q20.rs
@@ -240,7 +240,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q21.rs
+++ b/crates/nexmark/src/queries/q21.rs
@@ -129,7 +129,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q22.rs
+++ b/crates/nexmark/src/queries/q22.rs
@@ -115,7 +115,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q3.rs
+++ b/crates/nexmark/src/queries/q3.rs
@@ -209,7 +209,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q4.rs
+++ b/crates/nexmark/src/queries/q4.rs
@@ -226,7 +226,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q5.rs
+++ b/crates/nexmark/src/queries/q5.rs
@@ -201,7 +201,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q6.rs
+++ b/crates/nexmark/src/queries/q6.rs
@@ -194,7 +194,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 
@@ -268,7 +268,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 
@@ -510,7 +510,7 @@ mod tests {
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 
@@ -628,7 +628,7 @@ mod tests {
             let output = q6(stream);
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q7.rs
+++ b/crates/nexmark/src/queries/q7.rs
@@ -174,7 +174,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q8.rs
+++ b/crates/nexmark/src/queries/q8.rs
@@ -204,7 +204,7 @@ mod tests {
             let mut expected_output = expected_zsets.into_iter();
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 

--- a/crates/nexmark/src/queries/q9.rs
+++ b/crates/nexmark/src/queries/q9.rs
@@ -387,7 +387,7 @@ mod tests {
             let output = q9(stream);
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
 
-            input_handle
+            Ok(input_handle)
         })
         .unwrap();
 


### PR DESCRIPTION
It seems reasonable to do things that might fail inside the constructor passed to `RootCircuit::build()` or `Runtime::init_circuit()`, especially the latter.  This was also listed as a TODO on the former function.

This commit makes that possible, by changing the `DBSPError`[*] type to allow for an additional `Constructor` alternative.  Along with changing `RootCircuit::build` to returning `DBSPError` instead of the more-specific `SchedulerError`[**], this is about all we need substantively.

In addition, this commit fixes up every constructor closure to return an `Ok` result type.  Unfortunately, the compiler can't infer the failure type in cases where the closure can't fail (which is every existing case), so in addition this change has to annotate a `()` failure type in each case as well.

[*] Well actually `dbsp::error::Error`, but `circuit_builder.rs` renames it.
[**] Well actually `dbsp::circuit::schedule::Error`.