### PR TITLE
Add support for Codespaces.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:22.04 AS base
+
+WORKDIR /home/
+
+COPY . .
+
+RUN bash ./setup.sh
+
+ENV PATH="/root/.cargo/bin:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "DBSP",
+	"extensions": [
+		"cschleiden.vscode-github-actions",
+		"ms-vsliveshare.vsliveshare",
+		"matklad.rust-analyzer",
+		"serayuzgur.crates",
+		"vadimcn.vscode-lldb"
+	],
+	"dockerFile": "Dockerfile",
+	"settings": {
+		"editor.formatOnSave": true,
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"files.exclude": {
+			"**/CODE_OF_CONDUCT.md": true,
+			"**/LICENSE": true
+		}
+	}
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,26 @@
+## update and install some things we should probably have
+apt-get update
+apt-get install -y \
+  curl \
+  git \
+  gnupg2 \
+  sudo \
+  build-essential \
+  openssl \
+  cmake \
+  pkg-config \
+  libssl-dev \
+  nodejs \
+  npm
+
+## Install rustup and common components
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+rustup install nightly
+rustup component add rustfmt
+rustup component add rustfmt --toolchain nightly
+rustup component add clippy 
+rustup component add clippy --toolchain nightly
+#curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
+npm install --global yarn
+npm install --global openapi-typescript-codegen

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ multiple nodes for high availability and throughput.
 
 ## Getting started
 
+DBSP is implemented in Rust and uses Rust's `cargo` build system.  You
+can build everything with `cargo build` at the top level of this tree.
+If you want to do development without installing the Rust toolchain
+locally, you can use Github Codespaces: from
+https://github.com/feldera/dbsp, click on the green `<> Code` button,
+then select Codespaces and click on "Create codespace on main".
+
 To learn about using DBSP as a Rust programmer, start by reading the
 [`circuit_builder`](`circuit::circuit_builder`) module documentation.
 The examples folder also has some simple places to start.  For more


### PR DESCRIPTION
Github Codespaces allows for Rust development using a container hosted by Github.  You can do development in a web browser without needing to have your own development setup.