### PR TITLE
dbsp: Change `&mut self` to `&self` on CollectionHandle::append.

### DIFF
--- a/crates/dbsp/examples/tutorial/tutorial2.rs
+++ b/crates/dbsp/examples/tutorial/tutorial2.rs
@@ -22,7 +22,7 @@ fn build_circuit(circuit: &mut RootCircuit) -> Result<CollectionHandle<Record, i
 
 fn main() -> Result<()> {
     // Build circuit.
-    let (circuit, mut input_handle) = RootCircuit::build(build_circuit)?;
+    let (circuit, input_handle) = RootCircuit::build(build_circuit)?;
 
     // Feed data into circuit.
     let path = format!(

--- a/crates/dbsp/examples/tutorial/tutorial3.rs
+++ b/crates/dbsp/examples/tutorial/tutorial3.rs
@@ -32,7 +32,7 @@ fn build_circuit(
 
 fn main() -> Result<()> {
     // Build circuit.
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     // Feed data into circuit.
     let path = format!(

--- a/crates/dbsp/examples/tutorial/tutorial4.rs
+++ b/crates/dbsp/examples/tutorial/tutorial4.rs
@@ -39,7 +39,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     let path = format!(
         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/dbsp/examples/tutorial/tutorial5.rs
+++ b/crates/dbsp/examples/tutorial/tutorial5.rs
@@ -47,7 +47,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     let path = format!(
         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/dbsp/examples/tutorial/tutorial6.rs
+++ b/crates/dbsp/examples/tutorial/tutorial6.rs
@@ -55,7 +55,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     let path = format!(
         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/dbsp/examples/tutorial/tutorial7.rs
+++ b/crates/dbsp/examples/tutorial/tutorial7.rs
@@ -58,7 +58,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     let path = format!(
         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/dbsp/examples/tutorial/tutorial8.rs
+++ b/crates/dbsp/examples/tutorial/tutorial8.rs
@@ -62,7 +62,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut vax_handle, mut pop_handle, output_handle)) =
+    let (circuit, (vax_handle, pop_handle, output_handle)) =
         RootCircuit::build(build_circuit)?;
 
     let path = format!(

--- a/crates/dbsp/examples/tutorial/tutorial9.rs
+++ b/crates/dbsp/examples/tutorial/tutorial9.rs
@@ -58,7 +58,7 @@ fn build_circuit(
 }
 
 fn main() -> Result<()> {
-    let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+    let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 
     let path = format!(
         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/dbsp/src/operator/aggregate/mod.rs
+++ b/crates/dbsp/src/operator/aggregate/mod.rs
@@ -952,7 +952,7 @@ mod test {
         let sum_weighted_output_clone = sum_weighted_output.clone();
         let sum_distinct_output_clone = sum_distinct_output.clone();
 
-        let (mut dbsp, mut input_handle) = Runtime::init_circuit(workers, move |circuit| {
+        let (mut dbsp, input_handle) = Runtime::init_circuit(workers, move |circuit| {
             let (input_stream, input_handle) = circuit.add_input_indexed_zset();
             input_stream
                 .weighted_count()

--- a/crates/dbsp/src/operator/distinct.rs
+++ b/crates/dbsp/src/operator/distinct.rs
@@ -833,7 +833,7 @@ mod test {
         let output2 = Arc::new(Mutex::new(OrdIndexedZSet::empty(())));
         let output2_clone = output2.clone();
 
-        let (mut circuit, mut input) = Runtime::init_circuit(4, move |circuit| {
+        let (mut circuit, input) = Runtime::init_circuit(4, move |circuit| {
             let (input, input_handle) = circuit.add_input_indexed_zset::<usize, usize, isize>();
 
             input

--- a/crates/dbsp/src/operator/input.rs
+++ b/crates/dbsp/src/operator/input.rs
@@ -664,7 +664,7 @@ where
     /// result in only a subset of the workers observing updates from this
     /// `append` operation.  The remaining updates will appear
     /// during subsequent logical clock cycles.
-    pub fn append(&mut self, vals: &mut Vec<(K, V)>) {
+    pub fn append(&self, vals: &mut Vec<(K, V)>) {
         let num_partitions = self.num_partitions();
         let next_worker = if num_partitions > 1 {
             self.next_worker.load(Ordering::Acquire)
@@ -1096,7 +1096,7 @@ mod test {
 
     #[test]
     fn zset_test_st() {
-        let (circuit, mut input_handle) =
+        let (circuit, input_handle) =
             RootCircuit::build(move |circuit| zset_test_circuit(circuit)).unwrap();
 
         for mut vec in input_vecs().into_iter() {
@@ -1121,7 +1121,7 @@ mod test {
     }
 
     fn zset_test_mt(workers: usize) {
-        let (mut dbsp, mut input_handle) =
+        let (mut dbsp, input_handle) =
             Runtime::init_circuit(workers, |circuit| zset_test_circuit(circuit)).unwrap();
 
         for mut vec in input_vecs().into_iter() {
@@ -1203,7 +1203,7 @@ mod test {
 
     #[test]
     fn indexed_zset_test_st() {
-        let (circuit, mut input_handle) =
+        let (circuit, input_handle) =
             RootCircuit::build(move |circuit| indexed_zset_test_circuit(circuit)).unwrap();
 
         for mut vec in input_indexed_vecs().into_iter() {
@@ -1222,7 +1222,7 @@ mod test {
     }
 
     fn indexed_zset_test_mt(workers: usize) {
-        let (mut dbsp, mut input_handle) =
+        let (mut dbsp, input_handle) =
             Runtime::init_circuit(workers, |circuit| indexed_zset_test_circuit(circuit)).unwrap();
 
         for mut vec in input_indexed_vecs().into_iter() {

--- a/crates/dbsp/src/operator/join.rs
+++ b/crates/dbsp/src/operator/join.rs
@@ -1347,7 +1347,7 @@ mod test {
         let output = Arc::new(Mutex::new(OrdIndexedZSet::empty(())));
         let output_clone = output.clone();
 
-        let (mut circuit, (mut input1, mut input2)) = Runtime::init_circuit(4, move |circuit| {
+        let (mut circuit, (input1, input2)) = Runtime::init_circuit(4, move |circuit| {
             let (input1, input_handle1) = circuit.add_input_indexed_zset::<usize, usize, isize>();
             let (input2, input_handle2) = circuit.add_input_indexed_zset::<usize, usize, isize>();
 

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -284,7 +284,7 @@ mod test {
 
     #[test]
     fn test_output_handle() {
-        let (mut dbsp, (mut input, output)) = Runtime::init_circuit(4, |circuit| {
+        let (mut dbsp, (input, output)) = Runtime::init_circuit(4, |circuit| {
             let (zset, zset_handle) = circuit.add_input_zset::<u64, isize>();
             let zset_output = zset.output();
 

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -833,7 +833,7 @@ mod test {
 
     #[test]
     fn test_partitioned_over_range_2() {
-        let (mut circuit, mut input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 
         circuit.step().unwrap();
 
@@ -848,7 +848,7 @@ mod test {
 
     #[test]
     fn test_partitioned_over_range() {
-        let (mut circuit, mut input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+        let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 
         circuit.step().unwrap();
 
@@ -888,7 +888,7 @@ mod test {
     // Test derived from issue #199 (https://github.com/feldera/dbsp/issues/199).
     #[test]
     fn test_partitioned_rolling_aggregate2() {
-        let (circuit, (mut input, mut expected)) = RootCircuit::build(move |circuit| {
+        let (circuit, (input, expected)) = RootCircuit::build(move |circuit| {
             let (input, input_handle) = circuit.add_input_indexed_zset::<u64, (u64, i64), i64>();
             let (expected, expected_handle) =
                 circuit.add_input_indexed_zset::<u64, (u64, Option<i64>), i64>();
@@ -933,7 +933,7 @@ mod test {
 
     #[test]
     fn test_partitioned_rolling_average() {
-        let (circuit, (mut input, mut expected)) = RootCircuit::build(move |circuit| {
+        let (circuit, (input, expected)) = RootCircuit::build(move |circuit| {
             let (input_stream, input_handle) =
                 circuit.add_input_indexed_zset::<u64, (u64, i64), i64>();
             let (expected_stream, expected_handle) =
@@ -970,7 +970,7 @@ mod test {
 
     #[test]
     fn test_partitioned_rolling_aggregate() {
-        let (circuit, mut input) = RootCircuit::build(move |circuit| {
+        let (circuit, input) = RootCircuit::build(move |circuit| {
             let (input_stream, input_handle) =
                 circuit.add_input_indexed_zset::<u64, (u64, i64), i64>();
 
@@ -1060,7 +1060,7 @@ mod test {
         #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_rolling_aggregate_quasi_monotone(trace in input_trace_quasi_monotone(5, 10_000, 2_000, 20, 200)) {
             // 10_000 is an empirically established bound: without GC this test needs >10KB.
-            let (mut circuit, mut input) = partition_rolling_aggregate_circuit(10000, Some(10_000));
+            let (mut circuit, input) = partition_rolling_aggregate_circuit(10000, Some(10_000));
 
             for mut batch in trace {
                 input.append(&mut batch);
@@ -1075,7 +1075,7 @@ mod test {
         #[test]
         #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_over_range_sparse(trace in input_trace(5, 1_000_000, 20, 20)) {
-            let (mut circuit, mut input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 
             for mut batch in trace {
                 input.append(&mut batch);
@@ -1088,7 +1088,7 @@ mod test {
         #[test]
         #[cfg_attr(feature = "persistence", ignore = "takes a long time?")]
         fn proptest_partitioned_over_range_dense(trace in input_trace(5, 1_000, 50, 20)) {
-            let (mut circuit, mut input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
+            let (mut circuit, input) = partition_rolling_aggregate_circuit(u64::max_value(), None);
 
             for mut batch in trace {
                 input.append(&mut batch);

--- a/crates/dbsp/src/operator/time_series/watermark.rs
+++ b/crates/dbsp/src/operator/time_series/watermark.rs
@@ -83,7 +83,7 @@ mod tests {
     fn test_watermark_monotonic(workers: usize) {
         let mut expected_watermarks = vec![115, 115, 125, 145].into_iter();
 
-        let (mut dbsp, mut input_handle) = Runtime::init_circuit(workers, move |circuit| {
+        let (mut dbsp, input_handle) = Runtime::init_circuit(workers, move |circuit| {
             let (stream, handle) = circuit.add_input_zset();
             stream
                 .watermark_monotonic(|ts| ts + 5)

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -185,7 +185,7 @@
 //!
 //! fn main() -> Result<()> {
 //!     // Build circuit.
-//!     let (circuit, mut input_handle) = RootCircuit::build(build_circuit)?;
+//!     let (circuit, input_handle) = RootCircuit::build(build_circuit)?;
 //!
 //!     // ...feed data into circuit...
 //!     // ...execute circuit...
@@ -225,7 +225,7 @@
 //! #
 //! # fn main() -> Result<()> {
 //! #     // Build circuit.
-//! #     let (circuit, mut input_handle) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, input_handle) = RootCircuit::build(build_circuit)?;
 //! #
 //!     // Feed data into circuit.
 //!     let path = format!(
@@ -293,7 +293,7 @@
 //! #
 //! # fn main() -> Result<()> {
 //! #     // Build circuit.
-//! #     let (circuit, mut input_handle) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, input_handle) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     // Feed data into circuit.
 //! #     let path = format!(
@@ -367,7 +367,7 @@
 //! #
 //! # fn main() -> Result<()> {
 //! #     // Build circuit.
-//! #     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     // Feed data into circuit.
 //! #     let path = format!(
@@ -431,7 +431,7 @@
 //! #
 //! # fn main() -> Result<()> {
 //! #     // Build circuit.
-//! #     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     // Feed data into circuit.
 //! #     let path = format!(
@@ -498,7 +498,7 @@
 //! #
 //! # fn main() -> Result<()> {
 //!     // Build circuit.
-//!     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//!     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     // Feed data into circuit.
 //! #     let path = format!(
@@ -628,7 +628,7 @@
 //! }
 //! 
 //! fn main() -> Result<()> {
-//! #     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     let path = format!(
 //! #         "{}/examples/tutorial/vaccinations.csv",
@@ -772,7 +772,7 @@
 //! }
 //!
 //! # fn main() -> Result<()> {
-//! #     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     let path = format!(
 //! #         "{}/examples/tutorial/vaccinations.csv",
@@ -920,7 +920,7 @@
 //! }
 //!
 //! fn main() -> Result<()> {
-//!     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//!     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #     let path = format!(
 //! #         "{}/examples/tutorial/vaccinations.csv",
 //! #         env!("CARGO_MANIFEST_DIR")
@@ -1073,7 +1073,7 @@
 //! }
 //!
 //! fn main() -> Result<()> {
-//! #     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//! #     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //! #
 //! #     let path = format!(
 //! #         "{}/examples/tutorial/vaccinations.csv",
@@ -1201,7 +1201,7 @@
 //! }
 //!
 //! # fn main() -> Result<()> {
-//! #     let (circuit, (mut vax_handle, mut pop_handle, output_handle)) =
+//! #     let (circuit, (vax_handle, pop_handle, output_handle)) =
 //! #         RootCircuit::build(build_circuit)?;
 //! #
 //! #     let path = format!(
@@ -1303,7 +1303,7 @@
 //! # }
 //! #
 //! fn main() -> Result<()> {
-//!     let (circuit, (mut vax_handle, mut pop_handle, output_handle)) =
+//!     let (circuit, (vax_handle, pop_handle, output_handle)) =
 //!         RootCircuit::build(build_circuit)?;
 //! #
 //! #     let path = format!(
@@ -1476,7 +1476,7 @@
 //! # }
 //! # 
 //! # fn main() -> Result<()> {
-//! #     let (circuit, (mut vax_handle, mut pop_handle, output_handle)) =
+//! #     let (circuit, (vax_handle, pop_handle, output_handle)) =
 //! #         RootCircuit::build(build_circuit)?;
 //! # 
 //! #     let path = format!(
@@ -1601,7 +1601,7 @@
 //! # }
 //! #
 //! fn main() -> Result<()> {
-//!     let (circuit, (mut input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
+//!     let (circuit, (input_handle, output_handle)) = RootCircuit::build(build_circuit)?;
 //!
 //!     let path = format!(
 //!         "{}/examples/tutorial/vaccinations.csv",

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -90,7 +90,7 @@ fn spawn_dbsp_consumer(
 
 fn spawn_source_producer(
     nexmark_config: NexmarkConfig,
-    mut input_handle: CollectionHandle<Event, isize>,
+    input_handle: CollectionHandle<Event, isize>,
     step_do_rx: mpsc::Receiver<()>,
     step_done_tx: mpsc::SyncSender<StepCompleted>,
     source_exhausted_tx: mpsc::SyncSender<InputStats>,

--- a/crates/nexmark/benches/nexmark/run_queries.rs
+++ b/crates/nexmark/benches/nexmark/run_queries.rs
@@ -63,7 +63,7 @@ macro_rules! run_queries {
     (@circuit q13) => {
         |circuit: &mut RootCircuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
-            let (side_stream, mut side_input_handle) =
+            let (side_stream, side_input_handle) =
                 circuit.add_input_zset::<(usize, String, u64), isize>();
 
             let output = q13(stream, side_stream);

--- a/crates/nexmark/src/lib.rs
+++ b/crates/nexmark/src/lib.rs
@@ -301,7 +301,7 @@ pub mod tests {
 
     #[test]
     fn test_nexmark_dbsp_source_full_batch() {
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset();
 
             let expected_zset = generate_expected_zset(0, 10);

--- a/crates/nexmark/src/queries/q0.rs
+++ b/crates/nexmark/src/queries/q0.rs
@@ -81,7 +81,7 @@ mod tests {
             ]
         }
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q0(stream);

--- a/crates/nexmark/src/queries/q1.rs
+++ b/crates/nexmark/src/queries/q1.rs
@@ -111,7 +111,7 @@ mod tests {
             ]
         }
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q1(stream);

--- a/crates/nexmark/src/queries/q12.rs
+++ b/crates/nexmark/src/queries/q12.rs
@@ -123,7 +123,7 @@ mod tests {
         let proc_time_iter = RefCell::new(proc_times.into_iter());
         let process_time = move || -> u64 { proc_time_iter.borrow_mut().next().unwrap() };
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q12_for_process_time(stream, process_time);

--- a/crates/nexmark/src/queries/q13.rs
+++ b/crates/nexmark/src/queries/q13.rs
@@ -152,7 +152,7 @@ mod tests {
         ]]
         .into_iter();
 
-        let (circuit, (mut input_handle, mut side_input_handle)) = RootCircuit::build(move |circuit| {
+        let (circuit, (input_handle, side_input_handle)) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let (side_stream, side_input_handle) =
                 circuit.add_input_zset::<(usize, String, u64), isize>();

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -178,7 +178,7 @@ mod tests {
         )]]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![expected_zset].into_iter();

--- a/crates/nexmark/src/queries/q15.rs
+++ b/crates/nexmark/src/queries/q15.rs
@@ -538,7 +538,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (mut dbsp, mut input_handle) = Runtime::init_circuit(num_threads, move |circuit| {
+        let (mut dbsp, input_handle) = Runtime::init_circuit(num_threads, move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![

--- a/crates/nexmark/src/queries/q16.rs
+++ b/crates/nexmark/src/queries/q16.rs
@@ -703,7 +703,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (mut dbsp, mut input_handle) = Runtime::init_circuit(num_threads, move |circuit| {
+        let (mut dbsp, input_handle) = Runtime::init_circuit(num_threads, move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![

--- a/crates/nexmark/src/queries/q17.rs
+++ b/crates/nexmark/src/queries/q17.rs
@@ -326,7 +326,7 @@ mod tests {
                 .collect()
         });
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q17(stream);

--- a/crates/nexmark/src/queries/q18.rs
+++ b/crates/nexmark/src/queries/q18.rs
@@ -376,7 +376,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|b| (Event::Bid(b), 1)).collect());
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q18(stream);

--- a/crates/nexmark/src/queries/q19.rs
+++ b/crates/nexmark/src/queries/q19.rs
@@ -280,7 +280,7 @@ mod tests {
                 .collect()
         });
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q19(stream);

--- a/crates/nexmark/src/queries/q2.rs
+++ b/crates/nexmark/src/queries/q2.rs
@@ -87,7 +87,7 @@ mod tests {
             ],
         ];
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q2(stream);

--- a/crates/nexmark/src/queries/q20.rs
+++ b/crates/nexmark/src/queries/q20.rs
@@ -232,7 +232,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q20(stream);

--- a/crates/nexmark/src/queries/q21.rs
+++ b/crates/nexmark/src/queries/q21.rs
@@ -121,7 +121,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q21(stream);

--- a/crates/nexmark/src/queries/q22.rs
+++ b/crates/nexmark/src/queries/q22.rs
@@ -107,7 +107,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q22(stream);

--- a/crates/nexmark/src/queries/q3.rs
+++ b/crates/nexmark/src/queries/q3.rs
@@ -163,7 +163,7 @@ mod tests {
             ],
         ];
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q3(stream);

--- a/crates/nexmark/src/queries/q4.rs
+++ b/crates/nexmark/src/queries/q4.rs
@@ -209,7 +209,7 @@ mod tests {
             ],
         ];
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q4(stream);

--- a/crates/nexmark/src/queries/q5.rs
+++ b/crates/nexmark/src/queries/q5.rs
@@ -193,7 +193,7 @@ mod tests {
                         .collect()
                 });
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q5(stream);

--- a/crates/nexmark/src/queries/q6.rs
+++ b/crates/nexmark/src/queries/q6.rs
@@ -176,7 +176,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![
@@ -253,7 +253,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let mut expected_output = vec![
                 // First batch has a single auction seller with best bid of 100.
@@ -493,7 +493,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let mut expected_output = vec![
                 // First has 5 auction for person 99, but average is (200 + 100 * 4) / 5.
@@ -611,7 +611,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![

--- a/crates/nexmark/src/queries/q7.rs
+++ b/crates/nexmark/src/queries/q7.rs
@@ -166,7 +166,7 @@ mod tests {
                 .collect()
         });
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q7(stream);

--- a/crates/nexmark/src/queries/q8.rs
+++ b/crates/nexmark/src/queries/q8.rs
@@ -196,7 +196,7 @@ mod tests {
                     .collect()
             });
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q8(stream);

--- a/crates/nexmark/src/queries/q9.rs
+++ b/crates/nexmark/src/queries/q9.rs
@@ -366,7 +366,7 @@ mod tests {
         ]
         .into_iter();
 
-        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
+        let (circuit, input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![


### PR DESCRIPTION
There wasn't a reason for it to take a mutable reference anymore.

Most of the commit is updating callers to remove `mut` from input handles.