### PR TITLE
[JIT] Misc improvements

### DIFF
--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -53,6 +53,7 @@ use std::{
     cell::{Ref, RefCell},
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet, HashMap},
+    mem::size_of,
     rc::Rc,
     sync::Arc,
 };
@@ -65,6 +66,7 @@ const TRAP_ASSERT_EQ: TrapCode = TrapCode::User(3);
 // const TRAP_CAPACITY_OVERFLOW: TrapCode = TrapCode::User(4);
 const TRAP_DIV_OVERFLOW: TrapCode = TrapCode::User(5);
 const TRAP_ABORT: TrapCode = TrapCode::User(6);
+const TRAP_FAILED_PARSE: TrapCode = TrapCode::User(7);
 
 // TODO: Pretty function debugging https://github.com/bjorn3/rustc_codegen_cranelift/blob/master/src/pretty_clif.rs
 
@@ -2386,5 +2388,15 @@ impl<'a> CodegenCtx<'a> {
                 unreachable!("tried to cast {value_ty} to pointer-sized {ptr_ty}")
             }
         }
+    }
+
+    #[inline]
+    fn usize_is_u64(&self) -> bool {
+        self.frontend_config().pointer_bytes() as usize == size_of::<u64>()
+    }
+
+    #[inline]
+    fn isize_is_i64(&self) -> bool {
+        self.usize_is_u64()
     }
 }

--- a/crates/dataflow-jit/src/dataflow/tests.rs
+++ b/crates/dataflow-jit/src/dataflow/tests.rs
@@ -89,8 +89,8 @@ fn compiled_dataflow() {
         },
     );
 
-    let mul_sink = graph.sink(mul);
-    let y_squared_sink = graph.sink(y_squared);
+    let mul_sink = graph.sink(mul, StreamLayout::Set(x_layout));
+    let y_squared_sink = graph.sink(y_squared, StreamLayout::Set(x_layout));
 
     // let mut validator = Validator::new();
     // validator.validate_graph(&graph);
@@ -347,7 +347,7 @@ fn bfs() {
         vec![distances, unreachable_nodes],
         StreamLayout::Set(u64x2),
     ));
-    let sink = graph.sink(distances);
+    let sink = graph.sink(distances, StreamLayout::Set(u64x2));
 
     let (dataflow, jit_handle, layout_cache) =
         CompiledDataflow::new(&graph, CodegenConfig::debug(), |_| ());

--- a/crates/dataflow-jit/src/ir/literal.rs
+++ b/crates/dataflow-jit/src/ir/literal.rs
@@ -57,6 +57,17 @@ impl StreamLiteral {
     pub fn is_empty(&self) -> bool {
         self.value.is_empty()
     }
+
+    pub fn consolidate(&mut self) {
+        self.value.consolidate();
+    }
+
+    pub fn to_consolidated(&self) -> Self {
+        Self {
+            layout: self.layout,
+            value: self.value.to_consolidated(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema)]
@@ -73,8 +84,75 @@ impl StreamCollection {
         }
     }
 
+    pub const fn empty(layout: StreamLayout) -> StreamCollection {
+        match layout {
+            StreamLayout::Set(_) => Self::Set(Vec::new()),
+            StreamLayout::Map(..) => Self::Map(Vec::new()),
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn consolidate(&mut self) {
+        match self {
+            Self::Set(set) => {
+                // FIXME: We really should be sorting by the criteria that the
+                // runtime rows will be sorted by so we have less work to do at
+                // runtime, but technically any sorting criteria works as long
+                // as it's consistent and allows us to deduplicate the stream
+                set.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+                // Deduplicate rows and combine their weights
+                set.dedup_by(|(a, weight_a), (b, weight_b)| {
+                    if a == b {
+                        *weight_b = weight_b
+                            .checked_add(*weight_a)
+                            .expect("weight overflow in constant stream");
+
+                        true
+                    } else {
+                        false
+                    }
+                });
+
+                // Remove all zero weights
+                set.retain(|&(_, weight)| weight != 0);
+            }
+
+            Self::Map(map) => {
+                // FIXME: We really should be sorting by the criteria that the
+                // runtime rows will be sorted by so we have less work to do at
+                // runtime, but technically any sorting criteria works as long
+                // as it's consistent and allows us to deduplicate the stream
+                map.sort_by(|(key_a, value_a, _), (key_b, value_b, _)| {
+                    key_a.cmp(key_b).then_with(|| value_a.cmp(value_b))
+                });
+
+                // Deduplicate rows and combine their weights
+                map.dedup_by(|(key_a, value_a, weight_a), (key_b, value_b, weight_b)| {
+                    if key_a == key_b && value_a == value_b {
+                        *weight_b = weight_b
+                            .checked_add(*weight_a)
+                            .expect("weight overflow in constant stream");
+
+                        true
+                    } else {
+                        false
+                    }
+                });
+
+                // Remove all zero weights
+                map.retain(|&(_, _, weight)| weight != 0);
+            }
+        }
+    }
+
+    pub fn to_consolidated(&self) -> Self {
+        let mut this = self.clone();
+        this.consolidate();
+        this
     }
 }
 

--- a/crates/dataflow-jit/src/ir/nodes/mod.rs
+++ b/crates/dataflow-jit/src/ir/nodes/mod.rs
@@ -79,6 +79,14 @@ impl Node {
             None
         }
     }
+
+    pub const fn as_sink(&self) -> Option<&Sink> {
+        if let Self::Sink(sink) = self {
+            Some(sink)
+        } else {
+            None
+        }
+    }
 }
 
 // TODO: Fully flesh this out, make it useful

--- a/crates/dataflow-jit/src/ir/optimize/dedup.rs
+++ b/crates/dataflow-jit/src/ir/optimize/dedup.rs
@@ -105,8 +105,8 @@ mod tests {
         let source = graph.source(u32);
         let distinct2 = graph.distinct(source, StreamLayout::Set(u32));
         let distinct3 = graph.distinct(source, StreamLayout::Set(u32));
-        let sink1 = graph.sink(distinct2);
-        let sink2 = graph.sink(distinct3);
+        let sink1 = graph.sink(distinct2, StreamLayout::Set(u32));
+        let sink2 = graph.sink(distinct3, StreamLayout::Set(u32));
 
         let constant = StreamLiteral::new(
             StreamLayout::Set(u32),
@@ -120,8 +120,8 @@ mod tests {
             StreamLayout::Set(u32),
         ));
         let empty2 = graph.add_node(ConstantStream::new(constant, StreamLayout::Set(u32)));
-        let sink3 = graph.sink(empty1);
-        let sink4 = graph.sink(empty2);
+        let sink3 = graph.sink(empty1, StreamLayout::Set(u32));
+        let sink4 = graph.sink(empty2, StreamLayout::Set(u32));
 
         graph.optimize();
 

--- a/crates/dataflow-jit/src/ir/optimize/distinct.rs
+++ b/crates/dataflow-jit/src/ir/optimize/distinct.rs
@@ -272,7 +272,7 @@ mod tests {
             builder.build()
         });
         let distinct_2 = graph.distinct(filtered, StreamLayout::Set(u32));
-        let sink = graph.sink(distinct_2);
+        let sink = graph.sink(distinct_2, StreamLayout::Set(u32));
 
         graph.optimize();
 

--- a/crates/dataflow-jit/src/ir/optimize/shake.rs
+++ b/crates/dataflow-jit/src/ir/optimize/shake.rs
@@ -155,7 +155,7 @@ impl Subgraph {
 #[cfg(test)]
 mod tests {
     use crate::{
-        ir::{ColumnType, Graph, GraphExt, RowLayoutBuilder},
+        ir::{nodes::StreamLayout, ColumnType, Graph, GraphExt, RowLayoutBuilder},
         utils,
     };
 
@@ -173,7 +173,7 @@ mod tests {
         graph.source(value);
 
         let empty = graph.empty_set(value);
-        graph.sink(empty);
+        graph.sink(empty, StreamLayout::Set(value));
 
         graph.optimize();
 

--- a/crates/dataflow-jit/src/sql_graph.rs
+++ b/crates/dataflow-jit/src/sql_graph.rs
@@ -264,7 +264,7 @@ mod tests {
             StreamLayout::Set(i32),
         )));
 
-        let sink = graph.sink(flat_map);
+        let sink = graph.sink(flat_map, StreamLayout::Set(i32));
 
         let graph = SqlGraph::from(graph);
         let json_graph = serde_json::to_string_pretty(&graph).unwrap();
@@ -365,7 +365,7 @@ mod tests {
             i32,
         )));
 
-        graph.sink(filter_map);
+        graph.sink(filter_map, StreamLayout::Set(i32));
 
         let graph = SqlGraph::from(graph);
         let json_graph = serde_json::to_string_pretty(&graph).unwrap();


### PR DESCRIPTION
- Bedrock for string parsing
- Fixed dead sources/sinks panicking (fixes #128)
- Added `.consolidate()`/`.to_consolidated()` methods to `StreamCollection` (addresses #125, if comparing two possibly non-consolidated `StreamCollections` you can consolidate and compare them)
- Adds an `input_layout: StreamLayout` field to `Sink`s (cc @mihaibudiu for json changes), new json will look like this
  ```json
  "Sink": {
    "input": 1,
    "input_layout": { "Set": 2 }
  }
  ```