### PR TITLE
`neighborhood` operator

### DIFF
--- a/crates/dbsp/src/operator/apply3.rs
+++ b/crates/dbsp/src/operator/apply3.rs
@@ -1,0 +1,140 @@
+//! Ternary operator that applies an arbitrary ternary function to its inputs.
+
+use crate::circuit::{
+    metadata::OperatorLocation,
+    operator_traits::{Operator, TernaryOperator},
+    Circuit, OwnershipPreference, Scope, Stream,
+};
+use std::{borrow::Cow, panic::Location};
+
+impl<C, T1> Stream<C, T1>
+where
+    C: Circuit,
+    T1: Clone + 'static,
+{
+    /// Apply a user-provided ternary function to inputs from three streams at each
+    /// timestamp.
+    #[track_caller]
+    pub fn apply3<F, T2, T3, T4>(
+        &self,
+        other1: &Stream<C, T2>,
+        other2: &Stream<C, T3>,
+        func: F,
+    ) -> Stream<C, T4>
+    where
+        T2: Clone + 'static,
+        T3: Clone + 'static,
+        T4: Clone + 'static,
+        F: Fn(Cow<'_, T1>, Cow<'_, T2>, Cow<'_, T3>) -> T4 + 'static,
+    {
+        self.apply3_with_preference(
+            OwnershipPreference::INDIFFERENT,
+            (other1, OwnershipPreference::INDIFFERENT),
+            (other2, OwnershipPreference::INDIFFERENT),
+            func,
+        )
+    }
+
+    /// Apply a user-provided ternary function to inputs at each
+    /// timestamp.
+    ///
+    /// Allows the caller to specify the ownership preference for
+    /// each input stream.
+    #[track_caller]
+    pub fn apply3_with_preference<F, T2, T3, T4>(
+        &self,
+        self_preference: OwnershipPreference,
+        other1: (&Stream<C, T2>, OwnershipPreference),
+        other2: (&Stream<C, T3>, OwnershipPreference),
+        func: F,
+    ) -> Stream<C, T4>
+    where
+        T2: Clone + 'static,
+        T3: Clone + 'static,
+        T4: Clone + 'static,
+        F: Fn(Cow<'_, T1>, Cow<'_, T2>, Cow<'_, T3>) -> T4 + 'static,
+    {
+        self.circuit().add_ternary_operator_with_preference(
+            Apply3::new(func, Location::caller()),
+            (self, self_preference),
+            other1,
+            other2,
+        )
+    }
+}
+
+/// Applies a user-provided ternary function to its inputs at each timestamp.
+pub struct Apply3<F> {
+    func: F,
+    location: &'static Location<'static>,
+}
+
+impl<F> Apply3<F> {
+    pub const fn new(func: F, location: &'static Location<'static>) -> Self
+    where
+        F: 'static,
+    {
+        Self { func, location }
+    }
+}
+
+impl<F> Operator for Apply3<F>
+where
+    F: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Apply3")
+    }
+
+    fn location(&self) -> OperatorLocation {
+        Some(self.location)
+    }
+
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        // TODO: either change `F` type to `Fn` from `FnMut` or
+        // parameterize the operator with custom fixed point check.
+        unimplemented!();
+    }
+}
+
+impl<T1, T2, T3, T4, F> TernaryOperator<T1, T2, T3, T4> for Apply3<F>
+where
+    F: Fn(Cow<'_, T1>, Cow<'_, T2>, Cow<'_, T3>) -> T4 + 'static,
+    T1: Clone + 'static,
+    T2: Clone + 'static,
+    T3: Clone + 'static,
+{
+    fn eval<'a>(&mut self, i1: Cow<'a, T1>, i2: Cow<'a, T2>, i3: Cow<'a, T3>) -> T4 {
+        (self.func)(i1, i2, i3)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{operator::Generator, Circuit, RootCircuit};
+    use std::vec;
+
+    #[test]
+    fn apply3_test() {
+        let circuit = RootCircuit::build(move |circuit| {
+            let mut inputs1 = vec![2, 4, 6].into_iter();
+            let mut inputs2 = vec![-1, -2, -3].into_iter();
+            let mut inputs3 = vec![-1, -2, -3].into_iter();
+
+            let source1 = circuit.add_source(Generator::new(move || inputs1.next().unwrap()));
+            let source2 = circuit.add_source(Generator::new(move || inputs2.next().unwrap()));
+            let source3 = circuit.add_source(Generator::new(move || inputs3.next().unwrap()));
+
+            source1
+                .apply3(&source2, &source3, |x, y, z| *x + *y + *z)
+                .inspect(|z| assert_eq!(*z, 0));
+            Ok(())
+        })
+        .unwrap()
+        .0;
+
+        for _ in 0..3 {
+            circuit.step().unwrap();
+        }
+    }
+}

--- a/crates/dbsp/src/operator/group/lag.rs
+++ b/crates/dbsp/src/operator/group/lag.rs
@@ -1,7 +1,10 @@
 use super::{GroupTransformer, Monotonicity};
 use crate::{
     algebra::{HasZero, ZRingValue},
-    trace::{cursor::{CursorPair, ReverseKeyCursor}, Cursor},
+    trace::{
+        cursor::{CursorPair, ReverseKeyCursor},
+        Cursor,
+    },
     DBData, DBWeight, IndexedZSet, OrdIndexedZSet, RootCircuit, Stream,
 };
 use std::{cmp::Ordering, marker::PhantomData};

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -1,6 +1,7 @@
-//! Some basic operators.
+//! DBSP stream operators.
 
 pub mod apply2;
+pub mod apply3;
 pub mod communication;
 pub mod recursive;
 
@@ -26,6 +27,7 @@ mod integrate;
 mod join;
 pub mod join_range;
 mod neg;
+mod neighborhood;
 mod output;
 mod plus;
 mod semijoin;

--- a/crates/dbsp/src/operator/neighborhood.rs
+++ b/crates/dbsp/src/operator/neighborhood.rs
@@ -1,0 +1,704 @@
+use crate::{
+    algebra::{HasZero, ZRingValue},
+    circuit::{
+        circuit_builder::OwnershipPreference,
+        operator_traits::{BinaryOperator, Operator},
+        Scope,
+    },
+    trace::{cursor::Cursor, Batch, BatchReader, Builder},
+    Circuit, DBData, DBWeight, IndexedZSet, OrdIndexedZSet, RootCircuit, Stream,
+};
+use std::{borrow::Cow, marker::PhantomData};
+
+/// A a contiguous range of rows preceding and following a fixed "anchor"
+/// point.
+///
+/// A neighborhood is a contiguous range of rows preceding and following
+/// a fixed "anchor" point.  The anchor may represent the first row in
+/// the on-screen grid.  Rows are numbered, with number 0 representing
+/// the anchor, negative numbers representing rows preceding the anchor,
+/// and positive numbers rows following the anchor.
+///
+/// Each row contains a key/value pair.  Rows are ordered by keys and,
+/// for each key, by values.
+///
+/// Similar to other DBSP collections, the [`Neighborhood`] type can represent
+/// a complete neighborhood or a delta that must be applied to the previous
+/// state of the neighborhood to obtain a new complete snapshot.  A complete
+/// neighborhood always contains a contiguous set of indexes, as in the
+/// following example:
+///
+/// ```text
+///             │  #  │ key │ val │ w
+///             ├─────┼─────┼─────┼───
+///             │ -3  │ "a" │ 100 │ 1
+///             │ -2  │ "a" │ 101 │ 1
+///             │ -1  │ "b" │   5 │ 5
+/// anchor ───► │  0  │ "b" │   7 │ 1
+///             │  1  │ "b" │  10 │ 1
+///             │  2  │ "c" │ 324 │ 1
+///             │  3  │ "d" │   0 │ 1
+///             │  4  │ "e" │  11 │ 2
+///             │  5  │ "e" │  12 │ 1
+/// ```
+///
+/// A delta on the other hand only contains affected indexes.  The following
+/// delta, for instance, inserts the key/value pair `("a", 102)` in position
+/// `-2` in the neighborhood, shifting `("a", 101)` to position `-3`
+/// and pushing `("a", 100)` out of the neighborhood:
+///
+/// ```text
+///             │  #  │ key │ val │ w
+///             ├─────┼─────┼─────┼───
+///             │ -3  │ "a" │ 100 │ -1 // ("a", 100) pushed out of the neighborhood
+///             │ -3  │ "a" │ 101 │ +1 // ("a", 101) pushed from position -2 to -3
+///             │ -2  │ "a" │ 101 │ -1
+///             │ -2  │ "a" │ 102 │ +1 // ("a", 102) in inserted in positon -2.
+/// ```
+pub type Neighborhood<K, V, R> = OrdIndexedZSet<isize, (K, V), R>;
+
+/// Neighborhood descriptor represents a request from the user to
+/// output a specific neighborhood.  The neighborhood is defined in
+/// terms of its central point (`anchor`) and the number of rows
+/// preceding and following the anchor to output.
+#[derive(Clone)]
+pub struct NeighborhoodDescr<K, V> {
+    anchor: (K, V),
+    before: usize,
+    after: usize,
+}
+
+/// Stream of neighborhoods output by the [`Stream::neighborhood`] operator.
+pub type NeighborhoodStream<K, V, R> = Stream<RootCircuit, Neighborhood<K, V, R>>;
+
+/// Stream of neighborhood descriptors supplied as input to the
+/// [`Stream::neighborhood`] operator.
+pub type NeighborhoodDescrStream<K, V> = Stream<RootCircuit, Option<NeighborhoodDescr<K, V>>>;
+
+impl<K, V> NeighborhoodDescr<K, V> {
+    pub fn new(k: K, v: V, before: usize, after: usize) -> Self {
+        Self {
+            anchor: (k, v),
+            before,
+            after,
+        }
+    }
+}
+
+impl<B> Stream<RootCircuit, B>
+where
+    B: IndexedZSet + Send,
+    B::R: ZRingValue,
+{
+    /// Returns a small contiguous range of rows ([`Neighborhood`]) of the input
+    /// table.
+    ///
+    /// This operator helps to visualize the contents of the input table in a
+    /// UI.  The UI client may not have enough throughput/memory to store the entire
+    /// table, and will instead limit its state to a small range of rows that fit
+    /// on the screen.  We specify such a range, or _neighborhood_, in terms of its
+    /// center (or "anchor"), and the number of rows preceding and following the
+    /// anchor (see [`NeighborhoodDescr`]).  The user may be interested in a static
+    /// snapshot of the neighborhood or in a changing view.  Both modes are
+    /// supported by this operator (see the `reset` argument).  The output of the
+    /// operator is a stream of [`Neighborhood`]s.
+    ///
+    /// NOTE: This operator assumes that the integral of the input stream does not
+    /// contain negative weights (which should normally be the case) and may
+    /// produce incorrect outputs otherwise.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - a stream of changes to an indexed Z-set.
+    ///
+    /// * `neighborhood_descr` - contains the neighborhood descriptor to
+    ///   evaluate at every clock tick.  Set to `None` to disable the
+    ///   operator (it will output an empty neighborhood).
+    ///
+    /// * `reset` - controls whether the operator outputs the the entire
+    ///   neighborhood or an incrmental change to the neighborhood.  Set to
+    ///   `true` to request the complete neighborhood to be output at the end
+    ///   of the current clock cycle or `false` to output the incremental
+    ///   change to the neighborhood relative to the previous clock cycle.
+    ///
+    /// # Output
+    ///
+    /// The output neighborhood will contain rows with indexes between
+    /// `-descr.before` and `descr.after - 1`.  Row 0 is the anchor row, i.e.,
+    /// is the first row in the input stream greater than or equal to
+    /// `descr.anchor`.  If there is no such row (i.e., all rows in the input
+    /// stream are smaller than the anchor), then the neighborhood will only
+    /// contain negative indexes.
+    ///
+    /// The first index in the neightborhood may be greater
+    /// than `-descr.before` if the input stream doesn't contain enough rows
+    /// preceding the specified anchor.  The last index may be smaller than
+    /// `descr.after - 1` if the input stream doesn't contain `descr.after`
+    /// rows following the anchor point.
+    pub fn neighborhood(
+        &self,
+        neighborhood_descr: &NeighborhoodDescrStream<B::Key, B::Val>,
+        reset: &Stream<RootCircuit, bool>,
+    ) -> NeighborhoodStream<B::Key, B::Val, B::R> {
+        self.circuit().region("neighborhood", || {
+            // Compute local neighborhood in each worker.  We don't shard
+            // the input stream, which means that multiple workers can
+            // contain the same key in their neighborhood.  This shouldn't
+            // affect correctness assuming that the integral of the input
+            // stream does not contain negative weights (which should normally
+            // be the case) and so identical key/value pairs in different
+            // workers won't cancel out.
+            let stream = self.try_sharded_version();
+            let local_output = self
+                .circuit()
+                .add_binary_operator(
+                    NeighborhoodLocal::new(),
+                    &stream.integrate_trace(),
+                    neighborhood_descr,
+                )
+                .differentiate();
+
+            // Gather all results in worker 0.  Worker 0 then computes
+            // the final neighborhood.
+            // TODO: use different workers for different collections.
+            let output = self.circuit().add_binary_operator(
+                NeighborhoodNumbered::new(),
+                &local_output.gather(0).integrate_trace(),
+                neighborhood_descr,
+            );
+
+            output.apply3_with_preference(
+                OwnershipPreference::STRONGLY_PREFER_OWNED,
+                (&output.differentiate(), OwnershipPreference::INDIFFERENT),
+                (reset, OwnershipPreference::INDIFFERENT),
+                |range, delta, reset: Cow<'_, bool>| {
+                    if *reset {
+                        range.into_owned()
+                    } else {
+                        (*delta).clone()
+                    }
+                },
+            )
+        })
+    }
+}
+
+/// Computes the neighborhood without row numbers.
+///
+/// Used for per-worker neighborhood computation in each worker, where
+/// row numbers are not needed (since row numbers are assigned by
+/// worker 0).
+///
+/// The operator takes a trace of the input table and produces
+/// a complete neighborhood as its output.  The internal implementation
+/// is non-incremental and will do the work proportional to the size
+/// of the neighborhood even if the neighborhood has not
+/// changed since the last clock cycle.  This is ok assuming small
+/// neighborhoods.  We may want to switch to an incremental
+/// implementation in the future.
+struct NeighborhoodLocal<T>
+where
+    T: BatchReader,
+{
+    _phantom: PhantomData<T>,
+}
+
+impl<T> NeighborhoodLocal<T>
+where
+    T: BatchReader,
+{
+    fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Operator for NeighborhoodLocal<T>
+where
+    T: BatchReader + 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("NeighborhoodLocal")
+    }
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+impl<T>
+    BinaryOperator<
+        T,
+        Option<NeighborhoodDescr<T::Key, T::Val>>,
+        OrdIndexedZSet<T::Key, T::Val, T::R>,
+    > for NeighborhoodLocal<T>
+where
+    T: BatchReader<Time = ()>,
+    T::Key: DBData,
+    T::Val: DBData,
+    T::R: DBWeight,
+{
+    fn eval<'a>(
+        &mut self,
+        input_trace: &T,
+        descr: &Option<NeighborhoodDescr<T::Key, T::Val>>,
+    ) -> OrdIndexedZSet<T::Key, T::Val, T::R> {
+        let mut cursor = input_trace.cursor();
+
+        if let Some(descr) = descr {
+            let (anchor_key, anchor_val) = &descr.anchor;
+
+            // Forward pass: locate the anchor and `decr.after`
+            // following rows.
+            let mut after = Vec::with_capacity(descr.after);
+            let mut offset = 0;
+
+            cursor.seek_keyval(anchor_key, anchor_val);
+            while cursor.keyval_valid() && offset < descr.after {
+                let w = cursor.weight();
+
+                if !cursor.weight().is_zero() {
+                    after.push(((cursor.key().clone(), cursor.val().clone()), w));
+                    offset += 1;
+                }
+                cursor.step_keyval();
+            }
+
+            // Reverse pass: find `descr.before` rows preceding the anchor.
+            cursor.fast_forward_keys();
+            cursor.fast_forward_vals();
+
+            let mut before = Vec::with_capacity(descr.before);
+            offset = 1;
+
+            cursor.seek_keyval_reverse(anchor_key, anchor_val);
+            if cursor.keyval_valid() && cursor.keyval() == (anchor_key, anchor_val) {
+                cursor.step_keyval_reverse();
+            }
+
+            while cursor.keyval_valid() && offset <= descr.before {
+                let w = cursor.weight();
+
+                if !cursor.weight().is_zero() {
+                    before.push(((cursor.key().clone(), cursor.val().clone()), w));
+                    offset += 1;
+                }
+                cursor.step_keyval_reverse();
+            }
+
+            // Assemble final result.
+            let mut builder = <<OrdIndexedZSet<_, _, _> as Batch>::Builder>::with_capacity(
+                (),
+                before.len() + after.len(),
+            );
+            for update in before.into_iter().rev() {
+                builder.push(update);
+            }
+            for update in after.into_iter() {
+                builder.push(update);
+            }
+
+            builder.done()
+        } else {
+            Batch::empty(())
+        }
+    }
+}
+
+/// Computes the neighborhood including row numbers.
+///
+/// Used to compute the final output of the [`Stream::neighborhood`]
+/// operator in worker-0.
+struct NeighborhoodNumbered<T>
+where
+    T: BatchReader,
+{
+    _phantom: PhantomData<T>,
+}
+
+impl<T> NeighborhoodNumbered<T>
+where
+    T: BatchReader,
+{
+    fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> Operator for NeighborhoodNumbered<T>
+where
+    T: BatchReader + 'static,
+    T::Key: DBData,
+    T::Val: DBData,
+    T::R: DBWeight,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("NeighborhoodNumbered")
+    }
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+impl<T>
+    BinaryOperator<T, Option<NeighborhoodDescr<T::Key, T::Val>>, Neighborhood<T::Key, T::Val, T::R>>
+    for NeighborhoodNumbered<T>
+where
+    T: BatchReader<Time = ()> + Clone,
+{
+    fn eval<'a>(
+        &mut self,
+        input_trace: &T,
+        descr: &Option<NeighborhoodDescr<T::Key, T::Val>>,
+    ) -> Neighborhood<T::Key, T::Val, T::R> {
+        let mut cursor = input_trace.cursor();
+
+        if let Some(descr) = &descr {
+            let (anchor_key, anchor_val) = &descr.anchor;
+
+            let mut after = Vec::with_capacity(descr.after);
+            let mut offset = 0;
+
+            cursor.seek_keyval(anchor_key, anchor_val);
+            while cursor.keyval_valid() && offset < descr.after {
+                let w = cursor.weight();
+
+                if !cursor.weight().is_zero() {
+                    after.push((
+                        (
+                            offset as isize,
+                            (cursor.key().clone(), cursor.val().clone()),
+                        ),
+                        w,
+                    ));
+                    offset += 1;
+                }
+                cursor.step_keyval();
+            }
+
+            cursor.fast_forward_keys();
+            cursor.fast_forward_vals();
+
+            let mut before = Vec::with_capacity(descr.before);
+            offset = 1;
+
+            cursor.seek_keyval_reverse(anchor_key, anchor_val);
+            if cursor.keyval_valid() && cursor.keyval() == (anchor_key, anchor_val) {
+                cursor.step_keyval_reverse();
+            }
+
+            while cursor.keyval_valid() && offset <= descr.before {
+                let w = cursor.weight();
+
+                if !cursor.weight().is_zero() {
+                    before.push((
+                        (
+                            -(offset as isize),
+                            (cursor.key().clone(), cursor.val().clone()),
+                        ),
+                        w,
+                    ));
+                    offset += 1;
+                }
+                cursor.step_keyval_reverse();
+            }
+
+            let mut builder = <<Neighborhood<_, _, _> as Batch>::Builder>::with_capacity(
+                (),
+                before.len() + after.len(),
+            );
+            for update in before.into_iter().rev() {
+                builder.push(update);
+            }
+            for update in after.into_iter() {
+                builder.push(update);
+            }
+
+            builder.done()
+        } else {
+            Batch::empty(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        algebra::ZRingValue,
+        operator::neighborhood::NeighborhoodDescr,
+        trace::{
+            test_batch::{assert_batch_eq, batch_to_tuples, TestBatch},
+            Batch, Trace,
+        },
+        CollectionHandle, DBData, DBWeight, InputHandle, OrdIndexedZSet, OutputHandle, RootCircuit,
+        Runtime,
+    };
+    use anyhow::Result as AnyResult;
+    use std::cmp::{max, min};
+
+    impl<K, V, R> TestBatch<K, V, (), R>
+    where
+        K: DBData,
+        V: DBData,
+        R: DBWeight + ZRingValue,
+    {
+        fn neighborhood(
+            &self,
+            descr: &Option<NeighborhoodDescr<K, V>>,
+        ) -> TestBatch<isize, (K, V), (), R> {
+            if let Some(descr) = &descr {
+                let (anchor_k, anchor_v) = &descr.anchor;
+                let tuples = batch_to_tuples(self);
+                let start = tuples
+                    .iter()
+                    .position(|((k, v, ()), _w)| (k, v) >= (anchor_k, anchor_v))
+                    .unwrap_or_else(|| tuples.len()) as isize;
+
+                let mut from = start - descr.before as isize;
+                let mut to = start + descr.after as isize;
+
+                from = max(from, 0);
+                to = min(to, tuples.len() as isize);
+
+                let output = tuples[from as usize..to as usize]
+                    .iter()
+                    .enumerate()
+                    .map(|(i, ((k, v, ()), w))| {
+                        (
+                            (i as isize - (start - from), (k.clone(), v.clone()), ()),
+                            w.clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                TestBatch::from_data(&output)
+            } else {
+                TestBatch::new(None)
+            }
+        }
+    }
+
+    fn test_circuit(
+        circuit: &mut RootCircuit,
+    ) -> AnyResult<(
+        InputHandle<bool>,
+        InputHandle<Option<NeighborhoodDescr<i32, i32>>>,
+        CollectionHandle<i32, (i32, i32)>,
+        OutputHandle<OrdIndexedZSet<isize, (i32, i32), i32>>,
+    )> {
+        let (reset_stream, reset_handle) = circuit.add_input_stream::<bool>();
+        let (descr_stream, descr_handle) =
+            circuit.add_input_stream::<Option<NeighborhoodDescr<i32, i32>>>();
+        let (input_stream, input_handle) = circuit.add_input_indexed_zset::<i32, i32, i32>();
+
+        let range_handle = input_stream
+            .neighborhood(&descr_stream, &reset_stream)
+            .output();
+
+        Ok((reset_handle, descr_handle, input_handle, range_handle))
+    }
+
+    #[test]
+    fn bounded_range_test() {
+        let (mut dbsp, (reset_handle, descr_handle, input_handle, output_handle)) =
+            Runtime::init_circuit(4, test_circuit).unwrap();
+
+        // Empty collection.
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+
+        dbsp.step().unwrap();
+
+        assert!(batch_to_tuples(&output_handle.consolidate()).is_empty());
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(9, (0, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[((-1, (9, 0), ()), 1)]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(9, (1, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[((-2, (9, 0), ()), 1), ((-1, (9, 1), ()), 1)]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(8, (1, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1)
+            ]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(7, (1, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1)
+            ]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(10, (10, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1),
+                ((0, (10, 10), ()), 1)
+            ]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(10, (11, 1));
+        input_handle.push(12, (0, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1),
+                ((0, (10, 10), ()), 1),
+                ((1, (10, 11), ()), 1),
+                ((2, (12, 0), ()), 1)
+            ]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(10, (10, -1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1),
+                ((0, (10, 11), ()), 1),
+                ((1, (12, 0), ()), 1)
+            ]
+        );
+
+        reset_handle.set_for_all(true);
+        descr_handle.set_for_all(Some(NeighborhoodDescr::new(10, 10, 3, 5)));
+        input_handle.push(13, (0, 1));
+        input_handle.push(14, (0, 1));
+        input_handle.push(14, (1, 1));
+        input_handle.push(14, (2, 1));
+        input_handle.push(14, (3, 1));
+
+        dbsp.step().unwrap();
+
+        assert_eq!(
+            &batch_to_tuples(&output_handle.consolidate()),
+            &[
+                ((-3, (8, 1), ()), 1),
+                ((-2, (9, 0), ()), 1),
+                ((-1, (9, 1), ()), 1),
+                ((0, (10, 11), ()), 1),
+                ((1, (12, 0), ()), 1),
+                ((2, (13, 0), ()), 1),
+                ((3, (14, 0), ()), 1),
+                ((4, (14, 1), ()), 1)
+            ]
+        );
+    }
+
+    use proptest::{collection::vec, prelude::*};
+
+    fn input_trace(
+        max_key: i32,
+        max_val: i32,
+        max_batch_size: usize,
+        max_batches: usize,
+    ) -> impl Strategy<Value = Vec<(Vec<(i32, i32, i32)>, (i32, i32), usize, usize, bool)>> {
+        vec(
+            (
+                vec((0..max_key, 0..max_val, 1..2), 0..max_batch_size),
+                (0..max_key, 0..max_val),
+                (0..(max_key * max_val) as usize),
+                (0..(max_key * max_val) as usize),
+                prop::bool::ANY,
+            ),
+            0..max_batches,
+        )
+    }
+
+    proptest! {
+        #[test]
+        fn bounded_range_proptest(trace in input_trace(100, 5, 200, 20)) {
+
+            let (mut dbsp, (reset_handle, descr_handle, input_handle, output_handle)) =
+                Runtime::init_circuit(4, test_circuit).unwrap();
+
+            let mut ref_trace = TestBatch::new(None);
+            let mut prev_output = OrdIndexedZSet::empty(());
+
+            for (batch, (start_key, start_val), before, after, reset) in trace.into_iter() {
+
+                let records = batch.iter().map(|(k, v, r)| ((*k, *v, ()), *r)).collect::<Vec<_>>();
+
+                let ref_batch = TestBatch::from_data(&records);
+                ref_trace.insert(ref_batch);
+
+                for (k, v, r) in batch.into_iter() {
+                    input_handle.push(k, (v, r));
+                }
+                let descr = NeighborhoodDescr::new(start_key, start_val, before, after);
+                reset_handle.set_for_all(reset);
+                descr_handle.set_for_all(Some(descr.clone()));
+
+                dbsp.step().unwrap();
+
+                let output = output_handle.consolidate();
+                let ref_output = ref_trace.neighborhood(&Some(descr));
+
+                if reset {
+                    assert_batch_eq(&output, &ref_output);
+                    prev_output = output;
+                } else {
+                    prev_output = prev_output.merge(&output);
+                    assert_batch_eq(&prev_output, &ref_output);
+                }
+            }
+        }
+    }
+}

--- a/crates/dbsp/src/trace/cursor/mod.rs
+++ b/crates/dbsp/src/trace/cursor/mod.rs
@@ -15,6 +15,7 @@ pub mod cursor_empty;
 pub mod cursor_group;
 pub mod cursor_list;
 pub mod cursor_pair;
+mod reverse;
 
 #[derive(Debug, PartialEq, Eq)]
 enum Direction {
@@ -26,6 +27,7 @@ pub use cursor_empty::CursorEmpty;
 pub use cursor_group::CursorGroup;
 pub use cursor_list::CursorList;
 pub use cursor_pair::CursorPair;
+pub use reverse::ReverseKeyCursor;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` tuples.
 pub trait Cursor<K, V, T, R> {

--- a/crates/dbsp/src/trace/cursor/reverse.rs
+++ b/crates/dbsp/src/trace/cursor/reverse.rs
@@ -1,0 +1,168 @@
+use crate::trace::Cursor;
+use std::marker::PhantomData;
+
+/// Cursor that reverses the direction of keys in the underlying
+/// cursor.
+///
+/// WARNING: This cursor iterates over keys in descending order,
+/// and thus will not work correctly with code that assumes
+/// monotonically growing keys.
+pub struct ReverseKeyCursor<'a, C, K, V, R> {
+    cursor: &'a mut C,
+    _phantom: PhantomData<(K, V, R)>,
+}
+
+impl<'a, C, K, V, R> ReverseKeyCursor<'a, C, K, V, R>
+where
+    C: Cursor<K, V, (), R>,
+{
+    pub fn new(cursor: &'a mut C) -> Self {
+        cursor.fast_forward_keys();
+
+        Self {
+            cursor,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, C, K, V, R> Cursor<K, V, (), R> for ReverseKeyCursor<'a, C, K, V, R>
+where
+    C: Cursor<K, V, (), R>,
+{
+    fn key_valid(&self) -> bool {
+        self.cursor.key_valid()
+    }
+
+    fn val_valid(&self) -> bool {
+        self.cursor.val_valid()
+    }
+
+    fn key(&self) -> &K {
+        self.cursor.key()
+    }
+
+    fn val(&self) -> &V {
+        self.cursor.val()
+    }
+
+    fn get_key(&self) -> Option<&K> {
+        self.cursor.get_key()
+    }
+
+    fn get_val(&self) -> Option<&V> {
+        self.cursor.get_val()
+    }
+
+    fn map_times<L>(&mut self, logic: L)
+    where
+        L: FnMut(&(), &R),
+    {
+        self.cursor.map_times(logic)
+    }
+
+    fn fold_times<F, U>(&mut self, init: U, fold: F) -> U
+    where
+        F: FnMut(U, &(), &R) -> U,
+    {
+        self.cursor.fold_times(init, fold)
+    }
+
+    fn map_times_through<L>(&mut self, upper: &(), logic: L)
+    where
+        L: FnMut(&(), &R),
+    {
+        self.cursor.map_times_through(upper, logic);
+    }
+
+    fn fold_times_through<F, U>(&mut self, upper: &(), init: U, fold: F) -> U
+    where
+        F: FnMut(U, &(), &R) -> U,
+    {
+        self.cursor.fold_times_through(upper, init, fold)
+    }
+
+    fn weight(&mut self) -> R {
+        self.cursor.weight()
+    }
+
+    fn map_values<L: FnMut(&V, &R)>(&mut self, logic: L) {
+        self.cursor.map_values(logic)
+    }
+
+    fn step_key(&mut self) {
+        self.cursor.step_key_reverse()
+    }
+
+    fn step_key_reverse(&mut self) {
+        self.cursor.step_key()
+    }
+
+    fn seek_key(&mut self, key: &K) {
+        self.cursor.seek_key_reverse(key)
+    }
+
+    fn seek_key_with<P>(&mut self, predicate: P)
+    where
+        P: Fn(&K) -> bool + Clone,
+    {
+        self.cursor.seek_key_with_reverse(predicate)
+    }
+
+    fn seek_key_with_reverse<P>(&mut self, predicate: P)
+    where
+        P: Fn(&K) -> bool + Clone,
+    {
+        self.cursor.seek_key_with(predicate)
+    }
+
+    fn seek_key_reverse(&mut self, key: &K) {
+        self.cursor.seek_key(key)
+    }
+
+    fn step_val(&mut self) {
+        self.cursor.step_val()
+    }
+
+    fn step_val_reverse(&mut self) {
+        self.cursor.step_val_reverse()
+    }
+
+    fn seek_val(&mut self, val: &V) {
+        self.cursor.seek_val(val)
+    }
+
+    fn seek_val_reverse(&mut self, val: &V) {
+        self.cursor.seek_val_reverse(val)
+    }
+
+    fn seek_val_with<P>(&mut self, predicate: P)
+    where
+        P: Fn(&V) -> bool + Clone,
+    {
+        self.cursor.seek_val_with(predicate)
+    }
+
+    fn seek_val_with_reverse<P>(&mut self, predicate: P)
+    where
+        P: Fn(&V) -> bool + Clone,
+    {
+        self.cursor.seek_val_with_reverse(predicate)
+    }
+
+    fn rewind_keys(&mut self) {
+        self.cursor.fast_forward_keys()
+    }
+
+    fn fast_forward_keys(&mut self) {
+        self.cursor.rewind_keys()
+    }
+
+    fn rewind_vals(&mut self) {
+        self.cursor.rewind_vals()
+    }
+
+    fn fast_forward_vals(&mut self) {
+        self.cursor.fast_forward_vals()
+    }
+}

--- a/demo/project_demo04-SecOps/run.py
+++ b/demo/project_demo04-SecOps/run.py
@@ -76,7 +76,6 @@ def make_config(project):
 
 
 if __name__ == "__main__":
-    prepare()
     run_demo(
         "SecOps demo", os.path.join(SCRIPT_DIR, "project.sql"), make_config, prepare
     )


### PR DESCRIPTION
The neighborhood operator helps to visualize the contents of a table.
The UI client may not have enough throughput/memory to store the entire
table, and will instead limit the state it tracks to a small range of rows
that fit on the screen.  We specify such a range, or _neighborhood_, in terms
of its center (or "anchor"), and the number of rows preceding and following
the anchor.  The user may be interested in a static snapshot of the
neighborhood or in a changing view.  Both modes are supported by this
operator.

A complete snapshot of a neighborhood contains a contiguous set of indexes, as
in the following example:

```
            │  #  │ key │ val │ w
            ├─────┼─────┼─────┼───
            │ -3  │ "a" │ 100 │ 1
            │ -2  │ "a" │ 101 │ 1
            │ -1  │ "b" │   5 │ 5
anchor ───► │  0  │ "b" │   7 │ 1
            │  1  │ "b" │  10 │ 1
            │  2  │ "c" │ 324 │ 1
            │  3  │ "d" │   0 │ 1
            │  4  │ "e" │  11 │ 2
            │  5  │ "e" │  12 │ 1
```

A delta on the other hand only contains affected indexes.  The following
delta, for instance, inserts the key/value pair `("a", 102)` in position
`-2` in the neighborhood, shifting `("a", 101)` to position `-3`
and pushing `("a", 100)` out of the neighborhood:

```
            │  #  │ key │ val │ w
            ├─────┼─────┼─────┼───
            │ -3  │ "a" │ 100 │ -1 // ("a", 100) pushed out of the neighborhood
            │ -3  │ "a" │ 101 │ +1 // ("a", 101) pushed from position -2 to -3
            │ -2  │ "a" │ 101 │ -1
            │ -2  │ "a" │ 102 │ +1 // ("a", 102) in inserted in positon -2.
```