### PR TITLE
Docker compose and Kubernetes spec tweaks

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -27,10 +27,27 @@ jobs:
         env:
           muix_license: ${{ secrets.muix_license }}
 
+      - name: Docker meta (dbsp-manager)
+        id: meta_dbsp
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DBSP_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Docker meta (demo-container)
+        id: meta_demo
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DEMO_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+
       - name: Run integration tests
         run: |
           cd deploy && \
           SECOPS_DEMO_ARGS="--prepare-args 500000" docker compose -f docker-compose.yml -f docker-compose-dev.yml --profile demo up --build --force-recreate --exit-code-from demo --renew-anon-volumes
+
       # Disable until we bring the Kubernetes workflows up to speed
       #
       # - uses: engineerd/setup-kind@v0.5.0
@@ -45,14 +62,50 @@ jobs:
       #   run: cd deploy/kind && sleep 60 && kubectl apply -f dbsp-deploy.yml && kubectl wait --for=condition=ready pod -l app=dbsp -n dbsp --timeout=300s
 
       - name: Log in to the Container registry
-        if: github.event_name == 'release'
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Docker image
+      # Push untagged images when the workflow is not triggered by a release
+      - name: Push containers
+        if: github.event_name != 'release'
+        run: docker push ${{ env.DBSP_IMAGE }} && docker push ${{ env.DEMO_IMAGE }}
+
+      # Tagged DBSP image
+      - name: Push (dbsp-manager)
+        uses: docker/build-push-action@v4
         if: github.event_name == 'release'
-        run: |
-          docker push ${{ env.DBSP_IMAGE }} && docker push ${{ env.DEMO_IMAGE }}
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta_dbsp.outputs.tags }}
+          labels: ${{ steps.meta_dbsp.outputs.labels }}
+
+      # Tagged demo image
+      - name: Push (demo-container)
+        uses: docker/build-push-action@v4
+        if: github.event_name == 'release'
+        with:
+          context: .
+          file: deploy/Dockerfile
+          target: client
+          push: true
+          tags: ${{ steps.meta_demo.outputs.tags }}
+          labels: ${{ steps.meta_demo.outputs.labels }}
+
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name: dbsp-manager
+          package-type: 'container'
+          min-versions-to-keep: 5
+          delete-only-untagged-versions: 'true'
+
+      - uses: actions/delete-package-versions@v4
+        with:
+          package-name:  demo-container
+          package-type: 'container'
+          min-versions-to-keep: 5
+          delete-only-untagged-versions: 'true'

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -73,7 +73,7 @@ FROM ubuntu:22.04 AS client
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && apt install build-essential pkg-config \
      # cmake is needed by rdkafka
-     cmake \ 
+     cmake \
      python3-pip python3-plumbum \
      curl unzip -y
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
@@ -91,7 +91,7 @@ RUN rm dbsp_pipeline_manager
 RUN pip3 install openapi-python-client websockets
 RUN cd python &&  \
     openapi-python-client generate --path ../openapi.json && \
-    pip3 install ./dbsp-api-client && \ 
+    pip3 install ./dbsp-api-client && \
     pip3 install .
 # TODO: only required for running the fraud detection demo. Remove when we clean that up.
 RUN pip3 install gdown

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   db:
     image: postgres
-    container_name: dbsp-postgres
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
@@ -19,7 +18,6 @@ services:
     db:
       condition: service_healthy
    stop_grace_period: 0s
-   container_name: dbsp
    environment:
      - RUST_BACKTRACE=1
      - REDPANDA_BROKERS=redpanda:9092
@@ -30,7 +28,7 @@ services:
      - --working-directory=/working-dir
      - --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler
      - --dbsp-override-path=/database-stream-processor
-     - --db-connection-string=postgresql://postgres:postgres@dbsp-postgres:5432
+     - --db-connection-string=postgresql://postgres:postgres@db:5432
 
   redpanda:
     command:
@@ -59,7 +57,6 @@ services:
       # enable logs for debugging.
       # - --default-log-level=debug
     image: docker.redpanda.com/vectorized/redpanda:v22.3.11
-    container_name: redpanda
     ports:
       - 18081:18081
       - 18082:18082
@@ -72,7 +69,6 @@ services:
       dbsp:
         condition: service_started
     image: ghcr.io/feldera/demo-container
-    container_name: demo-container
     environment:
       - RUST_BACKTRACE=1
       - REDPANDA_BROKERS=redpanda:9092

--- a/deploy/kind/dbsp-deploy.yml
+++ b/deploy/kind/dbsp-deploy.yml
@@ -57,16 +57,16 @@ spec:
         app: dbsp
     spec:
       containers:
-      - image: localhost:5001/dbspmanager
+      - image: ghcr.io/feldera/dbsp-manager
         name: dbsp-manager
         ports:
         - containerPort: 8080
-        command: 
+        command:
           - ./dbsp_pipeline_manager
         args:
-          - --bind-address=0.0.0.0 
-          - --working-directory=/working-dir 
-          - --sql-compiler-home=/sql-to-dbsp-compiler 
+          - --bind-address=0.0.0.0
+          - --working-directory=/working-dir
+          - --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler
           - --dbsp-override-path=/database-stream-processor
           - --db-connection-string=postgresql://$(PGUSER):$(PGPASSWORD)@postgres.dbsp.svc.cluster.local:5432
         env:

--- a/deploy/kind/setup.sh
+++ b/deploy/kind/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+set -e
 
 #### Refresh kind
 kind delete cluster


### PR DESCRIPTION
* Use docker compose's generated names to avoid container name conflicts.
* Sync the Kubernetes specs to recent Docker container changes
* Publish containers on a nightly cadence. These containers will be untagged, and we will only keep the 5 most recent versions (we use a `delete-package-version` GH action for it). Anyone interested in using these containers can them via <container-name>:latest. 
* Release versions of the containers are published using Github releases. These containers will be tagged with the release version, and will not be reaped by the `delete-package-version` action.