### PR TITLE
sql: use a custom parser for the SQL compiler

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -245,10 +245,10 @@ build-manager:
     RUN cargo +$RUST_TOOLCHAIN clippy $RUST_BUILD_PROFILE --package dbsp_pipeline_manager -- -D warnings
     RUN cargo +$RUST_TOOLCHAIN test $RUST_BUILD_PROFILE --package dbsp_pipeline_manager --no-run
     RUN cargo make -e RUST_BUILD_PROFILE=$RUST_BUILD_PROFILE --cwd crates/pipeline_manager/ openapi_python
-    IF [ -f ./target/debug/dbsp_pipeline_manager ] 
+    IF [ -f ./target/debug/dbsp_pipeline_manager ]
         SAVE ARTIFACT --keep-ts --keep-own ./target/debug/dbsp_pipeline_manager dbsp_pipeline_manager
     END
-    IF [ -f ./target/release/dbsp_pipeline_manager ] 
+    IF [ -f ./target/release/dbsp_pipeline_manager ]
         SAVE ARTIFACT --keep-ts --keep-own ./target/release/dbsp_pipeline_manager dbsp_pipeline_manager
     END
     SAVE ARTIFACT --keep-ts --keep-own ./python python
@@ -381,6 +381,13 @@ test-rust:
     BUILD +test-dataflow-jit --RUST_TOOLCHAIN=$RUST_TOOLCHAIN --RUST_BUILD_PROFILE=$RUST_BUILD_PROFILE
     BUILD +test-manager --RUST_TOOLCHAIN=$RUST_TOOLCHAIN --RUST_BUILD_PROFILE=$RUST_BUILD_PROFILE
 
+test-sql:
+    ARG RUST_TOOLCHAIN=$RUST_VERSION
+    ARG RUST_BUILD_PROFILE=$RUST_BUILD_MODE
+
+    FROM +build-sql --RUST_TOOLCHAIN=$RUST_TOOLCHAIN --RUST_BUILD_PROFILE=$RUST_BUILD_PROFILE
+    RUN cd "sql-to-dbsp-compiler/SQL-compiler" && mvn test
+
 # TODO: the following two container tasks duplicate work that we otherwise do in the Dockerfile,
 # but by mostly repeating ourselves, we can reuse earlier Earthly stages to speed up the CI.
 build-dbsp-manager-container:
@@ -439,4 +446,5 @@ all-tests:
     BUILD +test-rust
     BUILD +test-python
     BUILD +audit
+    BUILD +test-sql
     BUILD +test-docker-compose

--- a/Earthfile
+++ b/Earthfile
@@ -384,8 +384,8 @@ test-rust:
 test-sql:
     ARG RUST_TOOLCHAIN=$RUST_VERSION
     ARG RUST_BUILD_PROFILE=$RUST_BUILD_MODE
-
     FROM +build-sql --RUST_TOOLCHAIN=$RUST_TOOLCHAIN --RUST_BUILD_PROFILE=$RUST_BUILD_PROFILE
+    RUN apt install graphviz -y
     RUN cd "sql-to-dbsp-compiler/SQL-compiler" && mvn test
 
 # TODO: the following two container tasks duplicate work that we otherwise do in the Dockerfile,

--- a/sql-to-dbsp-compiler/SQL-compiler/pom.xml
+++ b/sql-to-dbsp-compiler/SQL-compiler/pom.xml
@@ -45,6 +45,110 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M7</version>
             </plugin>
+
+            <!-- Apache calcite parser extension.
+                 The flow here is to populate the build directory
+                 with Calcite's Parser.jj file and our own fmpp/ftl files.
+                 Next, we run FMPP to generate the input for JavaCC,
+                 and then run JavaCC to generate our parser. -->
+            <plugin>
+                <!-- Copy over calcite's templates/Parser.jj file -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-parser-template</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.calcite</groupId>
+                                    <artifactId>calcite-core</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/</outputDirectory>
+                                    <includes>**/Parser.jj</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Copy over our freemarker templates -->
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-fmpp-resources</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/codegen</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/codegen</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run FMPP to produce the inputs for JavaCC -->
+            <plugin>
+                <groupId>com.googlecode.fmpp-maven-plugin</groupId>
+                <artifactId>fmpp-maven-plugin</artifactId>
+                <version>1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.freemarker</groupId>
+                        <artifactId>freemarker</artifactId>
+                        <version>2.3.28</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>generate-fmpp-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <cfgFile>${project.build.directory}/codegen/config.fmpp</cfgFile>
+                            <outputDirectory>target/generated-sources</outputDirectory>
+                            <templateDirectory>${project.build.directory}/codegen/templates</templateDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Run JavaCC -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>javacc-maven-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <id>javacc</id>
+                        <goals>
+                            <goal>javacc</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirectory>${project.build.directory}/generated-sources/</sourceDirectory>
+                            <includes>
+                                <include>**/Parser.jj</include>
+                            </includes>
+                            <lookAhead>1</lookAhead>
+                            <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -1,0 +1,106 @@
+# Structure has to follow the fields in Calcite's default_config.fmpp.
+
+data: {
+  parser: {
+    package: "org.dbsp.generated.parser",
+    class: "DbspParserImpl",
+
+    imports: [
+      "org.apache.calcite.schema.ColumnStrategy"
+      "org.apache.calcite.sql.SqlCreate"
+      "org.apache.calcite.sql.SqlDrop"
+      "org.apache.calcite.sql.ddl.SqlDdlNodes"
+    ]
+
+    # List of new keywords. Example: "DATABASES", "TABLES". If the keyword is
+    # not a reserved keyword, add it to the 'nonReservedKeywords' section.
+    keywords: [
+      "IF"
+    ]
+
+    # List of keywords from "keywords" section that are not reserved.
+    # We might want the full list from here: https://github.com/apache/calcite/blob/main/core/src/main/codegen/default_config.fmpp
+    nonReservedKeywords: [
+    ]
+
+    # List of non-reserved keywords to add
+    nonReservedKeywordsToAdd: [
+      "IF"
+      # from core
+      "A"
+      "FIRST"
+      "STATE"
+      "TYPE"
+      "NAME"
+      "NAMES"
+      "PATH"
+    ]
+
+    # List of non-reserved keywords to remove;
+    # items in this list become reserved.
+    nonReservedKeywordsToRemove: [
+    ]
+
+    # List of additional join types. Each is a method with no arguments.
+    joinTypes: [
+    ]
+
+    # List of methods for parsing custom SQL statements.
+    # Return type of method implementation should be 'SqlNode'.
+    statementParserMethods: [
+    ]
+
+    # List of methods for parsing custom literals.
+    # Return type of method implementation should be "SqlNode".
+    literalParserMethods: [
+    ]
+
+    # List of methods for parsing custom data types.
+    dataTypeParserMethods: [
+    ]
+
+    # List of methods for parsing builtin function calls.
+    # Return type of method implementation should be "SqlNode".
+    builtinFunctionCallMethods: [
+    ]
+
+    # List of methods for parsing extensions to "ALTER <scope>" calls.
+    # Each must accept arguments "(SqlParserPos pos, String scope)".
+    alterStatementParserMethods: [
+    ]
+
+    # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
+    # Each must accept arguments "(SqlParserPos pos, boolean replace)".
+    createStatementParserMethods: [
+      "SqlCreateTable"
+      "SqlCreateView"
+    ]
+
+    # List of methods for parsing extensions to "DROP" calls.
+    # Each must accept arguments "(SqlParserPos pos)".
+    dropStatementParserMethods: [
+    ]
+
+    # Binary operators tokens.
+    binaryOperatorsTokens: [
+    ]
+
+    # Binary operators initialization.
+    extraBinaryExpressions: [
+    ]
+
+    includePosixOperators: false
+    includeCompoundIdentifier: true
+    includeBraces: true
+    includeAdditionalDeclarations: false
+    includeParsingStringLiteralAsArrayLiteral: false
+
+    implementationFiles: [
+      "ddl.ftl"
+    ]
+  }
+}
+
+freemarkerLinks: {
+  includes: includes/
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
@@ -75,13 +75,7 @@ void TableElement(List<SqlNode> list) :
         list.add(id);
     }
 |
-    [ <CONSTRAINT> { s.add(this); } name = SimpleIdentifier() ]
     (
-        <CHECK> { s.add(this); } <LPAREN>
-        e = Expression(ExprContext.ACCEPT_SUB_QUERY) <RPAREN> {
-            list.add(SqlDdlNodes.check(s.end(this), name, e));
-        }
-    |
         <UNIQUE> { s.add(this); }
         columnList = ParenthesizedSimpleIdentifierList() {
             list.add(SqlDdlNodes.unique(s.end(columnList), name, columnList));

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/includes/ddl.ftl
@@ -1,0 +1,184 @@
+/// Adapted from calcite-ddl and calcite-BABEL
+/// https://github.com/apache/calcite/blob/main/babel/src/main/codegen/config.fmpp
+
+boolean IfNotExistsOpt() :
+{
+}
+{
+    <IF> <NOT> <EXISTS> { return true; }
+|
+    { return false; }
+}
+
+boolean IfExistsOpt() :
+{
+}
+{
+    <IF> <EXISTS> { return true; }
+|
+    { return false; }
+}
+
+SqlNodeList TableElementList() :
+{
+    final Span s;
+    final List<SqlNode> list = new ArrayList<SqlNode>();
+}
+{
+    <LPAREN> { s = span(); }
+    TableElement(list)
+    (
+        <COMMA> TableElement(list)
+    )*
+    <RPAREN> {
+        return new SqlNodeList(list, s.end(this));
+    }
+}
+
+void TableElement(List<SqlNode> list) :
+{
+    final SqlIdentifier id;
+    final SqlDataTypeSpec type;
+    final boolean nullable;
+    final SqlNode e;
+    SqlIdentifier name = null;
+    final SqlNodeList columnList;
+    final Span s = Span.of();
+    final ColumnStrategy strategy;
+}
+{
+    LOOKAHEAD(2) id = SimpleIdentifier()
+    (
+        type = DataType()
+        nullable = NullableOptDefaultTrue()
+        (
+            <DEFAULT_> e = Expression(ExprContext.ACCEPT_SUB_QUERY) {
+                strategy = ColumnStrategy.DEFAULT;
+            }
+        |
+            {
+                e = null;
+                strategy = nullable ? ColumnStrategy.NULLABLE
+                    : ColumnStrategy.NOT_NULLABLE;
+            }
+        )
+        {
+            list.add(
+                SqlDdlNodes.column(s.add(id).end(this), id,
+                    type.withNullable(nullable), e, strategy));
+        }
+    |
+        { list.add(id); }
+    )
+|
+    id = SimpleIdentifier() {
+        list.add(id);
+    }
+|
+    [ <CONSTRAINT> { s.add(this); } name = SimpleIdentifier() ]
+    (
+        <CHECK> { s.add(this); } <LPAREN>
+        e = Expression(ExprContext.ACCEPT_SUB_QUERY) <RPAREN> {
+            list.add(SqlDdlNodes.check(s.end(this), name, e));
+        }
+    |
+        <UNIQUE> { s.add(this); }
+        columnList = ParenthesizedSimpleIdentifierList() {
+            list.add(SqlDdlNodes.unique(s.end(columnList), name, columnList));
+        }
+    |
+        <PRIMARY>  { s.add(this); } <KEY>
+        columnList = ParenthesizedSimpleIdentifierList() {
+            list.add(SqlDdlNodes.primary(s.end(columnList), name, columnList));
+        }
+    )
+}
+
+SqlNodeList AttributeDefList() :
+{
+    final Span s;
+    final List<SqlNode> list = new ArrayList<SqlNode>();
+}
+{
+    <LPAREN> { s = span(); }
+    AttributeDef(list)
+    (
+        <COMMA> AttributeDef(list)
+    )*
+    <RPAREN> {
+        return new SqlNodeList(list, s.end(this));
+    }
+}
+
+void AttributeDef(List<SqlNode> list) :
+{
+    final SqlIdentifier id;
+    final SqlDataTypeSpec type;
+    final boolean nullable;
+    SqlNode e = null;
+    final Span s = Span.of();
+}
+{
+    id = SimpleIdentifier()
+    (
+        type = DataType()
+        nullable = NullableOptDefaultTrue()
+    )
+    [ <DEFAULT_> e = Expression(ExprContext.ACCEPT_SUB_QUERY) ]
+    {
+        list.add(SqlDdlNodes.attribute(s.add(id).end(this), id,
+            type.withNullable(nullable), e, null));
+    }
+}
+
+SqlCreate SqlCreateType(Span s, boolean replace) :
+{
+    final SqlIdentifier id;
+    SqlNodeList attributeDefList = null;
+    SqlDataTypeSpec type = null;
+}
+{
+    <TYPE>
+    id = CompoundIdentifier()
+    <AS>
+    (
+        attributeDefList = AttributeDefList()
+    |
+        type = DataType()
+    )
+    {
+        return SqlDdlNodes.createType(s.end(this), replace, id, attributeDefList, type);
+    }
+}
+
+SqlCreate SqlCreateTable(Span s, boolean replace) :
+{
+    final boolean ifNotExists;
+    final SqlIdentifier id;
+    SqlNodeList tableElementList = null;
+    SqlNode query = null;
+}
+{
+    <TABLE> ifNotExists = IfNotExistsOpt() id = CompoundIdentifier()
+    [ tableElementList = TableElementList() ]
+    [ <AS> query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) ]
+    {
+        return SqlDdlNodes.createTable(s.end(this), replace, ifNotExists, id,
+            tableElementList, query);
+    }
+}
+
+SqlCreate SqlCreateView(Span s, boolean replace) :
+{
+    final SqlIdentifier id;
+    SqlNodeList columnList = null;
+    final SqlNode query;
+}
+{
+    <VIEW> id = CompoundIdentifier()
+    [ columnList = ParenthesizedSimpleIdentifierList() ]
+    <AS> query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY) {
+        return SqlDdlNodes.createView(s.end(this), replace, id, columnList,
+            query);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/calciteCompiler/CalciteCompiler.java
@@ -64,6 +64,7 @@ import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.Pair;
+import org.dbsp.generated.parser.DbspParserImpl;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
 import org.dbsp.sqlCompiler.compiler.frontend.statements.*;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
@@ -195,7 +196,7 @@ public class CalciteCompiler implements IModule {
         this.parserConfig = SqlParser.config()
                 .withLex(options.ioOptions.lexicalRules)
                 // Add support for DDL language
-                .withParserFactory(SqlDdlParserImpl.FACTORY)
+                .withParserFactory(DbspParserImpl.FACTORY)
                 // Enable the next to preserve casing.
                 //.withUnquotedCasing(Casing.UNCHANGED)
                 //.withQuotedCasing(Casing.UNCHANGED)


### PR DESCRIPTION
We currently use calcite-server's DDL parser, but would like to extend this with functionality from calcite-babel.  The only way to compose parsers like this is to create a custom parser by using FMPP/FTL files to customize Calcite's parser template.

This patch adds a custom parser that replaces the currently used DdlParser, and sets it up for further babel extensions.

At build time, we extract Parser.jj from the calcite jar, combine it with our FMPP/FTL files, and run java-cc on the result to codegen our custom parser.