### PR TITLE
Make `DBSPError` implement `std::error::Error`.

### DIFF
--- a/crates/dbsp/src/error.rs
+++ b/crates/dbsp/src/error.rs
@@ -1,6 +1,7 @@
 use crate::{RuntimeError, SchedulerError};
 use anyhow::Error as AnyError;
 use std::{
+    error::Error as StdError,
     fmt::{Display, Error as FmtError, Formatter},
     io::Error as IOError,
 };
@@ -13,6 +14,8 @@ pub enum Error {
     Constructor(AnyError),
     Custom(String),
 }
+
+impl StdError for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {


### PR DESCRIPTION
This makes it possible to use `DBSPError` with `anyhow`, so that you can write things like

```
use anyhow::Result;
use dbsp::RootCircuit;

fn main() -> Result<()> {
    let (_circuit, ()) = RootCircuit::build(|_| Ok(()))?;
    Ok(())
}
```

using `?` and without having to use `unwrap()` or explicit error handling.