### PR TITLE
Clippy and doc fixes

### DIFF
--- a/crates/dbsp/src/operator/group/test.rs
+++ b/crates/dbsp/src/operator/group/test.rs
@@ -170,7 +170,7 @@ fn lead_test_circuit(
 proptest! {
     #[test]
     fn test_topk(trace in input_trace(5, 1_000, 200, 20)) {
-        let (mut dbsp, (input_handle, topk_asc_handle, topk_desc_handle)) = Runtime::init_circuit(4, |circuit| topk_test_circuit(circuit)).unwrap();
+        let (mut dbsp, (input_handle, topk_asc_handle, topk_desc_handle)) = Runtime::init_circuit(4, topk_test_circuit).unwrap();
 
         let mut ref_trace = TestBatch::new(None);
 
@@ -198,7 +198,7 @@ proptest! {
 
     #[test]
     fn test_lag(trace in input_trace(5, 100, 200, 20)) {
-        let (mut dbsp, (input_handle, lag_handle)) = Runtime::init_circuit(4, |circuit| lag_test_circuit(circuit)).unwrap();
+        let (mut dbsp, (input_handle, lag_handle)) = Runtime::init_circuit(4, lag_test_circuit).unwrap();
 
         let mut ref_trace = TestBatch::new(None);
 
@@ -222,7 +222,7 @@ proptest! {
 
     #[test]
     fn test_lead(trace in input_trace(5, 100, 200, 20)) {
-        let (mut dbsp, (input_handle, lead_handle)) = Runtime::init_circuit(4, |circuit| lead_test_circuit(circuit)).unwrap();
+        let (mut dbsp, (input_handle, lead_handle)) = Runtime::init_circuit(4, lead_test_circuit).unwrap();
 
         let mut ref_trace = TestBatch::new(None);
 

--- a/crates/dbsp/src/operator/mod.rs
+++ b/crates/dbsp/src/operator/mod.rs
@@ -27,7 +27,7 @@ mod integrate;
 mod join;
 pub mod join_range;
 mod neg;
-mod neighborhood;
+pub mod neighborhood;
 mod output;
 mod plus;
 pub mod sample;

--- a/crates/dbsp/src/operator/neighborhood.rs
+++ b/crates/dbsp/src/operator/neighborhood.rs
@@ -455,7 +455,7 @@ mod test {
                 let start = tuples
                     .iter()
                     .position(|((k, v, ()), _w)| (k, v) >= (anchor_k, anchor_v))
-                    .unwrap_or_else(|| tuples.len()) as isize;
+                    .unwrap_or(tuples.len()) as isize;
 
                 let mut from = start - descr.before as isize;
                 let mut to = start + descr.after as isize;

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -697,7 +697,7 @@ mod test {
                     &watermark,
                     |(partition, val)| (*partition, *val),
                     aggregator.clone(),
-                    range_spec.clone(),
+                    range_spec,
                 )
                 .gather(0)
                 .integrate();
@@ -732,7 +732,7 @@ mod test {
                     &watermark,
                     |(partition, val)| (*partition, *val),
                     aggregator.clone(),
-                    range_spec.clone(),
+                    range_spec,
                 );
             let output_500_500_watermark = aggregate_500_500_watermark.gather(0).integrate();
 
@@ -740,12 +740,11 @@ mod test {
             bound.set((u64::max_value(), None));
 
             aggregate_500_500_watermark
-                .integrate_trace_with_bound(TraceBound::new(), bound.clone())
+                .integrate_trace_with_bound(TraceBound::new(), bound)
                 .apply(move |trace| {
                     if let Some(bound) = size_bound {
                         assert!(trace.size_of().total_bytes() <= bound);
                     }
-                    ()
                 });
 
             expected_500_500.apply2(&output_500_500_watermark, |expected, actual| {

--- a/crates/dbsp/src/operator/time_series/window.rs
+++ b/crates/dbsp/src/operator/time_series/window.rs
@@ -470,7 +470,6 @@ mod test {
                 .integrate_trace_with_bound(bound, TraceBound::new())
                 .apply(|trace| {
                     assert!(trace.size_of().total_bytes() < 20000);
-                    ()
                 });
 
             Ok(input_handle)

--- a/crates/dbsp/src/trace/test_batch.rs
+++ b/crates/dbsp/src/trace/test_batch.rs
@@ -274,7 +274,7 @@ where
         for ((k, v, t), r) in records.iter() {
             data.entry((k.clone(), v.clone(), t.clone()))
                 .or_insert_with(HasZero::zero)
-                .add_assign_by_ref(&r);
+                .add_assign_by_ref(r);
         }
 
         data.retain(|_, r| !r.is_zero());

--- a/crates/pipeline_manager/src/auth.rs
+++ b/crates/pipeline_manager/src/auth.rs
@@ -602,8 +602,8 @@ mod test {
             }),
         );
         let app = test::init_service(app).await;
-        let resp = test::call_service(&app, req).await;
-        resp
+
+        test::call_service(&app, req).await
     }
 
     #[tokio::test]
@@ -721,7 +721,7 @@ mod test {
         let (token, decoding_key) = setup(claim).await;
 
         // Modify the claim
-        let base64_parts: Vec<&str> = token.split(".").collect();
+        let base64_parts: Vec<&str> = token.split('.').collect();
         let claim_base64 = base64::engine::general_purpose::STANDARD_NO_PAD
             .decode(base64_parts.get(1).unwrap())
             .unwrap();

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -11,6 +11,7 @@ use pretty_assertions::assert_eq;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
 use proptest_derive::Arbitrary;
+use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -1411,7 +1412,7 @@ impl Storage for Mutex<DbModel> {
         let mut hasher = sha::Sha256::new();
         hasher.update(key.as_bytes());
         let hash = openssl::base64::encode_block(&hasher.finish());
-        if let std::collections::btree_map::Entry::Vacant(e) = s.api_keys.entry(hash) {
+        if let btree_map::Entry::Vacant(e) = s.api_keys.entry(hash) {
             e.insert(permissions);
             Ok(())
         } else {

--- a/crates/webui-tester/src/ui.rs
+++ b/crates/webui-tester/src/ui.rs
@@ -23,7 +23,7 @@ impl VerticalMenuLink {
     /// Name of the menu item.
     pub async fn name(&self) -> WebDriverResult<String> {
         let elem = self.link.resolve().await?;
-        Ok(elem.text().await?)
+        elem.text().await
     }
 
     /// Click the menu item (navigates to the page).
@@ -71,7 +71,7 @@ async fn set_text_generic(elem: &ElementResolver<WebElement>, text: &str) -> Web
 /// Retrieves the text of an element.
 async fn get_text_generic(elem: &ElementResolver<WebElement>) -> WebDriverResult<String> {
     let elem = elem.resolve().await?;
-    Ok(elem.text().await?)
+    elem.text().await
 }
 
 /// Generic function that waits until the text of `elem` is `wait_for_this`.
@@ -302,19 +302,19 @@ pub async fn drag_and_drop_impl(
     // or still the drag-and-drop bug in selenium
     driver
         .action_chain()
-        .move_to_element_center(&from)
+        .move_to_element_center(from)
         .perform()
         .await?;
     tokio::time::sleep(Duration::from_millis(800)).await;
     driver
         .action_chain()
-        .click_and_hold_element(&from)
+        .click_and_hold_element(from)
         .perform()
         .await?;
     tokio::time::sleep(Duration::from_millis(800)).await;
     driver
         .action_chain()
-        .move_to_element_center(&to)
+        .move_to_element_center(to)
         .perform()
         .await?;
     tokio::time::sleep(Duration::from_millis(800)).await;
@@ -535,7 +535,7 @@ impl PipelineBuilder {
         let buttons_len = drawer.select_buttons.resolve_present().await?.len();
         for idx in 0..buttons_len {
             let button = &drawer.select_buttons.resolve_present().await?[idx];
-            let _r = button.click().await?;
+            button.click().await?;
             // This keeps the ID of the drawer but we changed the content, don't
             // reference stuff in drawer at the moment as most of it is gone and
             // will throw an runtime error in selenium
@@ -598,9 +598,9 @@ impl PipelineBuilder {
                     return Ok(());
                 }
             }
-            return Err(anyhow!("`view` not found in program views"));
+            Err(anyhow!("`view` not found in program views"))
         } else {
-            return Err(anyhow!("`connector_name` not found in outputs"));
+            Err(anyhow!("`connector_name` not found in outputs"))
         }
     }
 
@@ -637,9 +637,9 @@ impl PipelineBuilder {
                     return Ok(());
                 }
             }
-            return Err(anyhow!("`table` not found in program tables"));
+            Err(anyhow!("`table` not found in program tables"))
         } else {
-            return Err(anyhow!("`connector_name` not found in inputs"));
+            Err(anyhow!("`connector_name` not found in inputs"))
         }
     }
 }


### PR DESCRIPTION
This fixes Clippy warnings and doc warnings from `tools/pre-push`. The doc fix was manual, the Clippy ones automatic via `clippy --fix`.