### PR TITLE
genlib: Do not format with `cargo fmt`.

### DIFF
--- a/sql-to-dbsp-compiler/lib/genlib/rustfmt.toml
+++ b/sql-to-dbsp-compiler/lib/genlib/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
This crate is autogenerated and there's no point.