### PR TITLE
CI speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,3 @@ jobs:
 
       - name: Run CI
         run: earthly -P +all-tests
-
-      - name: Check images
-        run: docker image ls

--- a/Earthfile
+++ b/Earthfile
@@ -388,7 +388,7 @@ test-docker-compose:
     COPY deploy/docker-compose.yml .
     WITH DOCKER --load ghcr.io/feldera/dbsp-manager=+build-dbsp-manager-container \
                 --load ghcr.io/feldera/demo-container=+build-demo-container
-        RUN docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo
+        RUN SECOPS_DEMO_ARGS="--prepare-args 500000" docker-compose -f docker-compose.yml --profile demo up --force-recreate --exit-code-from demo
     END
 
 all-tests:

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -39,6 +39,7 @@ def run_demo(name, code_file, make_pipeline_fn, prepare_fn=None, verify_fn=None)
         description='What do you want to do with the demo.')
     parser.add_argument('--dbsp_url', required=True)
     parser.add_argument('--actions', nargs='*', default=['create'])
+    parser.add_argument('--prepare-args', nargs='*', default=None)
     args = parser.parse_args()
 
     # Add hard-coded dependencies
@@ -53,5 +54,6 @@ def run_demo(name, code_file, make_pipeline_fn, prepare_fn=None, verify_fn=None)
         actions.add('compile')
         actions.add('create')
         actions.add('run')
+    prepare = prepare_fn if args.prepare_args == None else lambda: prepare_fn(args.prepare_args)
     execute(dbsp_url, actions, name, code_file,
-            make_pipeline_fn, prepare_fn, verify_fn)
+            make_pipeline_fn, prepare, verify_fn)

--- a/demo/project_demo04-SecOps/run.py
+++ b/demo/project_demo04-SecOps/run.py
@@ -14,8 +14,10 @@ from demo import *
 SCRIPT_DIR = os.path.join(os.path.dirname(__file__))
 
 
-def prepare():
-    cmd = ["cargo", "run", "--release"]
+def prepare(args=[2000000]):
+    assert len(args) == 1, "Expected one '--prepare-args' argument for num_pipelines"
+    num_pipelines = args[0]
+    cmd = ["cargo", "run", "--release", "--", "%s" % num_pipelines]
     # Override --release if RUST_BUILD_PROFILE is set
     if "RUST_BUILD_PROFILE" in os.environ:
         cmd[-1] = os.environ["RUST_BUILD_PROFILE"]

--- a/demo/project_demo04-SecOps/run.py
+++ b/demo/project_demo04-SecOps/run.py
@@ -20,7 +20,7 @@ def prepare(args=[2000000]):
     cmd = ["cargo", "run", "--release", "--", "%s" % num_pipelines]
     # Override --release if RUST_BUILD_PROFILE is set
     if "RUST_BUILD_PROFILE" in os.environ:
-        cmd[-1] = os.environ["RUST_BUILD_PROFILE"]
+        cmd[2] = os.environ["RUST_BUILD_PROFILE"]
     subprocess.run(cmd, cwd=os.path.join(SCRIPT_DIR, "simulator"))
 
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -37,17 +37,31 @@ RUN /root/.cargo/bin/cargo build --release --bin=dbsp_pipeline_manager --no-defa
 # Java build can be performed in parallel
 FROM base as javabuild
 RUN mkdir sql
-COPY .git /sql/.git
 COPY sql-to-dbsp-compiler /sql/sql-to-dbsp-compiler
 RUN cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -DskipTests package
 
 # Minimal image for running the pipeline manager
 FROM base as release
 ENV PATH="$PATH:/root/.cargo/bin"
+# Pipeline manager binary
 COPY --from=builder /app/target/release/dbsp_pipeline_manager dbsp_pipeline_manager
-COPY --from=javabuild /sql/sql-to-dbsp-compiler sql-to-dbsp-compiler
-COPY . /database-stream-processor
-CMD ./dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-dir --sql-compiler-home=/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor
+# SQL compiler needs the rust libraries, the compiler fat jar and the script
+#  to invoke the compiler jar
+RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
+COPY --from=javabuild /sql/sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
+# The crates needed for the SQL compiler
+COPY crates/dbsp database-stream-processor/crates/dbsp
+COPY crates/adapters database-stream-processor/crates/adapters
+COPY crates/dataflow-jit database-stream-processor/crates/dataflow-jit
+COPY README.md database-stream-processor/README.md
+# TODO: This is a bug. The compiler should not be referencing two different libs
+RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+COPY sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
+CMD ./dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor
 
 # The dev target adds an rpk client and demo projects
 FROM builder as client

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,13 +1,18 @@
-# The base image  contains tools to build the code given that
+# The base image contains tools to build the code given that
 # we need a Java and Rust compiler to run alongside the pipeline manager
 # as of now. This will change later.
 FROM ubuntu:22.04 AS base
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update && apt install libssl-dev build-essential pkg-config \
-     git gcc clang libclang-dev python3-pip python3-plumbum hub numactl cmake \
-     curl openjdk-19-jre-headless maven netcat jq \
-     adduser libfontconfig1 unzip -y
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN apt update && apt install \
+     # pkg-config is required for cargo to find libssl
+     libssl-dev pkg-config \
+     # rdkafka dependency needs cmake and a CXX compiler
+     cmake build-essential \
+     # To install rust
+     curl  \
+     # For running the SQL compiler
+     openjdk-19-jre-headless -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 # web-ui build tools
 RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
 RUN apt-get install --yes nodejs
@@ -36,6 +41,7 @@ RUN /root/.cargo/bin/cargo build --release --bin=dbsp_pipeline_manager --no-defa
 
 # Java build can be performed in parallel
 FROM base as javabuild
+RUN apt install maven -y
 RUN mkdir sql
 COPY sql-to-dbsp-compiler /sql/sql-to-dbsp-compiler
 RUN cd /sql/sql-to-dbsp-compiler/SQL-compiler && mvn -DskipTests package
@@ -65,10 +71,12 @@ CMD ./dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-
 # The dev target adds an rpk client and demo projects
 FROM ubuntu:22.04 AS client
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt update && apt install libssl-dev build-essential pkg-config \
-     git gcc clang libclang-dev python3-pip python3-plumbum hub numactl cmake \
+RUN apt update && apt install build-essential pkg-config \
+     # cmake is needed by rdkafka
+     cmake \ 
+     python3-pip python3-plumbum \
      curl unzip -y
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
 ENV PATH="$PATH:/root/.cargo/bin"
 RUN arch=`dpkg --print-architecture`; \
    curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-$arch.zip \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -45,33 +45,41 @@ FROM base as release
 ENV PATH="$PATH:/root/.cargo/bin"
 # Pipeline manager binary
 COPY --from=builder /app/target/release/dbsp_pipeline_manager dbsp_pipeline_manager
-# SQL compiler needs the rust libraries, the compiler fat jar and the script
-#  to invoke the compiler jar
-RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+# SQL compiler uber jar
 RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target
-COPY --from=javabuild /sql/sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
-COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
 COPY --from=javabuild /sql/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/target/sql2dbsp-jar-with-dependencies.jar
-COPY --from=javabuild /sql/sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
 # The crates needed for the SQL compiler
 COPY crates/dbsp database-stream-processor/crates/dbsp
 COPY crates/adapters database-stream-processor/crates/adapters
 COPY crates/dataflow-jit database-stream-processor/crates/dataflow-jit
 COPY README.md database-stream-processor/README.md
-# TODO: This is a bug. The compiler should not be referencing two different libs
 RUN mkdir -p database-stream-processor/sql-to-dbsp-compiler/lib
+
+# Copy over the rust code and sql-to-dbsp script
 COPY sql-to-dbsp-compiler/lib database-stream-processor/sql-to-dbsp-compiler/lib
+COPY sql-to-dbsp-compiler/temp database-stream-processor/sql-to-dbsp-compiler/temp
+COPY sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp database-stream-processor/sql-to-dbsp-compiler/SQL-compiler/sql-to-dbsp
+
 CMD ./dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor
 
 # The dev target adds an rpk client and demo projects
-FROM builder as client
+FROM ubuntu:22.04 AS client
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update && apt install libssl-dev build-essential pkg-config \
+     git gcc clang libclang-dev python3-pip python3-plumbum hub numactl cmake \
+     curl unzip -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="$PATH:/root/.cargo/bin"
 RUN arch=`dpkg --print-architecture`; \
    curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-$arch.zip \
    && unzip rpk-linux-$arch.zip -d /bin/ \
    && rpk version \
    && rm rpk-linux-$arch.zip
-RUN target/release/dbsp_pipeline_manager --dump-openapi
+COPY --from=builder /app/target/release/dbsp_pipeline_manager dbsp_pipeline_manager
+COPY demo demo
+COPY python python
+RUN ./dbsp_pipeline_manager --dump-openapi
+RUN rm dbsp_pipeline_manager
 RUN pip3 install openapi-python-client websockets
 RUN cd python &&  \
     openapi-python-client generate --path ../openapi.json && \

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -85,4 +85,4 @@ services:
       - bash
       - -c
       # Run the SecOps demo
-      - "cd demo/project_demo04-SecOps && python3 run.py --dbsp_url http://dbsp:8080 --actions prepare create compile"
+      - "cd demo/project_demo04-SecOps && python3 run.py --dbsp_url http://dbsp:8080 --actions prepare create compile ${SECOPS_DEMO_ARGS}"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
      - ./dbsp_pipeline_manager 
      - --bind-address=0.0.0.0 
      - --working-directory=/working-dir 
-     - --sql-compiler-home=/sql-to-dbsp-compiler 
+     - --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler 
      - --dbsp-override-path=/database-stream-processor
      - --db-connection-string=postgresql://postgres:postgres@dbsp-postgres:5432
 

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -67,6 +67,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
             <version>3.0.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -114,6 +115,7 @@
             <artifactId>hsqldb</artifactId>
             <version>2.7.1</version>
             <classifier>jdk8</classifier>
+            <scope>test</scope>
         </dependency>
         <!-- The following is necessary only if you want to use the JDBC Sqlite driver
              for testing -->


### PR DESCRIPTION
* Reuse the dbsp-manager, SQL compiler and demo artifacts to create the images
used by the docker compose test. Doing so duplicates some stages in the
Dockerfile, but allows us to reuse work across the build to keep CI turnarounds
shorter.
* Use shorter SecOps demo runs in the CI.
* some tweaks to reduce Docker image sizes.