### PR TITLE
CI improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ target
 **/ldbc-graphalytics-data
 **/fraud_data
 **/.vscode
+**/__pycache__

--- a/.earthlyignore
+++ b/.earthlyignore
@@ -6,5 +6,6 @@
 **/node_modules
 **/.docusaurus
 **/openapi.json
-web-ui/.next
+**/.next
 **/out
+**/__pycache__

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,11 @@ on:
   pull_request:
     paths:
       - docs/**
-      - .github/docs.yml
+      - .github/workflows/docs.yml
   push:
     paths:
       - docs/**
-      - .github/docs.yml
+      - .github/workflows/docs.yml
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ cargo_workspace
 openapi.json
 
 # python
-python/dbsp-api-client/
+__pycache__

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
     "[python]": {
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
-    "python.formatting.provider": "none",
     "[javascript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
@@ -23,4 +22,5 @@
     },
     "editor.formatOnSave": true,
     "files.trimTrailingWhitespace": true,
+    "prettier.requireConfig": true,
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,6 +1378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "compare"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5343,6 +5349,29 @@ name = "target-lexicon"
 version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+
+[[package]]
+name = "temp"
+version = "0.1.0"
+dependencies = [
+ "compare",
+ "dataflow-jit",
+ "dbsp",
+ "dbsp_adapters",
+ "genlib",
+ "geo",
+ "geo-types",
+ "hashing",
+ "readers",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "size-of",
+ "sqllib",
+ "sqlvalue",
+ "sqlx",
+ "tuple",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = ["crates/*", "sql-to-dbsp-compiler/lib/*"]
-exclude = ["sql-to-dbsp-compiler/temp"]
+members = ["crates/*", "sql-to-dbsp-compiler/lib/*", "sql-to-dbsp-compiler/temp"]
 
 [profile.bench]
 debug = true

--- a/crates/pipeline_manager/Makefile.toml
+++ b/crates/pipeline_manager/Makefile.toml
@@ -21,8 +21,8 @@ pip3 install openapi-python-client
 cd ../../python
 rm -rf dbsp-api-client
 openapi-python-client generate --path ../openapi.json --fail-on-warning
-pip3 install ./dbsp-api-client
-pip3 install .
+pip3 install -e ./dbsp-api-client
+pip3 install -e .
 pip3 install websockets
 '''
 

--- a/demo/demo_notebooks/requirements.txt
+++ b/demo/demo_notebooks/requirements.txt
@@ -5,3 +5,5 @@ geopy==2.3.0
 pandas==1.5.3
 scikit_learn==1.2.1
 xgboost==1.7.3
+# This is used by python/test.py and can go away once we remove websockets
+websockets==11.0.3

--- a/docs/.eslintrc.json
+++ b/docs/.eslintrc.json
@@ -1,0 +1,44 @@
+{
+    "extends": [
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
+    ],
+    "rules": {
+      "react/display-name": "off",
+      "@next/next/no-img-element": "off",
+      "react/no-unescaped-entities": "off",
+      "import/no-anonymous-default-export": "off",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+      "@typescript-eslint/ban-types": [
+        "error",
+        {
+          "extendDefaults": true,
+          "types": {
+            "{}": false
+          }
+        }
+      ]
+    },
+    "plugins": [
+      "import"
+    ],
+    "settings": {
+      "import/parsers": {
+        "@typescript-eslint/parser": [
+          ".ts",
+          ".tsx"
+        ]
+      },
+      "import/resolver": {
+        "typescript": {
+          "alwaysTryTypes": true,
+          "project": [
+            "./tsconfig.json"
+          ]
+        }
+      }
+    }
+  }

--- a/docs/.prettierrc.js
+++ b/docs/.prettierrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+    arrowParens: 'avoid',
+    bracketSpacing: true,
+    htmlWhitespaceSensitivity: 'css',
+    insertPragma: false,
+    bracketSameLine: false,
+    jsxSingleQuote: true,
+    printWidth: 120,
+    proseWrap: 'preserve',
+    quoteProps: 'as-needed',
+    requirePragma: false,
+    semi: false,
+    singleQuote: true,
+    tabWidth: 2,
+    trailingComma: 'none',
+    useTabs: false
+  }

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,13 @@ yarn dev
 This command starts a local development server and opens up a browser window.
 Most changes are reflected live without having to restart the server.
 
+Format the code & linting:
+
+```bash
+yarn format
+yarn lint
+```
+
 ### Build
 
 ```bash

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,10 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "lint": "eslint --max-warnings 0 --fix \"src/**/*.{js,jsx,ts,tsx}\"",
+    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\""
   },
   "dependencies": {
     "@docusaurus/core": "2.4.1",
@@ -30,9 +33,21 @@
     "url": "^0.11.1"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.59.11",
+    "@typescript-eslint/parser": "^5.59.11",
     "@docusaurus/module-type-aliases": "2.4.1",
     "@tsconfig/docusaurus": "^1.0.7",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.0",
+    "eslint": "^8.42.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-import-resolver-typescript": "^3.5.5",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.24",
+    "prettier": "^2.8.8"
   },
   "browserslist": {
     "production": [

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -1,70 +1,60 @@
-import React from "react";
-import clsx from "clsx";
-import styles from "./styles.module.css";
-import Link from "@docusaurus/Link";
+import React from 'react'
+import clsx from 'clsx'
+import styles from './styles.module.css'
 
 type FeatureItem = {
-  title: string;
-  Svg: React.ComponentType<React.ComponentProps<"svg">>;
-  description: JSX.Element;
-};
+  title: string
+  Svg: React.ComponentType<React.ComponentProps<'svg'>>
+  description: JSX.Element
+}
 
 const FeatureList: FeatureItem[] = [
   {
-    title: "Deploy",
-    Svg: require("@site/static/img/deploy.svg").default,
-    description: (
-      <>
-        Setup and and Run DBSP in just a few minutes in a Docker container.
-      </>
-    ),
+    title: 'Deploy',
+    /* eslint-disable */
+    Svg: require('@site/static/img/deploy.svg').default,
+    description: <>Setup and and Run DBSP in just a few minutes in a Docker container.</>
   },
   {
-    title: "Develop",
-    Svg: require("@site/static/img/sql.svg").default,
-    description: (
-      <>
-        Transforms, aggregate, filters and join all your data in-motion using SQL tables and views.
-      </>
-    ),
+    title: 'Develop',
+    /* eslint-disable */
+    Svg: require('@site/static/img/sql.svg').default,
+    description: <>Transforms, aggregate, filters and join all your data in-motion using SQL tables and views.</>
   },
   {
-    title: "Explore",
-    Svg: require("@site/static/img/study.svg").default,
-    description: (
-      <>
-        Study our Demos to see the full potential of DBSP.
-      </>
-    ),
-  },
-];
+    title: 'Explore',
+    /* eslint-disable */
+    Svg: require('@site/static/img/study.svg').default,
+    description: <>Study our Demos to see the full potential of DBSP.</>
+  }
+]
 
 function Feature({ title, Svg, description }: FeatureItem) {
   return (
-    <div className={clsx("col col--4")}>
+    <div className={clsx('col col--4')}>
       <div className={styles.box}>
-        <div className="text--center">
-          <Svg className={styles.featureSvg} role="img" />
+        <div className='text--center'>
+          <Svg className={styles.featureSvg} role='img' />
         </div>
-        <div className="text--center padding-horiz--md">
+        <div className='text--center padding-horiz--md'>
           <h3>{title}</h3>
           <p>{description}</p>
         </div>
       </div>
     </div>
-  );
+  )
 }
 
 export default function HomepageFeatures(): JSX.Element {
   return (
     <section className={styles.features}>
-      <div className="container">
-        <div className={clsx("row")}>
+      <div className='container'>
+        <div className={clsx('row')}>
           {FeatureList.map((props, idx) => (
             <Feature key={idx} {...props} />
           ))}
         </div>
       </div>
     </section>
-  );
+  )
 }

--- a/docs/src/components/HomepageShader/index.tsx
+++ b/docs/src/components/HomepageShader/index.tsx
@@ -1,16 +1,16 @@
-import React, { useRef, useState } from "react";
+import React, { useRef } from 'react'
 
-import * as THREE from "three";
-import { Canvas, useFrame, ThreeElements } from "@react-three/fiber";
+import * as THREE from 'three'
+import { Canvas, useFrame, ThreeElements } from '@react-three/fiber'
 
-function FlowingLinesShader(props: ThreeElements["mesh"]) {
-  const ref = useRef<THREE.Mesh>(null!);
-  var tuniform = {
-    iTime: { type: "f", value: 0.0 },
-    iResolution: { type: "v2", value: new THREE.Vector2(1, 1) },
-  };
+function FlowingLinesShader(props: ThreeElements['mesh']) {
+  const ref = useRef<THREE.Mesh>(null!)
+  const tuniform = {
+    iTime: { type: 'f', value: 0.0 },
+    iResolution: { type: 'v2', value: new THREE.Vector2(1, 1) }
+  }
 
-  useFrame((state, delta) => (tuniform.iTime.value += delta));
+  useFrame((state, delta) => (tuniform.iTime.value += delta))
 
   const vshader = `
   varying vec2 vUv;
@@ -19,7 +19,7 @@ function FlowingLinesShader(props: ThreeElements["mesh"]) {
     vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
     gl_Position = projectionMatrix * mvPosition;
   }
-  `;
+  `
 
   const fshader = `
 varying vec2 vUv;
@@ -131,22 +131,13 @@ void main() {
 
 	gl_FragColor = vec4(color);
 }
-`;
+`
 
   return (
-    <mesh
-      geometry={new THREE.PlaneGeometry(window.outerWidth, 394, 1, 1)}
-      {...props}
-      ref={ref}
-    >
-      <shaderMaterial
-        vertexShader={vshader}
-        fragmentShader={fshader}
-        uniforms={tuniform}
-        side={THREE.DoubleSide}
-      />
+    <mesh geometry={new THREE.PlaneGeometry(window.outerWidth, 394, 1, 1)} {...props} ref={ref}>
+      <shaderMaterial vertexShader={vshader} fragmentShader={fshader} uniforms={tuniform} side={THREE.DoubleSide} />
     </mesh>
-  );
+  )
 }
 
 export function FlowingLines() {
@@ -157,13 +148,13 @@ export function FlowingLines() {
     -1, // bottom
     -1, // near,
     1 // far
-  );
-  camera.lookAt(0, 0, 0);
+  )
+  camera.lookAt(0, 0, 0)
 
   return (
     <Canvas camera={camera}>
       <pointLight position={[10, 10, 10]} />
       <FlowingLinesShader position={[0, -0, 0]} />
     </Canvas>
-  );
+  )
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,49 +1,46 @@
-import React from "react";
-import clsx from "clsx";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import Layout from "@theme/Layout";
-import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import React from 'react'
+import clsx from 'clsx'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import Layout from '@theme/Layout'
+import HomepageFeatures from '@site/src/components/HomepageFeatures'
 
-import Typed from "@site/src/theme/Typed";
-import styles from "./index.module.css";
-import { FlowingLines } from "../components/HomepageShader";
+import Typed from '@site/src/theme/Typed'
+import styles from './index.module.css'
+import { FlowingLines } from '../components/HomepageShader'
 
 function HomepageHeader(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
 
   return (
-    <header className={clsx("hero hero--primary", styles.heroBanner)}>
-      <div className="row">
-        <div className="col col--2"></div>
-        <div className="col col--6">
-          <div className="row">
-            <div className="col col--12">
-              <h1 className="hero__title">{siteConfig.title}</h1>
-              <p className="hero__subtitle">
+    <header className={clsx('hero hero--primary', styles.heroBanner)}>
+      <div className='row'>
+        <div className='col col--2'></div>
+        <div className='col col--6'>
+          <div className='row'>
+            <div className='col col--12'>
+              <h1 className='hero__title'>{siteConfig.title}</h1>
+              <p className='hero__subtitle'>
                 <Typed strings={[siteConfig.tagline]} typeSpeed={75} />
               </p>
             </div>
           </div>
         </div>
-        <div className="col col--12">
+        <div className='col col--12'>
           <FlowingLines />
         </div>
       </div>
     </header>
-  );
+  )
 }
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext()
   return (
-    <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
-    >
+    <Layout title={`Hello from ${siteConfig.title}`} description='Description will go into a meta tag in <head />'>
       <HomepageHeader />
       <main>
         <HomepageFeatures />
       </main>
     </Layout>
-  );
+  )
 }

--- a/docs/src/theme/Typed/index.tsx
+++ b/docs/src/theme/Typed/index.tsx
@@ -1,26 +1,26 @@
-import React, { useRef, useEffect } from "react";
-import Typed, { type TypedOptions } from "typed.js";
+import React, { useRef, useEffect } from 'react'
+import Typed, { type TypedOptions } from 'typed.js'
 
 const ReactTyped = (props: TypedOptions) => {
-  const typeTarget = useRef<HTMLSpanElement>(null);
-  const { strings, typeSpeed } = props;
+  const typeTarget = useRef<HTMLSpanElement>(null)
+  const { strings, typeSpeed } = props
 
   useEffect(() => {
     if (!typeTarget.current) {
-      return;
+      return
     }
 
     const typed = new Typed(typeTarget.current, {
       strings: strings,
-      typeSpeed: typeSpeed ?? 40,
-    });
+      typeSpeed: typeSpeed ?? 40
+    })
 
     return () => {
-      typed.destroy();
-    };
-  }, []);
+      typed.destroy()
+    }
+  }, [strings, typeSpeed])
 
-  return <span ref={typeTarget} />;
-};
+  return <span ref={typeTarget} />
+}
 
-export default ReactTyped;
+export default ReactTyped

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1674,6 +1674,38 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
+  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  dependencies:
+    eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.4.0":
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
+
+"@eslint/eslintrc@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.0.3.tgz#4910db5505f4d503f27774bf356e3704818a0331"
+  integrity sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.5.2"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/js@8.42.0":
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.42.0.tgz#484a1d638de2911e6f5a30c12f49c7e4a3270fb6"
+  integrity sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==
+
 "@faker-js/faker@5.5.3":
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-5.5.3.tgz#18e3af6b8eae7984072bbeb0c0858474d7c4cefe"
@@ -1690,6 +1722,25 @@
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@humanwhocodes/config-array@^0.11.10":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
+  integrity sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.5"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
 "@jest/schemas@^29.4.3":
   version "29.4.3"
@@ -1822,13 +1873,25 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@pkgr/utils@^2.3.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.1.tgz#adf291d0357834c410ce80af16e711b56c7b1cd3"
+  integrity sha512-JOqwkgFEyi+OROIyq7l4Jy28h/WwhDnG/cPkXG2Z1iFbubB6jsHW1NDvmyOzTBxHr3yg68YGirmh1JUgMqa+9w==
+  dependencies:
+    cross-spawn "^7.0.3"
+    fast-glob "^3.2.12"
+    is-glob "^4.0.3"
+    open "^9.1.0"
+    picocolors "^1.0.0"
+    tslib "^2.5.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -2150,6 +2213,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"
   integrity sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
 "@types/mdast@^3.0.0":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.11.tgz#dc130f7e7d9306124286f6d6cee40cf4d14a3dc0"
@@ -2278,6 +2346,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
   integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
+"@types/semver@^7.3.12":
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
+  integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
 "@types/send@*":
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.1.tgz#ed4932b8a2a805f1fe362a70f4e62d0ac994e301"
@@ -2352,6 +2425,90 @@
   integrity sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@typescript-eslint/eslint-plugin@^5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.11.tgz#8d466aa21abea4c3f37129997b198d141f09e76f"
+  integrity sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==
+  dependencies:
+    "@eslint-community/regexpp" "^4.4.0"
+    "@typescript-eslint/scope-manager" "5.59.11"
+    "@typescript-eslint/type-utils" "5.59.11"
+    "@typescript-eslint/utils" "5.59.11"
+    debug "^4.3.4"
+    grapheme-splitter "^1.0.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.59.11.tgz#af7d4b7110e3068ce0b97550736de455e4250103"
+  integrity sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.59.11"
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/typescript-estree" "5.59.11"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz#5d131a67a19189c42598af9fb2ea1165252001ce"
+  integrity sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==
+  dependencies:
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/visitor-keys" "5.59.11"
+
+"@typescript-eslint/type-utils@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz#5eb67121808a84cb57d65a15f48f5bdda25f2346"
+  integrity sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.59.11"
+    "@typescript-eslint/utils" "5.59.11"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/types@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.11.tgz#1a9018fe3c565ba6969561f2a49f330cf1fe8db1"
+  integrity sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==
+
+"@typescript-eslint/typescript-estree@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz#b2caaa31725e17c33970c1197bcd54e3c5f42b9f"
+  integrity sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/visitor-keys" "5.59.11"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.11.tgz#9dbff49dc80bfdd9289f9f33548f2e8db3c59ba1"
+  integrity sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.59.11"
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/typescript-estree" "5.59.11"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
+"@typescript-eslint/visitor-keys@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz#dca561ddad169dc27d62396d64f45b2d2c3ecc56"
+  integrity sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.11"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
@@ -2497,12 +2654,17 @@ acorn-import-assertions@^1.9.0:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
 
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
 acorn-walk@^8.0.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.0.4, acorn@^8.7.1, acorn@^8.8.2:
+acorn@^8.0.4, acorn@^8.7.1, acorn@^8.8.0, acorn@^8.8.2:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -2549,7 +2711,7 @@ ajv@6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.10.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -2662,6 +2824,14 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-buffer-byte-length@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz#fabe8bc193fea865f317fe7807085ee0dee5aead"
+  integrity sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==
+  dependencies:
+    call-bind "^1.0.2"
+    is-array-buffer "^3.0.1"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2672,6 +2842,17 @@ array-flatten@^2.1.2:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
+array-includes@^3.1.5, array-includes@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
+  integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    is-string "^1.0.7"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -2681,6 +2862,37 @@ array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
   integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
+
+array.prototype.flat@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
+  integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.flatmap@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
+  integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
 
 asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
@@ -2718,6 +2930,11 @@ autoprefixer@^10.4.12, autoprefixer@^10.4.7:
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
+
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 axios@^0.25.0:
   version "0.25.0"
@@ -2814,6 +3031,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
+big-integer@^1.6.44:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2885,6 +3107,13 @@ boxen@^6.2.1:
     widest-line "^4.0.1"
     wrap-ansi "^8.0.1"
 
+bplist-parser@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
+  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
+  dependencies:
+    big-integer "^1.6.44"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2922,6 +3151,13 @@ buffer@^6.0.3:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
+
+bundle-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
+  integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
+  dependencies:
+    run-applescript "^5.0.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -3408,7 +3644,7 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "^2.6.11"
 
-cross-spawn@^7.0.3:
+cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -3583,12 +3819,19 @@ debug@2.6.9, debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.4:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -3607,10 +3850,33 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
 deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+default-browser-id@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
+  integrity sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==
+  dependencies:
+    bplist-parser "^0.2.0"
+    untildify "^4.0.0"
+
+default-browser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da"
+  integrity sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==
+  dependencies:
+    bundle-name "^3.0.0"
+    default-browser-id "^3.0.0"
+    execa "^7.1.1"
+    titleize "^3.0.0"
 
 default-gateway@^6.0.3:
   version "6.0.3"
@@ -3629,7 +3895,12 @@ define-lazy-prop@^2.0.0:
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
   integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
 
-define-properties@^1.1.4:
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
+
+define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
   integrity sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==
@@ -3725,6 +3996,20 @@ dns-packet@^5.2.2:
   integrity sha512-rza3UH1LwdHh9qyPXp8lkwpjSNk/AMD3dPytUoRoqnypDUhY0xvbdmVhWOfxO68frEfV9BU8V12Ez7ZsHGZpCQ==
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
+
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 docusaurus-plugin-openapi@^0.6.4:
   version "0.6.4"
@@ -3950,6 +4235,14 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+enhanced-resolve@^5.12.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
+  integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
 enhanced-resolve@^5.14.1:
   version "5.14.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz#de684b6803724477a4af5d74ccae5de52c25f6b3"
@@ -3980,10 +4273,75 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.19.0, es-abstract@^1.20.4:
+  version "1.21.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.21.2.tgz#a56b9695322c8a185dc25975aa3b8ec31d0e7eff"
+  integrity sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==
+  dependencies:
+    array-buffer-byte-length "^1.0.0"
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    es-set-tostringtag "^2.0.1"
+    es-to-primitive "^1.2.1"
+    function.prototype.name "^1.1.5"
+    get-intrinsic "^1.2.0"
+    get-symbol-description "^1.0.0"
+    globalthis "^1.0.3"
+    gopd "^1.0.1"
+    has "^1.0.3"
+    has-property-descriptors "^1.0.0"
+    has-proto "^1.0.1"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.5"
+    is-array-buffer "^3.0.2"
+    is-callable "^1.2.7"
+    is-negative-zero "^2.0.2"
+    is-regex "^1.1.4"
+    is-shared-array-buffer "^1.0.2"
+    is-string "^1.0.7"
+    is-typed-array "^1.1.10"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.4"
+    regexp.prototype.flags "^1.4.3"
+    safe-regex-test "^1.0.0"
+    string.prototype.trim "^1.2.7"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
+    typed-array-length "^1.0.4"
+    unbox-primitive "^1.0.2"
+    which-typed-array "^1.1.9"
+
 es-module-lexer@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.2.1.tgz#ba303831f63e6a394983fde2f97ad77b22324527"
   integrity sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==
+
+es-set-tostringtag@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz#338d502f6f674301d710b80c8592de8a15f09cd8"
+  integrity sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==
+  dependencies:
+    get-intrinsic "^1.1.3"
+    has "^1.0.3"
+    has-tostringtag "^1.0.0"
+
+es-shim-unscopables@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz#702e632193201e3edf8713635d083d378e510241"
+  integrity sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==
+  dependencies:
+    has "^1.0.3"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -4010,7 +4368,101 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
-eslint-scope@5.1.1:
+eslint-config-prettier@^8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz#bfda738d412adc917fd7b038857110efe98c9348"
+  integrity sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==
+
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
+
+eslint-import-resolver-node@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz#83b375187d412324a1963d84fa664377a23eb4d7"
+  integrity sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==
+  dependencies:
+    debug "^3.2.7"
+    is-core-module "^2.11.0"
+    resolve "^1.22.1"
+
+eslint-import-resolver-typescript@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz#0a9034ae7ed94b254a360fbea89187b60ea7456d"
+  integrity sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==
+  dependencies:
+    debug "^4.3.4"
+    enhanced-resolve "^5.12.0"
+    eslint-module-utils "^2.7.4"
+    get-tsconfig "^4.5.0"
+    globby "^13.1.3"
+    is-core-module "^2.11.0"
+    is-glob "^4.0.3"
+    synckit "^0.8.5"
+
+eslint-module-utils@^2.7.4:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz#e439fee65fc33f6bba630ff621efc38ec0375c49"
+  integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@^2.27.5:
+  version "2.27.5"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz#876a6d03f52608a3e5bb439c2550588e51dd6c65"
+  integrity sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    array.prototype.flatmap "^1.3.1"
+    debug "^3.2.7"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.7"
+    eslint-module-utils "^2.7.4"
+    has "^1.0.3"
+    is-core-module "^2.11.0"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.values "^1.1.6"
+    resolve "^1.22.1"
+    semver "^6.3.0"
+    tsconfig-paths "^3.14.1"
+
+eslint-plugin-prettier@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-react-hooks@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
+  integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
+eslint-plugin-react@^7.32.2:
+  version "7.32.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.32.2.tgz#e71f21c7c265ebce01bcbc9d0955170c55571f10"
+  integrity sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
+    doctrine "^2.1.0"
+    estraverse "^5.3.0"
+    jsx-ast-utils "^2.4.1 || ^3.0.0"
+    minimatch "^3.1.2"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
+    prop-types "^15.8.1"
+    resolve "^2.0.0-next.4"
+    semver "^6.3.0"
+    string.prototype.matchall "^4.0.8"
+
+eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -4018,10 +4470,84 @@ eslint-scope@5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
+eslint-scope@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.0.tgz#f21ebdafda02352f103634b96dd47d9f81ca117b"
+  integrity sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
+  integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
+
+eslint@^8.42.0:
+  version "8.42.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.42.0.tgz#7bebdc3a55f9ed7167251fe7259f75219cade291"
+  integrity sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.4.0"
+    "@eslint/eslintrc" "^2.0.3"
+    "@eslint/js" "8.42.0"
+    "@humanwhocodes/config-array" "^0.11.10"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.0"
+    eslint-visitor-keys "^3.4.1"
+    espree "^9.5.2"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+
+espree@^9.5.2:
+  version "9.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.5.2.tgz#e994e7dc33a082a7a82dceaf12883a829353215b"
+  integrity sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.4.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.5.0.tgz#6ce17738de8577694edd7361c57182ac8cb0db0b"
+  integrity sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==
+  dependencies:
+    estraverse "^5.1.0"
 
 esrecurse@^4.3.0:
   version "4.3.0"
@@ -4035,7 +4561,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.2.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -4087,6 +4613,21 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-7.1.1.tgz#3eb3c83d239488e7b409d48e8813b76bb55c9c43"
+  integrity sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^4.3.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
 
 express@^4.17.3:
   version "4.18.2"
@@ -4152,7 +4693,12 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-diff@^1.1.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
+  integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
+
+fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -4167,6 +4713,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-safe-stringify@^2.0.7, fast-safe-stringify@^2.1.1:
   version "2.1.1"
@@ -4230,6 +4781,13 @@ fflate@~0.6.9:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.10.tgz#5f40f9659205936a2d18abf88b2e7781662b6d43"
   integrity sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-loader@^6.2.0:
   version "6.2.0"
@@ -4301,6 +4859,19 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
+flatted@^3.1.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
+  integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
 flux@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/flux/-/flux-4.0.4.tgz#9661182ea81d161ee1a6a6af10d20485ef2ac572"
@@ -4313,6 +4884,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
 
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.3"
@@ -4406,6 +4984,21 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+function.prototype.name@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.5.tgz#cce0505fe1ffb80503e6f9e46cc64e46a12a9621"
+  integrity sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.19.0"
+    functions-have-names "^1.2.2"
+
+functions-have-names@^1.2.2, functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
 gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -4416,7 +5009,7 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
   integrity sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==
@@ -4450,10 +5043,25 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.0.0.tgz#7fdb81c900101fbd564dd5f1a30af5aadc1e58d6"
+  integrity sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.1"
+
+get-tsconfig@^4.5.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.6.0.tgz#e977690993a42f3e320e932427502a40f7af6d05"
+  integrity sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
 
 github-slugger@^1.4.0:
   version "1.5.0"
@@ -4467,7 +5075,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -4519,6 +5127,20 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
+globals@^13.19.0:
+  version "13.20.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
+  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  dependencies:
+    type-fest "^0.20.2"
+
+globalthis@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.3.tgz#5852882a52b80dc301b0660273e1ed082f0b6ccf"
+  integrity sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==
+  dependencies:
+    define-properties "^1.1.3"
+
 globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -4531,7 +5153,7 @@ globby@^11.0.1, globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-globby@^13.1.1:
+globby@^13.1.1, globby@^13.1.3:
   version "13.1.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.4.tgz#2f91c116066bcec152465ba36e5caa4a13c01317"
   integrity sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==
@@ -4541,6 +5163,13 @@ globby@^13.1.1:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^4.0.0"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
 
 got@^9.6.0:
   version "9.6.0"
@@ -4563,6 +5192,16 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+grapheme-splitter@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
+  integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 graphlib@^2.1.8:
   version "2.1.8"
@@ -4593,6 +5232,11 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
+has-bigints@^1.0.1, has-bigints@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
+  integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -4615,10 +5259,17 @@ has-proto@^1.0.1:
   resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.0.1.tgz#1885c1305538958aff469fef37937c22795408e0"
   integrity sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==
 
-has-symbols@^1.0.3:
+has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
+
+has-tostringtag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.0.tgz#7e133818a7d394734f941e73c3d3f9291e658b25"
+  integrity sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==
+  dependencies:
+    has-symbols "^1.0.2"
 
 has-yarn@^2.1.0:
   version "2.1.0"
@@ -4902,6 +5553,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
+  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -4950,7 +5606,7 @@ immer@^9.0.21, immer@^9.0.7:
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
-import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
+import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -5011,6 +5667,15 @@ inline-style-parser@0.1.1:
   resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.1.1.tgz#ec8a3b429274e9c0a1f1c4ffa9453a7fef72cea1"
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
+internal-slot@^1.0.3, internal-slot@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.5.tgz#f2a2ee21f668f8627a4667f309dc0f4fb6674986"
+  integrity sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==
+  dependencies:
+    get-intrinsic "^1.2.0"
+    has "^1.0.3"
+    side-channel "^1.0.4"
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
@@ -5046,10 +5711,26 @@ is-alphanumerical@^1.0.0:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
 
+is-array-buffer@^3.0.1, is-array-buffer@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.2.tgz#f2653ced8412081638ecb0ebbd0c41c6e0aecbbe"
+  integrity sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.2.0"
+    is-typed-array "^1.1.10"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-bigint@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
+  integrity sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==
+  dependencies:
+    has-bigints "^1.0.1"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -5058,10 +5739,23 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
+  integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-buffer@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -5070,12 +5764,19 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.11.0:
+is-core-module@^2.11.0, is-core-module@^2.9.0:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
   integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
   dependencies:
     has "^1.0.3"
+
+is-date-object@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
+  integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-decimal@^1.0.0:
   version "1.0.4"
@@ -5086,6 +5787,11 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
 
 is-extendable@^0.1.0:
   version "0.1.1"
@@ -5102,7 +5808,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -5114,6 +5820,13 @@ is-hexadecimal@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
 
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
+
 is-installed-globally@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
@@ -5122,10 +5835,22 @@ is-installed-globally@^0.4.0:
     global-dirs "^3.0.0"
     is-path-inside "^3.0.2"
 
+is-negative-zero@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
+
 is-npm@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
   integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
+
+is-number-object@^1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.7.tgz#59d50ada4c45251784e9904f5246c742f07a42fc"
+  integrity sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -5147,7 +5872,7 @@ is-path-cwd@^2.2.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-inside@^3.0.2:
+is-path-inside@^3.0.2, is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -5169,6 +5894,14 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-regex@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
+  integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
+  dependencies:
+    call-bind "^1.0.2"
+    has-tostringtag "^1.0.0"
+
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -5179,15 +5912,59 @@ is-root@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
   integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
+is-shared-array-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz#8f259c573b60b6a32d4058a1a07430c0a7344c79"
+  integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
+
+is-string@^1.0.5, is-string@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
+  integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
+  dependencies:
+    has-tostringtag "^1.0.0"
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.9:
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+
 is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
+is-weakref@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
+  dependencies:
+    call-bind "^1.0.2"
 
 is-whitespace-character@^1.0.0:
   version "1.0.4"
@@ -5365,6 +6142,18 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^2.1.2, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -5378,6 +6167,14 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+"jsx-ast-utils@^2.4.1 || ^3.0.0":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz#76b3e6e6cece5c69d49a5792c3d01bd1a0cdc7ea"
+  integrity sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==
+  dependencies:
+    array-includes "^3.1.5"
+    object.assign "^4.1.3"
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -5420,6 +6217,14 @@ leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
   integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lil-gui@~0.17.0:
   version "0.17.0"
@@ -5521,6 +6326,11 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.mergewith@^4.6.1:
   version "4.6.2"
@@ -5774,6 +6584,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
@@ -5791,14 +6606,14 @@ minimalistic-assert@^1.0.0:
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
   integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
-minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1:
+minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -5823,7 +6638,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -5845,6 +6660,16 @@ native-promise-only@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
   integrity sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -5922,6 +6747,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
+  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
+  dependencies:
+    path-key "^4.0.0"
+
 nprogress@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
@@ -5963,7 +6795,7 @@ object-assign@^4.1.0, object-assign@^4.1.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-object-inspect@^1.9.0:
+object-inspect@^1.12.3, object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
@@ -5973,7 +6805,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.1.0:
+object.assign@^4.1.0, object.assign@^4.1.3, object.assign@^4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.4.tgz#9673c7c7c351ab8c4d0b516f4343ebf4dfb7799f"
   integrity sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==
@@ -5982,6 +6814,41 @@ object.assign@^4.1.0:
     define-properties "^1.1.4"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+object.entries@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
+  integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+object.fromentries@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
+  integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+object.hasown@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
+  integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
+  dependencies:
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+object.values@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
+  integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -6014,6 +6881,13 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
 open@^8.0.9, open@^8.4.0:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -6021,6 +6895,16 @@ open@^8.0.9, open@^8.4.0:
   dependencies:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
+open@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
+  integrity sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==
+  dependencies:
+    default-browser "^4.0.0"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
     is-wsl "^2.2.0"
 
 openapi-to-postmanv2@^1.2.1:
@@ -6042,6 +6926,18 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
 
 p-cancelable@^1.0.0:
   version "1.1.0"
@@ -6222,6 +7118,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-loader@^1.0.10:
   version "1.0.12"
@@ -6585,7 +7486,7 @@ postcss@^7.0.5:
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.3.11, postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4.21:
+postcss@^8.3.11, postcss@^8.4.14, postcss@^8.4.17, postcss@^8.4.21, postcss@^8.4.24:
   version "8.4.24"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.24.tgz#f714dba9b2284be3cc07dbd2fc57ee4dc972d2df"
   integrity sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==
@@ -6701,10 +7602,27 @@ postman-url-encoder@3.0.5:
   dependencies:
     punycode "^2.1.1"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-error@^4.0.0:
   version "4.0.0"
@@ -6754,7 +7672,7 @@ prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7149,6 +8067,15 @@ regenerator-transform@^0.15.1:
   dependencies:
     "@babel/runtime" "^7.8.4"
 
+regexp.prototype.flags@^1.4.3:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz#fe7ce25e7e4cca8db37b6634c8a2c7009199b9cb"
+  integrity sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    functions-have-names "^1.2.3"
+
 regexpu-core@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-5.3.2.tgz#11a2b06884f3527aec3e93dbbf4a3b958a95546b"
@@ -7318,12 +8245,26 @@ resolve-pathname@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
   integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
-resolve@^1.1.6, resolve@^1.14.2, resolve@^1.3.2:
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
+resolve@^1.1.6, resolve@^1.14.2, resolve@^1.22.1, resolve@^1.3.2:
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
   dependencies:
     is-core-module "^2.11.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^2.0.0-next.4:
+  version "2.0.0-next.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-2.0.0-next.4.tgz#3d37a113d6429f496ec4752d2a2e58efb1fd4660"
+  integrity sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==
+  dependencies:
+    is-core-module "^2.9.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -7366,6 +8307,13 @@ rtlcss@^3.5.0:
     postcss "^8.3.11"
     strip-json-comments "^3.1.1"
 
+run-applescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
+  integrity sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==
+  dependencies:
+    execa "^5.0.0"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -7389,6 +8337,15 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex-test@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.0.0.tgz#793b874d524eb3640d1873aad03596db2d4f2295"
+  integrity sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==
+  dependencies:
+    call-bind "^1.0.2"
+    get-intrinsic "^1.1.3"
+    is-regex "^1.1.4"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -7660,7 +8617,7 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -7825,6 +8782,47 @@ string-width@^5.0.1:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string.prototype.matchall@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
+  integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    get-intrinsic "^1.1.3"
+    has-symbols "^1.0.3"
+    internal-slot "^1.0.3"
+    regexp.prototype.flags "^1.4.3"
+    side-channel "^1.0.4"
+
+string.prototype.trim@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz#a68352740859f6893f14ce3ef1bb3037f7a90533"
+  integrity sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+string.prototype.trimend@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
+  integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
+string.prototype.trimstart@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
+  integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -7867,12 +8865,22 @@ strip-bom-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom-string/-/strip-bom-string-1.0.0.tgz#e5211e9224369fbb81d633a2f00044dc8cedad92"
   integrity sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
 strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@^3.1.1:
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
+
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -7963,6 +8971,14 @@ svgo@^2.7.0, svgo@^2.8.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
+synckit@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
+  integrity sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==
+  dependencies:
+    "@pkgr/utils" "^2.3.1"
+    tslib "^2.5.0"
+
 tapable@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -8019,6 +9035,11 @@ tiny-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+titleize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
+  integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -8066,10 +9087,39 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
+tsconfig-paths@^3.14.1:
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
+  integrity sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.3.tgz#24944ba2d990940e6e982c4bea147aba80209913"
   integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -8089,6 +9139,15 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed-array-length@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.4.tgz#89d83785e5c4098bec72e08b319651f0eac9c1bb"
+  integrity sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==
+  dependencies:
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    is-typed-array "^1.1.9"
+
 typed.js@^2.0.12:
   version "2.0.16"
   resolved "https://registry.yarnpkg.com/typed.js/-/typed.js-2.0.16.tgz#2ba416821ec8a59521466f405784077eddb1d95e"
@@ -8101,7 +9160,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^5.1.3:
+typescript@^5.1.0:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
   integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
@@ -8110,6 +9169,16 @@ ua-parser-js@^1.0.35:
   version "1.0.35"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.35.tgz#c4ef44343bc3db0a3cbefdf21822f1b1fc1ab011"
   integrity sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==
+
+unbox-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.2.tgz#29032021057d5e6cdbd08c5129c226dff8ed6f9e"
+  integrity sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==
+  dependencies:
+    call-bind "^1.0.2"
+    has-bigints "^1.0.2"
+    has-symbols "^1.0.3"
+    which-boxed-primitive "^1.0.2"
 
 unherit@^1.0.4:
   version "1.1.3"
@@ -8251,6 +9320,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"
@@ -8577,10 +9651,33 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
+
 which-module@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
   integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
+which-typed-array@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
 
 which@^1.3.1:
   version "1.3.1"
@@ -8614,6 +9711,11 @@ wildcard@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==
+
+word-wrap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"

--- a/python/.dockerignore
+++ b/python/.dockerignore
@@ -1,2 +1,0 @@
-/dbsp-api-client
-__pycache__

--- a/python/.earthlyignore
+++ b/python/.earthlyignore
@@ -1,2 +1,0 @@
-dbsp-api-client
-dbsp/__pycache__

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,3 +1,0 @@
-# Uncommenting this for some reason breaks `pip install ./dbsp-api-client`.
-# /dbsp-api-client
-__pycache__

--- a/python/README.md
+++ b/python/README.md
@@ -1,3 +1,82 @@
 # Python bindings for the Database Stream Processor (DBSP) HTTP API
 
 See [project homepage](https://github.com/feldera/dbsp).
+
+## Development
+
+tldr:
+
+```bash
+cargo make --cwd crates/pipeline_manager/ python_test
+```
+
+To avoid installing the library every time you make updates and run the test
+scripts, you can set up a local development environment using a virtual
+environment and then install your library in editable mode. This allows you to
+make changes to the library code and have those changes immediately reflected
+when running your test scripts. Here's how you can do it:
+
+1. Create a virtual environment: Open a terminal/command prompt and navigate to
+   your project directory. Then, create a virtual environment by running the
+   following command in the dbsp base directory:
+
+```bash
+python3 -m venv venv
+```
+
+
+2. Activate the virtual environment: Activate the virtual environment using the
+   appropriate command for your operating system:
+
+- On macOS/Linux:
+
+```bash
+source venv/bin/activate
+```
+
+- On Windows:
+```bash
+venv\Scripts\activate.bat
+```
+
+3. Install your library in editable mode: While the virtual environment is
+   active, navigate to the directory where your library's `pyproject.toml` file
+   is located. Then, install the library in editable mode using `pip` as
+   follows:
+
+```bash
+cd python/dbsp-api-client
+pip install -e .
+cd ..
+pip install -e .
+```
+
+
+This will create a symlink from your virtual environment to your library code,
+allowing changes to be immediately reflected.
+
+4. Run your test scripts: You can now run your test scripts without having to
+   install the library again. The virtual environment will use the locally
+   installed version of your library.
+
+```bash
+cd demo
+bash demo.sh
+```
+
+Whenever you make changes to your library code, you don't need to reinstall it.
+Simply rerun your test scripts, and the changes will be picked up automatically.
+
+Remember to activate the virtual environment every time you work on your project
+or want to run the test scripts.
+
+
+## Regenerate dbsp-api-client code
+
+In case you make changes to the OpenAPI spec (by modifying
+crates/pipeline_manager), you'll need to regenerated the `dbsp-api-client`
+library. To do so, run the following command:
+
+```bash
+cargo make --cwd crates/pipeline_manager/ openapi_python
+```

--- a/python/dbsp-api-client/.gitignore
+++ b/python/dbsp-api-client/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/python/dbsp-api-client/README.md
+++ b/python/dbsp-api-client/README.md
@@ -1,0 +1,89 @@
+# dbsp-api-client
+A client library for accessing DBSP API
+
+## Usage
+First, create a client:
+
+```python
+from dbsp_api_client import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from dbsp_api_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from dbsp_api_client.models import MyDataModel
+from dbsp_api_client.api.my_tag import get_my_data_model
+from dbsp_api_client.types import Response
+
+my_data: MyDataModel = get_my_data_model.sync(client=client)
+# or if you need more info (e.g. status_code)
+response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from dbsp_api_client.models import MyDataModel
+from dbsp_api_client.api.my_tag import get_my_data_model
+from dbsp_api_client.types import Response
+
+my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
+```
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info.
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `dbsp_api_client.api.default`
+
+## Building / publishing this Client
+This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:
+1. Update the metadata in pyproject.toml (e.g. authors, version)
+1. If you're using a private repository, configure it with Poetry
+    1. `poetry config repositories.<your-repository-name> <url-to-your-repository>`
+    1. `poetry config http-basic.<your-repository-name> <username> <password>`
+1. Publish the client with `poetry publish --build -r <your-repository-name>` or, if for public PyPI, just `poetry publish --build`
+
+If you want to install this client into another project without publishing it (e.g. for development) then:
+1. If that project **is using Poetry**, you can simply do `poetry add <path-to-this-client>` from that project
+1. If that project is not using Poetry:
+    1. Build a wheel with `poetry build -f wheel`
+    1. Install that wheel from the other project `pip install <path-to-wheel>`

--- a/python/dbsp-api-client/dbsp_api_client/__init__.py
+++ b/python/dbsp-api-client/dbsp_api_client/__init__.py
@@ -1,0 +1,7 @@
+""" A client library for accessing DBSP API """
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/python/dbsp-api-client/dbsp_api_client/api/__init__.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+""" Contains methods for accessing the API """

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/connector_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/connector_status.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.connector_descr import ConnectorDescr
+from ...models.error_response import ErrorResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Dict[str, Any]:
+    url = "{}/v0/connector".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["id"] = id
+
+    params["name"] = name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ConnectorDescr, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = ConnectorDescr.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ConnectorDescr, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ConnectorDescr, ErrorResponse]]:
+    """Returns connector descriptor.
+
+     Returns connector descriptor.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ConnectorDescr, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ConnectorDescr, ErrorResponse]]:
+    """Returns connector descriptor.
+
+     Returns connector descriptor.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ConnectorDescr, ErrorResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        id=id,
+        name=name,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ConnectorDescr, ErrorResponse]]:
+    """Returns connector descriptor.
+
+     Returns connector descriptor.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ConnectorDescr, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ConnectorDescr, ErrorResponse]]:
+    """Returns connector descriptor.
+
+     Returns connector descriptor.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ConnectorDescr, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            id=id,
+            name=name,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/delete_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/delete_connector.py
@@ -1,0 +1,170 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    connector_id: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/connectors/{connector_id}".format(client.base_url, connector_id=connector_id)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "delete",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = cast(Any, None)
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    connector_id: str,
+    *,
+    client: Client,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Delete existing connector.
+
+     Delete existing connector.
+
+    Args:
+        connector_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        connector_id=connector_id,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    connector_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Delete existing connector.
+
+     Delete existing connector.
+
+    Args:
+        connector_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return sync_detailed(
+        connector_id=connector_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    connector_id: str,
+    *,
+    client: Client,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Delete existing connector.
+
+     Delete existing connector.
+
+    Args:
+        connector_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        connector_id=connector_id,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    connector_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Delete existing connector.
+
+     Delete existing connector.
+
+    Args:
+        connector_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            connector_id=connector_id,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/list_connectors.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/list_connectors.py
@@ -1,0 +1,151 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.connector_descr import ConnectorDescr
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/connectors".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List["ConnectorDescr"]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = ConnectorDescr.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[List["ConnectorDescr"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+) -> Response[List["ConnectorDescr"]]:
+    """Enumerate the connector database.
+
+     Enumerate the connector database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['ConnectorDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+) -> Optional[List["ConnectorDescr"]]:
+    """Enumerate the connector database.
+
+     Enumerate the connector database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['ConnectorDescr']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+) -> Response[List["ConnectorDescr"]]:
+    """Enumerate the connector database.
+
+     Enumerate the connector database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['ConnectorDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> Optional[List["ConnectorDescr"]]:
+    """Enumerate the connector database.
+
+     Enumerate the connector database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['ConnectorDescr']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/new_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/new_connector.py
@@ -1,0 +1,171 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.new_connector_request import NewConnectorRequest
+from ...models.new_connector_response import NewConnectorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: NewConnectorRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/connectors".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[NewConnectorResponse]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = NewConnectorResponse.from_dict(response.json())
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[NewConnectorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: NewConnectorRequest,
+) -> Response[NewConnectorResponse]:
+    """Create a new connector configuration.
+
+     Create a new connector configuration.
+
+    Args:
+        json_body (NewConnectorRequest): Request to create a new connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[NewConnectorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: NewConnectorRequest,
+) -> Optional[NewConnectorResponse]:
+    """Create a new connector configuration.
+
+     Create a new connector configuration.
+
+    Args:
+        json_body (NewConnectorRequest): Request to create a new connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        NewConnectorResponse
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: NewConnectorRequest,
+) -> Response[NewConnectorResponse]:
+    """Create a new connector configuration.
+
+     Create a new connector configuration.
+
+    Args:
+        json_body (NewConnectorRequest): Request to create a new connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[NewConnectorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: NewConnectorRequest,
+) -> Optional[NewConnectorResponse]:
+    """Create a new connector configuration.
+
+     Create a new connector configuration.
+
+    Args:
+        json_body (NewConnectorRequest): Request to create a new connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        NewConnectorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/update_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/update_connector.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.update_connector_request import UpdateConnectorRequest
+from ...models.update_connector_response import UpdateConnectorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: UpdateConnectorRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/connectors".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "patch",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Optional[Union[ErrorResponse, UpdateConnectorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = UpdateConnectorResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[ErrorResponse, UpdateConnectorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: UpdateConnectorRequest,
+) -> Response[Union[ErrorResponse, UpdateConnectorResponse]]:
+    """Update existing connector.
+
+     Update existing connector.
+
+    Updates config name and, optionally, code.
+    On success, increments config version by 1.
+
+    Args:
+        json_body (UpdateConnectorRequest): Request to update an existing data-connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdateConnectorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: UpdateConnectorRequest,
+) -> Optional[Union[ErrorResponse, UpdateConnectorResponse]]:
+    """Update existing connector.
+
+     Update existing connector.
+
+    Updates config name and, optionally, code.
+    On success, increments config version by 1.
+
+    Args:
+        json_body (UpdateConnectorRequest): Request to update an existing data-connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdateConnectorResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: UpdateConnectorRequest,
+) -> Response[Union[ErrorResponse, UpdateConnectorResponse]]:
+    """Update existing connector.
+
+     Update existing connector.
+
+    Updates config name and, optionally, code.
+    On success, increments config version by 1.
+
+    Args:
+        json_body (UpdateConnectorRequest): Request to update an existing data-connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdateConnectorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: UpdateConnectorRequest,
+) -> Optional[Union[ErrorResponse, UpdateConnectorResponse]]:
+    """Update existing connector.
+
+     Update existing connector.
+
+    Updates config name and, optionally, code.
+    On success, increments config version by 1.
+
+    Args:
+        json_body (UpdateConnectorRequest): Request to update an existing data-connector.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdateConnectorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_input.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_input.py
@@ -1,0 +1,189 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pipeline_id: str,
+    connector_name: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines/{pipeline_id}/connector/{connector_name}".format(
+        client.base_url, pipeline_id=pipeline_id, connector_name=connector_name
+    )
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, str]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = cast(str, response.json())
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, str]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pipeline_id: str,
+    connector_name: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Connect to an HTTP input/output websocket
+
+     Connect to an HTTP input/output websocket
+
+    Args:
+        pipeline_id (str):
+        connector_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        connector_name=connector_name,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pipeline_id: str,
+    connector_name: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Connect to an HTTP input/output websocket
+
+     Connect to an HTTP input/output websocket
+
+    Args:
+        pipeline_id (str):
+        connector_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return sync_detailed(
+        pipeline_id=pipeline_id,
+        connector_name=connector_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pipeline_id: str,
+    connector_name: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Connect to an HTTP input/output websocket
+
+     Connect to an HTTP input/output websocket
+
+    Args:
+        pipeline_id (str):
+        connector_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        connector_name=connector_name,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pipeline_id: str,
+    connector_name: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Connect to an HTTP input/output websocket
+
+     Connect to an HTTP input/output websocket
+
+    Args:
+        pipeline_id (str):
+        connector_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return (
+        await asyncio_detailed(
+            pipeline_id=pipeline_id,
+            connector_name=connector_name,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/list_pipelines.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/list_pipelines.py
@@ -1,0 +1,151 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.pipeline_descr import PipelineDescr
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List["PipelineDescr"]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = PipelineDescr.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[List["PipelineDescr"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+) -> Response[List["PipelineDescr"]]:
+    """List pipelines.
+
+     List pipelines.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['PipelineDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+) -> Optional[List["PipelineDescr"]]:
+    """List pipelines.
+
+     List pipelines.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['PipelineDescr']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+) -> Response[List["PipelineDescr"]]:
+    """List pipelines.
+
+     List pipelines.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['PipelineDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> Optional[List["PipelineDescr"]]:
+    """List pipelines.
+
+     List pipelines.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['PipelineDescr']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/new_pipeline.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/new_pipeline.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.new_pipeline_request import NewPipelineRequest
+from ...models.new_pipeline_response import NewPipelineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: NewPipelineRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, NewPipelineResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = NewPipelineResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, NewPipelineResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: NewPipelineRequest,
+) -> Response[Union[ErrorResponse, NewPipelineResponse]]:
+    """Create a new program configuration.
+
+     Create a new program configuration.
+
+    Args:
+        json_body (NewPipelineRequest): Request to create a new program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, NewPipelineResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: NewPipelineRequest,
+) -> Optional[Union[ErrorResponse, NewPipelineResponse]]:
+    """Create a new program configuration.
+
+     Create a new program configuration.
+
+    Args:
+        json_body (NewPipelineRequest): Request to create a new program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, NewPipelineResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: NewPipelineRequest,
+) -> Response[Union[ErrorResponse, NewPipelineResponse]]:
+    """Create a new program configuration.
+
+     Create a new program configuration.
+
+    Args:
+        json_body (NewPipelineRequest): Request to create a new program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, NewPipelineResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: NewPipelineRequest,
+) -> Optional[Union[ErrorResponse, NewPipelineResponse]]:
+    """Create a new program configuration.
+
+     Create a new program configuration.
+
+    Args:
+        json_body (NewPipelineRequest): Request to create a new program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, NewPipelineResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_action.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_action.py
@@ -1,0 +1,227 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pipeline_id: str,
+    action: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines/{pipeline_id}/{action}".format(client.base_url, pipeline_id=pipeline_id, action=action)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, str]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = cast(str, response.json())
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, str]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pipeline_id: str,
+    action: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Perform action on a pipeline.
+
+     Perform action on a pipeline.
+
+    - 'deploy': Run a new pipeline. Deploy a pipeline for the specified program
+    and configuration. This is a synchronous endpoint, which sends a response
+    once the pipeline has been initialized.
+    - 'pause': Pause the pipeline.
+    - 'start': Resume the paused pipeline.
+    - 'shutdown': Terminate the execution of a pipeline. Sends a termination
+    request to the pipeline process. Returns immediately, without waiting for
+    the pipeline to terminate (which can take several seconds). The pipeline is
+    not deleted from the database, but its `status` is set to `shutdown`.
+
+    Args:
+        pipeline_id (str):
+        action (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        action=action,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pipeline_id: str,
+    action: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Perform action on a pipeline.
+
+     Perform action on a pipeline.
+
+    - 'deploy': Run a new pipeline. Deploy a pipeline for the specified program
+    and configuration. This is a synchronous endpoint, which sends a response
+    once the pipeline has been initialized.
+    - 'pause': Pause the pipeline.
+    - 'start': Resume the paused pipeline.
+    - 'shutdown': Terminate the execution of a pipeline. Sends a termination
+    request to the pipeline process. Returns immediately, without waiting for
+    the pipeline to terminate (which can take several seconds). The pipeline is
+    not deleted from the database, but its `status` is set to `shutdown`.
+
+    Args:
+        pipeline_id (str):
+        action (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return sync_detailed(
+        pipeline_id=pipeline_id,
+        action=action,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pipeline_id: str,
+    action: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Perform action on a pipeline.
+
+     Perform action on a pipeline.
+
+    - 'deploy': Run a new pipeline. Deploy a pipeline for the specified program
+    and configuration. This is a synchronous endpoint, which sends a response
+    once the pipeline has been initialized.
+    - 'pause': Pause the pipeline.
+    - 'start': Resume the paused pipeline.
+    - 'shutdown': Terminate the execution of a pipeline. Sends a termination
+    request to the pipeline process. Returns immediately, without waiting for
+    the pipeline to terminate (which can take several seconds). The pipeline is
+    not deleted from the database, but its `status` is set to `shutdown`.
+
+    Args:
+        pipeline_id (str):
+        action (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        action=action,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pipeline_id: str,
+    action: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Perform action on a pipeline.
+
+     Perform action on a pipeline.
+
+    - 'deploy': Run a new pipeline. Deploy a pipeline for the specified program
+    and configuration. This is a synchronous endpoint, which sends a response
+    once the pipeline has been initialized.
+    - 'pause': Pause the pipeline.
+    - 'start': Resume the paused pipeline.
+    - 'shutdown': Terminate the execution of a pipeline. Sends a termination
+    request to the pipeline process. Returns immediately, without waiting for
+    the pipeline to terminate (which can take several seconds). The pipeline is
+    not deleted from the database, but its `status` is set to `shutdown`.
+
+    Args:
+        pipeline_id (str):
+        action (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return (
+        await asyncio_detailed(
+            pipeline_id=pipeline_id,
+            action=action,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_delete.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_delete.py
@@ -1,0 +1,186 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines/{pipeline_id}".format(client.base_url, pipeline_id=pipeline_id)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "delete",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, str]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = cast(str, response.json())
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR:
+        response_500 = ErrorResponse.from_dict(response.json())
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, str]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Terminate and delete a pipeline.
+
+     Terminate and delete a pipeline.
+
+    Shut down the pipeline if it is still running and delete it from
+    the database.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Terminate and delete a pipeline.
+
+     Terminate and delete a pipeline.
+
+    Shut down the pipeline if it is still running and delete it from
+    the database.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return sync_detailed(
+        pipeline_id=pipeline_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, str]]:
+    """Terminate and delete a pipeline.
+
+     Terminate and delete a pipeline.
+
+    Shut down the pipeline if it is still running and delete it from
+    the database.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, str]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, str]]:
+    """Terminate and delete a pipeline.
+
+     Terminate and delete a pipeline.
+
+    Shut down the pipeline if it is still running and delete it from
+    the database.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, str]
+    """
+
+    return (
+        await asyncio_detailed(
+            pipeline_id=pipeline_id,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_stats.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_stats.py
@@ -1,0 +1,180 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.pipeline_stats_response_200 import PipelineStatsResponse200
+from ...types import Response
+
+
+def _get_kwargs(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines/{pipeline_id}/stats".format(client.base_url, pipeline_id=pipeline_id)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Optional[Union[ErrorResponse, PipelineStatsResponse200]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = PipelineStatsResponse200.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[ErrorResponse, PipelineStatsResponse200]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, PipelineStatsResponse200]]:
+    """Retrieve pipeline metrics and performance counters.
+
+     Retrieve pipeline metrics and performance counters.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, PipelineStatsResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, PipelineStatsResponse200]]:
+    """Retrieve pipeline metrics and performance counters.
+
+     Retrieve pipeline metrics and performance counters.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, PipelineStatsResponse200]
+    """
+
+    return sync_detailed(
+        pipeline_id=pipeline_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, PipelineStatsResponse200]]:
+    """Retrieve pipeline metrics and performance counters.
+
+     Retrieve pipeline metrics and performance counters.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, PipelineStatsResponse200]]
+    """
+
+    kwargs = _get_kwargs(
+        pipeline_id=pipeline_id,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pipeline_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, PipelineStatsResponse200]]:
+    """Retrieve pipeline metrics and performance counters.
+
+     Retrieve pipeline metrics and performance counters.
+
+    Args:
+        pipeline_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, PipelineStatsResponse200]
+    """
+
+    return (
+        await asyncio_detailed(
+            pipeline_id=pipeline_id,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_status.py
@@ -1,0 +1,197 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.pipeline_descr import PipelineDescr
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipeline".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["id"] = id
+
+    params["name"] = name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, PipelineDescr]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = PipelineDescr.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, PipelineDescr]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ErrorResponse, PipelineDescr]]:
+    """Retrieve pipeline metadata.
+
+     Retrieve pipeline metadata.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, PipelineDescr]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ErrorResponse, PipelineDescr]]:
+    """Retrieve pipeline metadata.
+
+     Retrieve pipeline metadata.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, PipelineDescr]
+    """
+
+    return sync_detailed(
+        client=client,
+        id=id,
+        name=name,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ErrorResponse, PipelineDescr]]:
+    """Retrieve pipeline metadata.
+
+     Retrieve pipeline metadata.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, PipelineDescr]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ErrorResponse, PipelineDescr]]:
+    """Retrieve pipeline metadata.
+
+     Retrieve pipeline metadata.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, PipelineDescr]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            id=id,
+            name=name,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/update_pipeline.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/update_pipeline.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.update_pipeline_request import UpdatePipelineRequest
+from ...models.update_pipeline_response import UpdatePipelineResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: UpdatePipelineRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/pipelines".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "patch",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Optional[Union[ErrorResponse, UpdatePipelineResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = UpdatePipelineResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[ErrorResponse, UpdatePipelineResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: UpdatePipelineRequest,
+) -> Response[Union[ErrorResponse, UpdatePipelineResponse]]:
+    """Update existing program configuration.
+
+     Update existing program configuration.
+
+    Updates program config name, description and code and, optionally, config
+    and connectors. On success, increments config version by 1.
+
+    Args:
+        json_body (UpdatePipelineRequest): Request to update an existing program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdatePipelineResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: UpdatePipelineRequest,
+) -> Optional[Union[ErrorResponse, UpdatePipelineResponse]]:
+    """Update existing program configuration.
+
+     Update existing program configuration.
+
+    Updates program config name, description and code and, optionally, config
+    and connectors. On success, increments config version by 1.
+
+    Args:
+        json_body (UpdatePipelineRequest): Request to update an existing program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdatePipelineResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: UpdatePipelineRequest,
+) -> Response[Union[ErrorResponse, UpdatePipelineResponse]]:
+    """Update existing program configuration.
+
+     Update existing program configuration.
+
+    Updates program config name, description and code and, optionally, config
+    and connectors. On success, increments config version by 1.
+
+    Args:
+        json_body (UpdatePipelineRequest): Request to update an existing program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdatePipelineResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: UpdatePipelineRequest,
+) -> Optional[Union[ErrorResponse, UpdatePipelineResponse]]:
+    """Update existing program configuration.
+
+     Update existing program configuration.
+
+    Updates program config name, description and code and, optionally, config
+    and connectors. On success, increments config version by 1.
+
+    Args:
+        json_body (UpdatePipelineRequest): Request to update an existing program configuration.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdatePipelineResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/cancel_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/cancel_program.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.cancel_program_request import CancelProgramRequest
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: CancelProgramRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs/compile".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "delete",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, ErrorResponse]]:
+    if response.status_code == HTTPStatus.ACCEPTED:
+        response_202 = cast(Any, None)
+        return response_202
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: CancelProgramRequest,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Cancel outstanding compilation request.
+
+     Cancel outstanding compilation request.
+
+    The client should poll the `/program_status` endpoint
+    to determine when the cancelation request completes.
+
+    Args:
+        json_body (CancelProgramRequest): Request to cancel ongoing program compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: CancelProgramRequest,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Cancel outstanding compilation request.
+
+     Cancel outstanding compilation request.
+
+    The client should poll the `/program_status` endpoint
+    to determine when the cancelation request completes.
+
+    Args:
+        json_body (CancelProgramRequest): Request to cancel ongoing program compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: CancelProgramRequest,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Cancel outstanding compilation request.
+
+     Cancel outstanding compilation request.
+
+    The client should poll the `/program_status` endpoint
+    to determine when the cancelation request completes.
+
+    Args:
+        json_body (CancelProgramRequest): Request to cancel ongoing program compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: CancelProgramRequest,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Cancel outstanding compilation request.
+
+     Cancel outstanding compilation request.
+
+    The client should poll the `/program_status` endpoint
+    to determine when the cancelation request completes.
+
+    Args:
+        json_body (CancelProgramRequest): Request to cancel ongoing program compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/compile_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/compile_program.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.compile_program_request import CompileProgramRequest
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: CompileProgramRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs/compile".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, ErrorResponse]]:
+    if response.status_code == HTTPStatus.ACCEPTED:
+        response_202 = cast(Any, None)
+        return response_202
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: CompileProgramRequest,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Queue program for compilation.
+
+     Queue program for compilation.
+
+    The client should poll the `/program_status` endpoint
+    for compilation results.
+
+    Args:
+        json_body (CompileProgramRequest): Request to queue a program for compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: CompileProgramRequest,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Queue program for compilation.
+
+     Queue program for compilation.
+
+    The client should poll the `/program_status` endpoint
+    for compilation results.
+
+    Args:
+        json_body (CompileProgramRequest): Request to queue a program for compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: CompileProgramRequest,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Queue program for compilation.
+
+     Queue program for compilation.
+
+    The client should poll the `/program_status` endpoint
+    for compilation results.
+
+    Args:
+        json_body (CompileProgramRequest): Request to queue a program for compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: CompileProgramRequest,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Queue program for compilation.
+
+     Queue program for compilation.
+
+    The client should poll the `/program_status` endpoint
+    for compilation results.
+
+    Args:
+        json_body (CompileProgramRequest): Request to queue a program for compilation.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/delete_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/delete_program.py
@@ -1,0 +1,178 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union, cast
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    program_id: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs/{program_id}".format(client.base_url, program_id=program_id)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "delete",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[Any, ErrorResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = cast(Any, None)
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[Any, ErrorResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    program_id: str,
+    *,
+    client: Client,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Delete a program.
+
+     Delete a program.
+
+    Deletes all pipelines and configs associated with the program.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_id=program_id,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    program_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Delete a program.
+
+     Delete a program.
+
+    Deletes all pipelines and configs associated with the program.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return sync_detailed(
+        program_id=program_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    program_id: str,
+    *,
+    client: Client,
+) -> Response[Union[Any, ErrorResponse]]:
+    """Delete a program.
+
+     Delete a program.
+
+    Deletes all pipelines and configs associated with the program.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, ErrorResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_id=program_id,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    program_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[Any, ErrorResponse]]:
+    """Delete a program.
+
+     Delete a program.
+
+    Deletes all pipelines and configs associated with the program.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, ErrorResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            program_id=program_id,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/list_programs.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/list_programs.py
@@ -1,0 +1,151 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.program_descr import ProgramDescr
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[List["ProgramDescr"]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = ProgramDescr.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[List["ProgramDescr"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+) -> Response[List["ProgramDescr"]]:
+    """Enumerate the program database.
+
+     Enumerate the program database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['ProgramDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+) -> Optional[List["ProgramDescr"]]:
+    """Enumerate the program database.
+
+     Enumerate the program database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['ProgramDescr']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+) -> Response[List["ProgramDescr"]]:
+    """Enumerate the program database.
+
+     Enumerate the program database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[List['ProgramDescr']]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+) -> Optional[List["ProgramDescr"]]:
+    """Enumerate the program database.
+
+     Enumerate the program database.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        List['ProgramDescr']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/new_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/new_program.py
@@ -1,0 +1,192 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.new_program_request import NewProgramRequest
+from ...models.new_program_response import NewProgramResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: NewProgramRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "post",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, NewProgramResponse]]:
+    if response.status_code == HTTPStatus.CREATED:
+        response_201 = NewProgramResponse.from_dict(response.json())
+
+        return response_201
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, NewProgramResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: NewProgramRequest,
+) -> Response[Union[ErrorResponse, NewProgramResponse]]:
+    """Create a new program.
+
+     Create a new program.
+
+    If the `overwrite_existing` flag is set in the request and a program with
+    the same name already exists, all pipelines associated with that program and
+    the program itself will be deleted.
+
+    Args:
+        json_body (NewProgramRequest): Request to create a new DBSP program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, NewProgramResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: NewProgramRequest,
+) -> Optional[Union[ErrorResponse, NewProgramResponse]]:
+    """Create a new program.
+
+     Create a new program.
+
+    If the `overwrite_existing` flag is set in the request and a program with
+    the same name already exists, all pipelines associated with that program and
+    the program itself will be deleted.
+
+    Args:
+        json_body (NewProgramRequest): Request to create a new DBSP program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, NewProgramResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: NewProgramRequest,
+) -> Response[Union[ErrorResponse, NewProgramResponse]]:
+    """Create a new program.
+
+     Create a new program.
+
+    If the `overwrite_existing` flag is set in the request and a program with
+    the same name already exists, all pipelines associated with that program and
+    the program itself will be deleted.
+
+    Args:
+        json_body (NewProgramRequest): Request to create a new DBSP program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, NewProgramResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: NewProgramRequest,
+) -> Optional[Union[ErrorResponse, NewProgramResponse]]:
+    """Create a new program.
+
+     Create a new program.
+
+    If the `overwrite_existing` flag is set in the request and a program with
+    the same name already exists, all pipelines associated with that program and
+    the program itself will be deleted.
+
+    Args:
+        json_body (NewProgramRequest): Request to create a new DBSP program.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, NewProgramResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/program_code.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/program_code.py
@@ -1,0 +1,176 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.program_code_response import ProgramCodeResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    program_id: str,
+    *,
+    client: Client,
+) -> Dict[str, Any]:
+    url = "{}/v0/program/{program_id}/code".format(client.base_url, program_id=program_id)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, ProgramCodeResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = ProgramCodeResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, ProgramCodeResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    program_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, ProgramCodeResponse]]:
+    """Returns the latest SQL source code of the program along with its meta-data.
+
+     Returns the latest SQL source code of the program along with its meta-data.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, ProgramCodeResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_id=program_id,
+        client=client,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    program_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, ProgramCodeResponse]]:
+    """Returns the latest SQL source code of the program along with its meta-data.
+
+     Returns the latest SQL source code of the program along with its meta-data.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, ProgramCodeResponse]
+    """
+
+    return sync_detailed(
+        program_id=program_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    program_id: str,
+    *,
+    client: Client,
+) -> Response[Union[ErrorResponse, ProgramCodeResponse]]:
+    """Returns the latest SQL source code of the program along with its meta-data.
+
+     Returns the latest SQL source code of the program along with its meta-data.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, ProgramCodeResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        program_id=program_id,
+        client=client,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    program_id: str,
+    *,
+    client: Client,
+) -> Optional[Union[ErrorResponse, ProgramCodeResponse]]:
+    """Returns the latest SQL source code of the program along with its meta-data.
+
+     Returns the latest SQL source code of the program along with its meta-data.
+
+    Args:
+        program_id (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, ProgramCodeResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            program_id=program_id,
+            client=client,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/program_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/program_status.py
@@ -1,0 +1,201 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.program_descr import ProgramDescr
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Dict[str, Any]:
+    url = "{}/v0/program".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {}
+    params["id"] = id
+
+    params["name"] = name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    return {
+        "method": "get",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "params": params,
+    }
+
+
+def _parse_response(*, client: Client, response: httpx.Response) -> Optional[Union[ErrorResponse, ProgramDescr]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = ProgramDescr.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = ErrorResponse.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Client, response: httpx.Response) -> Response[Union[ErrorResponse, ProgramDescr]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ErrorResponse, ProgramDescr]]:
+    """Returns program descriptor, including current program version and
+
+     Returns program descriptor, including current program version and
+    compilation status.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, ProgramDescr]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ErrorResponse, ProgramDescr]]:
+    """Returns program descriptor, including current program version and
+
+     Returns program descriptor, including current program version and
+    compilation status.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, ProgramDescr]
+    """
+
+    return sync_detailed(
+        client=client,
+        id=id,
+        name=name,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Response[Union[ErrorResponse, ProgramDescr]]:
+    """Returns program descriptor, including current program version and
+
+     Returns program descriptor, including current program version and
+    compilation status.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, ProgramDescr]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        id=id,
+        name=name,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    id: Union[Unset, None, str] = UNSET,
+    name: Union[Unset, None, str] = UNSET,
+) -> Optional[Union[ErrorResponse, ProgramDescr]]:
+    """Returns program descriptor, including current program version and
+
+     Returns program descriptor, including current program version and
+    compilation status.
+
+    Args:
+        id (Union[Unset, None, str]):
+        name (Union[Unset, None, str]):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, ProgramDescr]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            id=id,
+            name=name,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/api/program/update_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/update_program.py
@@ -1,0 +1,204 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import Client
+from ...models.error_response import ErrorResponse
+from ...models.update_program_request import UpdateProgramRequest
+from ...models.update_program_response import UpdateProgramResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    json_body: UpdateProgramRequest,
+) -> Dict[str, Any]:
+    url = "{}/v0/programs".format(client.base_url)
+
+    headers: Dict[str, str] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "method": "patch",
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "follow_redirects": client.follow_redirects,
+        "json": json_json_body,
+    }
+
+
+def _parse_response(
+    *, client: Client, response: httpx.Response
+) -> Optional[Union[ErrorResponse, UpdateProgramResponse]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = UpdateProgramResponse.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = ErrorResponse.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = ErrorResponse.from_dict(response.json())
+
+        return response_409
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Client, response: httpx.Response
+) -> Response[Union[ErrorResponse, UpdateProgramResponse]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    json_body: UpdateProgramRequest,
+) -> Response[Union[ErrorResponse, UpdateProgramResponse]]:
+    """Change program code and/or name.
+
+     Change program code and/or name.
+
+    If program code changes, any ongoing compilation gets cancelled,
+    program status is reset to `None`, and program version
+    is incremented by 1.  Changing program name only doesn't affect its
+    version or the compilation process.
+
+    Args:
+        json_body (UpdateProgramRequest): Update program request.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdateProgramResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    response = httpx.request(
+        verify=client.verify_ssl,
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    json_body: UpdateProgramRequest,
+) -> Optional[Union[ErrorResponse, UpdateProgramResponse]]:
+    """Change program code and/or name.
+
+     Change program code and/or name.
+
+    If program code changes, any ongoing compilation gets cancelled,
+    program status is reset to `None`, and program version
+    is incremented by 1.  Changing program name only doesn't affect its
+    version or the compilation process.
+
+    Args:
+        json_body (UpdateProgramRequest): Update program request.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdateProgramResponse]
+    """
+
+    return sync_detailed(
+        client=client,
+        json_body=json_body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    json_body: UpdateProgramRequest,
+) -> Response[Union[ErrorResponse, UpdateProgramResponse]]:
+    """Change program code and/or name.
+
+     Change program code and/or name.
+
+    If program code changes, any ongoing compilation gets cancelled,
+    program status is reset to `None`, and program version
+    is incremented by 1.  Changing program name only doesn't affect its
+    version or the compilation process.
+
+    Args:
+        json_body (UpdateProgramRequest): Update program request.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[ErrorResponse, UpdateProgramResponse]]
+    """
+
+    kwargs = _get_kwargs(
+        client=client,
+        json_body=json_body,
+    )
+
+    async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
+        response = await _client.request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    json_body: UpdateProgramRequest,
+) -> Optional[Union[ErrorResponse, UpdateProgramResponse]]:
+    """Change program code and/or name.
+
+     Change program code and/or name.
+
+    If program code changes, any ongoing compilation gets cancelled,
+    program status is reset to `None`, and program version
+    is incremented by 1.  Changing program name only doesn't affect its
+    version or the compilation process.
+
+    Args:
+        json_body (UpdateProgramRequest): Update program request.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[ErrorResponse, UpdateProgramResponse]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            json_body=json_body,
+        )
+    ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/client.py
+++ b/python/dbsp-api-client/dbsp_api_client/client.py
@@ -1,0 +1,66 @@
+import ssl
+from typing import Dict, Union
+
+import attr
+
+
+@attr.s(auto_attribs=True)
+class Client:
+    """A class for keeping track of data related to the API
+
+    Attributes:
+        base_url: The base URL for the API, all requests are made to a relative path to this URL
+        cookies: A dictionary of cookies to be sent with every request
+        headers: A dictionary of headers to be sent with every request
+        timeout: The maximum amount of a time in seconds a request can take. API functions will raise
+            httpx.TimeoutException if this is exceeded.
+        verify_ssl: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+            but can be set to False for testing purposes.
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document.
+        follow_redirects: Whether or not to follow redirects. Default value is False.
+    """
+
+    base_url: str
+    cookies: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
+    headers: Dict[str, str] = attr.ib(factory=dict, kw_only=True)
+    timeout: float = attr.ib(5.0, kw_only=True)
+    verify_ssl: Union[str, bool, ssl.SSLContext] = attr.ib(True, kw_only=True)
+    raise_on_unexpected_status: bool = attr.ib(False, kw_only=True)
+    follow_redirects: bool = attr.ib(False, kw_only=True)
+
+    def get_headers(self) -> Dict[str, str]:
+        """Get headers to be used in all endpoints"""
+        return {**self.headers}
+
+    def with_headers(self, headers: Dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        return attr.evolve(self, headers={**self.headers, **headers})
+
+    def get_cookies(self) -> Dict[str, str]:
+        return {**self.cookies}
+
+    def with_cookies(self, cookies: Dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        return attr.evolve(self, cookies={**self.cookies, **cookies})
+
+    def get_timeout(self) -> float:
+        return self.timeout
+
+    def with_timeout(self, timeout: float) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        return attr.evolve(self, timeout=timeout)
+
+
+@attr.s(auto_attribs=True)
+class AuthenticatedClient(Client):
+    """A Client which has been authenticated for use on secured endpoints"""
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def get_headers(self) -> Dict[str, str]:
+        """Get headers to be used in authenticated endpoints"""
+        auth_header_value = f"{self.prefix} {self.token}" if self.prefix else self.token
+        return {self.auth_header_name: auth_header_value, **self.headers}

--- a/python/dbsp-api-client/dbsp_api_client/errors.py
+++ b/python/dbsp-api-client/dbsp_api_client/errors.py
@@ -1,0 +1,14 @@
+""" Contains shared errors types that can be raised from API functions """
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(f"Unexpected status code: {status_code}")
+
+
+__all__ = ["UnexpectedStatus"]

--- a/python/dbsp-api-client/dbsp_api_client/models/__init__.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/__init__.py
@@ -1,0 +1,103 @@
+""" Contains all the data models used in inputs/outputs """
+
+from .attached_connector import AttachedConnector
+from .cancel_program_request import CancelProgramRequest
+from .compile_program_request import CompileProgramRequest
+from .connector_descr import ConnectorDescr
+from .csv_encoder_config import CsvEncoderConfig
+from .csv_parser_config import CsvParserConfig
+from .error_response import ErrorResponse
+from .file_input_config import FileInputConfig
+from .file_output_config import FileOutputConfig
+from .format_config import FormatConfig
+from .format_config_config import FormatConfigConfig
+from .input_endpoint_config import InputEndpointConfig
+from .kafka_input_config import KafkaInputConfig
+from .kafka_input_config_log_level import KafkaInputConfigLogLevel
+from .kafka_log_level import KafkaLogLevel
+from .kafka_output_config import KafkaOutputConfig
+from .kafka_output_config_log_level import KafkaOutputConfigLogLevel
+from .new_connector_request import NewConnectorRequest
+from .new_connector_response import NewConnectorResponse
+from .new_pipeline_request import NewPipelineRequest
+from .new_pipeline_response import NewPipelineResponse
+from .new_program_request import NewProgramRequest
+from .new_program_response import NewProgramResponse
+from .output_endpoint_config import OutputEndpointConfig
+from .pipeline_config import PipelineConfig
+from .pipeline_config_inputs import PipelineConfigInputs
+from .pipeline_config_outputs import PipelineConfigOutputs
+from .pipeline_descr import PipelineDescr
+from .pipeline_stats_response_200 import PipelineStatsResponse200
+from .pipeline_status import PipelineStatus
+from .program_code_response import ProgramCodeResponse
+from .program_descr import ProgramDescr
+from .program_status_type_0 import ProgramStatusType0
+from .program_status_type_1 import ProgramStatusType1
+from .program_status_type_2 import ProgramStatusType2
+from .program_status_type_3 import ProgramStatusType3
+from .program_status_type_4 import ProgramStatusType4
+from .program_status_type_5 import ProgramStatusType5
+from .program_status_type_6 import ProgramStatusType6
+from .program_status_type_7 import ProgramStatusType7
+from .sql_compiler_message import SqlCompilerMessage
+from .transport_config import TransportConfig
+from .transport_config_config import TransportConfigConfig
+from .update_connector_request import UpdateConnectorRequest
+from .update_connector_response import UpdateConnectorResponse
+from .update_pipeline_request import UpdatePipelineRequest
+from .update_pipeline_response import UpdatePipelineResponse
+from .update_program_request import UpdateProgramRequest
+from .update_program_response import UpdateProgramResponse
+
+__all__ = (
+    "AttachedConnector",
+    "CancelProgramRequest",
+    "CompileProgramRequest",
+    "ConnectorDescr",
+    "CsvEncoderConfig",
+    "CsvParserConfig",
+    "ErrorResponse",
+    "FileInputConfig",
+    "FileOutputConfig",
+    "FormatConfig",
+    "FormatConfigConfig",
+    "InputEndpointConfig",
+    "KafkaInputConfig",
+    "KafkaInputConfigLogLevel",
+    "KafkaLogLevel",
+    "KafkaOutputConfig",
+    "KafkaOutputConfigLogLevel",
+    "NewConnectorRequest",
+    "NewConnectorResponse",
+    "NewPipelineRequest",
+    "NewPipelineResponse",
+    "NewProgramRequest",
+    "NewProgramResponse",
+    "OutputEndpointConfig",
+    "PipelineConfig",
+    "PipelineConfigInputs",
+    "PipelineConfigOutputs",
+    "PipelineDescr",
+    "PipelineStatsResponse200",
+    "PipelineStatus",
+    "ProgramCodeResponse",
+    "ProgramDescr",
+    "ProgramStatusType0",
+    "ProgramStatusType1",
+    "ProgramStatusType2",
+    "ProgramStatusType3",
+    "ProgramStatusType4",
+    "ProgramStatusType5",
+    "ProgramStatusType6",
+    "ProgramStatusType7",
+    "SqlCompilerMessage",
+    "TransportConfig",
+    "TransportConfigConfig",
+    "UpdateConnectorRequest",
+    "UpdateConnectorResponse",
+    "UpdatePipelineRequest",
+    "UpdatePipelineResponse",
+    "UpdateProgramRequest",
+    "UpdateProgramResponse",
+)

--- a/python/dbsp-api-client/dbsp_api_client/models/attached_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/attached_connector.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="AttachedConnector")
+
+
+@attr.s(auto_attribs=True)
+class AttachedConnector:
+    """Format to add attached connectors during a config update.
+
+    Attributes:
+        config (str): The YAML config for this attached connector.
+        connector_id (str): Unique connector id.
+        is_input (bool): Is this an input or an output?
+        name (str): A unique identifier for this attachement.
+    """
+
+    config: str
+    connector_id: str
+    is_input: bool
+    name: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        config = self.config
+        connector_id = self.connector_id
+        is_input = self.is_input
+        name = self.name
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "config": config,
+                "connector_id": connector_id,
+                "is_input": is_input,
+                "name": name,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        config = d.pop("config")
+
+        connector_id = d.pop("connector_id")
+
+        is_input = d.pop("is_input")
+
+        name = d.pop("name")
+
+        attached_connector = cls(
+            config=config,
+            connector_id=connector_id,
+            is_input=is_input,
+            name=name,
+        )
+
+        attached_connector.additional_properties = d
+        return attached_connector
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/cancel_program_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/cancel_program_request.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="CancelProgramRequest")
+
+
+@attr.s(auto_attribs=True)
+class CancelProgramRequest:
+    """Request to cancel ongoing program compilation.
+
+    Attributes:
+        program_id (str): Unique program id.
+        version (int): Version number.
+    """
+
+    program_id: str
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        program_id = self.program_id
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "program_id": program_id,
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        program_id = d.pop("program_id")
+
+        version = d.pop("version")
+
+        cancel_program_request = cls(
+            program_id=program_id,
+            version=version,
+        )
+
+        cancel_program_request.additional_properties = d
+        return cancel_program_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/compile_program_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/compile_program_request.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="CompileProgramRequest")
+
+
+@attr.s(auto_attribs=True)
+class CompileProgramRequest:
+    """Request to queue a program for compilation.
+
+    Attributes:
+        program_id (str): Unique program id.
+        version (int): Version number.
+    """
+
+    program_id: str
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        program_id = self.program_id
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "program_id": program_id,
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        program_id = d.pop("program_id")
+
+        version = d.pop("version")
+
+        compile_program_request = cls(
+            program_id=program_id,
+            version=version,
+        )
+
+        compile_program_request.additional_properties = d
+        return compile_program_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/connector_descr.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/connector_descr.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="ConnectorDescr")
+
+
+@attr.s(auto_attribs=True)
+class ConnectorDescr:
+    """Connector descriptor.
+
+    Attributes:
+        config (str):
+        connector_id (str): Unique connector id.
+        description (str):
+        name (str):
+    """
+
+    config: str
+    connector_id: str
+    description: str
+    name: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        config = self.config
+        connector_id = self.connector_id
+        description = self.description
+        name = self.name
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "config": config,
+                "connector_id": connector_id,
+                "description": description,
+                "name": name,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        config = d.pop("config")
+
+        connector_id = d.pop("connector_id")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        connector_descr = cls(
+            config=config,
+            connector_id=connector_id,
+            description=description,
+            name=name,
+        )
+
+        connector_descr.additional_properties = d
+        return connector_descr
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/csv_encoder_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/csv_encoder_config.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CsvEncoderConfig")
+
+
+@attr.s(auto_attribs=True)
+class CsvEncoderConfig:
+    """
+    Attributes:
+        buffer_size_records (Union[Unset, int]):
+    """
+
+    buffer_size_records: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        buffer_size_records = self.buffer_size_records
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if buffer_size_records is not UNSET:
+            field_dict["buffer_size_records"] = buffer_size_records
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        buffer_size_records = d.pop("buffer_size_records", UNSET)
+
+        csv_encoder_config = cls(
+            buffer_size_records=buffer_size_records,
+        )
+
+        csv_encoder_config.additional_properties = d
+        return csv_encoder_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/csv_parser_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/csv_parser_config.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="CsvParserConfig")
+
+
+@attr.s(auto_attribs=True)
+class CsvParserConfig:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        csv_parser_config = cls()
+
+        csv_parser_config.additional_properties = d
+        return csv_parser_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/error_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/error_response.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="ErrorResponse")
+
+
+@attr.s(auto_attribs=True)
+class ErrorResponse:
+    """Pipeline manager error response.
+
+    Attributes:
+        message (str):  Example: Unknown program id 42..
+    """
+
+    message: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        message = self.message
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "message": message,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        message = d.pop("message")
+
+        error_response = cls(
+            message=message,
+        )
+
+        error_response.additional_properties = d
+        return error_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/file_input_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/file_input_config.py
@@ -1,0 +1,84 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="FileInputConfig")
+
+
+@attr.s(auto_attribs=True)
+class FileInputConfig:
+    """Configuration for reading data from a file with [`FileInputTransport`].
+
+    Attributes:
+        path (str): File path.
+        buffer_size_bytes (Union[Unset, None, int]): Read buffer size.
+
+            Default: when this parameter is not specified, a platform-specific
+            default is used.
+        follow (Union[Unset, bool]): Enable file following.
+
+            When `false`, the endpoint outputs an [`eoi`](`InputConsumer::eoi`)
+            message and stops upon reaching the end of file.  When `true`, the
+            endpoint will keep watching the file and outputting any new content
+            appended to it.
+    """
+
+    path: str
+    buffer_size_bytes: Union[Unset, None, int] = UNSET
+    follow: Union[Unset, bool] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        path = self.path
+        buffer_size_bytes = self.buffer_size_bytes
+        follow = self.follow
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "path": path,
+            }
+        )
+        if buffer_size_bytes is not UNSET:
+            field_dict["buffer_size_bytes"] = buffer_size_bytes
+        if follow is not UNSET:
+            field_dict["follow"] = follow
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        path = d.pop("path")
+
+        buffer_size_bytes = d.pop("buffer_size_bytes", UNSET)
+
+        follow = d.pop("follow", UNSET)
+
+        file_input_config = cls(
+            path=path,
+            buffer_size_bytes=buffer_size_bytes,
+            follow=follow,
+        )
+
+        file_input_config.additional_properties = d
+        return file_input_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/file_output_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/file_output_config.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="FileOutputConfig")
+
+
+@attr.s(auto_attribs=True)
+class FileOutputConfig:
+    """Configuration for writing data to a file with [`FileOutputTransport`].
+
+    Attributes:
+        path (str): File path.
+    """
+
+    path: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        path = self.path
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "path": path,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        path = d.pop("path")
+
+        file_output_config = cls(
+            path=path,
+        )
+
+        file_output_config.additional_properties = d
+        return file_output_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/format_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/format_config.py
@@ -1,0 +1,82 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.format_config_config import FormatConfigConfig
+
+
+T = TypeVar("T", bound="FormatConfig")
+
+
+@attr.s(auto_attribs=True)
+class FormatConfig:
+    """Data format specification used to parse raw data received from the
+    endpoint or to encode data sent to the endpoint.
+
+        Attributes:
+            name (str): Format name, e.g., "csv", "json", "bincode", etc.
+            config (Union[Unset, FormatConfigConfig]): Format-specific parser or encoder configuration.
+    """
+
+    name: str
+    config: Union[Unset, "FormatConfigConfig"] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        config: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.config, Unset):
+            config = self.config.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if config is not UNSET:
+            field_dict["config"] = config
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.format_config_config import FormatConfigConfig
+
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        _config = d.pop("config", UNSET)
+        config: Union[Unset, FormatConfigConfig]
+        if isinstance(_config, Unset):
+            config = UNSET
+        else:
+            config = FormatConfigConfig.from_dict(_config)
+
+        format_config = cls(
+            name=name,
+            config=config,
+        )
+
+        format_config.additional_properties = d
+        return format_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/format_config_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/format_config_config.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="FormatConfigConfig")
+
+
+@attr.s(auto_attribs=True)
+class FormatConfigConfig:
+    """Format-specific parser or encoder configuration."""
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        format_config_config = cls()
+
+        format_config_config.additional_properties = d
+        return format_config_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/input_endpoint_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/input_endpoint_config.py
@@ -1,0 +1,101 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.format_config import FormatConfig
+    from ..models.transport_config import TransportConfig
+
+
+T = TypeVar("T", bound="InputEndpointConfig")
+
+
+@attr.s(auto_attribs=True)
+class InputEndpointConfig:
+    """
+    Attributes:
+        format_ (FormatConfig): Data format specification used to parse raw data received from the
+            endpoint or to encode data sent to the endpoint.
+        stream (str): The name of the input stream of the circuit that this endpoint is
+            connected to.
+        transport (TransportConfig): Transport endpoint configuration.
+        max_buffered_records (Union[Unset, int]): Backpressure threshold.
+
+            Maximal amount of records buffered by the endpoint before the endpoint
+            is paused by the backpressure mechanism.  Note that this is not a
+            hard bound: there can be a small delay between the backpressure
+            mechanism is triggered and the endpoint is paused, during which more
+            data may be received.
+
+            The default is 1 million.
+    """
+
+    format_: "FormatConfig"
+    stream: str
+    transport: "TransportConfig"
+    max_buffered_records: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        format_ = self.format_.to_dict()
+
+        stream = self.stream
+        transport = self.transport.to_dict()
+
+        max_buffered_records = self.max_buffered_records
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "format": format_,
+                "stream": stream,
+                "transport": transport,
+            }
+        )
+        if max_buffered_records is not UNSET:
+            field_dict["max_buffered_records"] = max_buffered_records
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.format_config import FormatConfig
+        from ..models.transport_config import TransportConfig
+
+        d = src_dict.copy()
+        format_ = FormatConfig.from_dict(d.pop("format"))
+
+        stream = d.pop("stream")
+
+        transport = TransportConfig.from_dict(d.pop("transport"))
+
+        max_buffered_records = d.pop("max_buffered_records", UNSET)
+
+        input_endpoint_config = cls(
+            format_=format_,
+            stream=stream,
+            transport=transport,
+            max_buffered_records=max_buffered_records,
+        )
+
+        input_endpoint_config.additional_properties = d
+        return input_endpoint_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/kafka_input_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/kafka_input_config.py
@@ -1,0 +1,85 @@
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..models.kafka_input_config_log_level import KafkaInputConfigLogLevel
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="KafkaInputConfig")
+
+
+@attr.s(auto_attribs=True)
+class KafkaInputConfig:
+    """
+    Attributes:
+        topics (List[str]):
+        group_join_timeout_secs (Union[Unset, int]): Maximum timeout in seconds to wait for the endpoint to join the
+            Kafka consumer group during initialization.
+        log_level (Union[Unset, KafkaInputConfigLogLevel]): Kafka logging levels.
+    """
+
+    topics: List[str]
+    group_join_timeout_secs: Union[Unset, int] = UNSET
+    log_level: Union[Unset, KafkaInputConfigLogLevel] = UNSET
+    additional_properties: Dict[str, str] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        topics = self.topics
+
+        group_join_timeout_secs = self.group_join_timeout_secs
+        log_level: Union[Unset, str] = UNSET
+        if not isinstance(self.log_level, Unset):
+            log_level = self.log_level.value
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "topics": topics,
+            }
+        )
+        if group_join_timeout_secs is not UNSET:
+            field_dict["group_join_timeout_secs"] = group_join_timeout_secs
+        if log_level is not UNSET:
+            field_dict["log_level"] = log_level
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        topics = cast(List[str], d.pop("topics"))
+
+        group_join_timeout_secs = d.pop("group_join_timeout_secs", UNSET)
+
+        _log_level = d.pop("log_level", UNSET)
+        log_level: Union[Unset, KafkaInputConfigLogLevel]
+        if isinstance(_log_level, Unset):
+            log_level = UNSET
+        else:
+            log_level = KafkaInputConfigLogLevel(_log_level)
+
+        kafka_input_config = cls(
+            topics=topics,
+            group_join_timeout_secs=group_join_timeout_secs,
+            log_level=log_level,
+        )
+
+        kafka_input_config.additional_properties = d
+        return kafka_input_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/kafka_input_config_log_level.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/kafka_input_config_log_level.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class KafkaInputConfigLogLevel(str, Enum):
+    ALERT = "alert"
+    CRITICAL = "critical"
+    DEBUG = "debug"
+    EMERG = "emerg"
+    ERROR = "error"
+    INFO = "info"
+    NOTICE = "notice"
+    WARNING = "warning"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/kafka_log_level.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/kafka_log_level.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class KafkaLogLevel(str, Enum):
+    ALERT = "alert"
+    CRITICAL = "critical"
+    DEBUG = "debug"
+    EMERG = "emerg"
+    ERROR = "error"
+    INFO = "info"
+    NOTICE = "notice"
+    WARNING = "warning"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/kafka_output_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/kafka_output_config.py
@@ -1,0 +1,93 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.kafka_output_config_log_level import KafkaOutputConfigLogLevel
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="KafkaOutputConfig")
+
+
+@attr.s(auto_attribs=True)
+class KafkaOutputConfig:
+    """
+    Attributes:
+        topic (str):
+        log_level (Union[Unset, KafkaOutputConfigLogLevel]): Kafka logging levels.
+        max_inflight_messages (Union[Unset, int]): Maximum number of unacknowledged messages buffered by the Kafka
+            producer.
+
+            Kafka producer buffers outgoing messages until it receives an
+            acknowledgement from the broker.  This configuration parameter
+            bounds the number of unacknowledged messages.  When the number of
+            unacknowledged messages reaches this limit, sending of a new message
+            blocks until additional acknowledgements arrive from the broker.
+
+            Defaults to 1000.
+    """
+
+    topic: str
+    log_level: Union[Unset, KafkaOutputConfigLogLevel] = UNSET
+    max_inflight_messages: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, str] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        topic = self.topic
+        log_level: Union[Unset, str] = UNSET
+        if not isinstance(self.log_level, Unset):
+            log_level = self.log_level.value
+
+        max_inflight_messages = self.max_inflight_messages
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "topic": topic,
+            }
+        )
+        if log_level is not UNSET:
+            field_dict["log_level"] = log_level
+        if max_inflight_messages is not UNSET:
+            field_dict["max_inflight_messages"] = max_inflight_messages
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        topic = d.pop("topic")
+
+        _log_level = d.pop("log_level", UNSET)
+        log_level: Union[Unset, KafkaOutputConfigLogLevel]
+        if isinstance(_log_level, Unset):
+            log_level = UNSET
+        else:
+            log_level = KafkaOutputConfigLogLevel(_log_level)
+
+        max_inflight_messages = d.pop("max_inflight_messages", UNSET)
+
+        kafka_output_config = cls(
+            topic=topic,
+            log_level=log_level,
+            max_inflight_messages=max_inflight_messages,
+        )
+
+        kafka_output_config.additional_properties = d
+        return kafka_output_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/kafka_output_config_log_level.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/kafka_output_config_log_level.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class KafkaOutputConfigLogLevel(str, Enum):
+    ALERT = "alert"
+    CRITICAL = "critical"
+    DEBUG = "debug"
+    EMERG = "emerg"
+    ERROR = "error"
+    INFO = "info"
+    NOTICE = "notice"
+    WARNING = "warning"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/new_connector_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_connector_request.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="NewConnectorRequest")
+
+
+@attr.s(auto_attribs=True)
+class NewConnectorRequest:
+    """Request to create a new connector.
+
+    Attributes:
+        config (str): connector config.
+        description (str): connector description.
+        name (str): connector name.
+    """
+
+    config: str
+    description: str
+    name: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        config = self.config
+        description = self.description
+        name = self.name
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "config": config,
+                "description": description,
+                "name": name,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        config = d.pop("config")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        new_connector_request = cls(
+            config=config,
+            description=description,
+            name=name,
+        )
+
+        new_connector_request.additional_properties = d
+        return new_connector_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/new_connector_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_connector_response.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="NewConnectorResponse")
+
+
+@attr.s(auto_attribs=True)
+class NewConnectorResponse:
+    """Response to a connector creation request.
+
+    Attributes:
+        connector_id (str): Unique connector id.
+    """
+
+    connector_id: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        connector_id = self.connector_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "connector_id": connector_id,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        connector_id = d.pop("connector_id")
+
+        new_connector_response = cls(
+            connector_id=connector_id,
+        )
+
+        new_connector_response.additional_properties = d
+        return new_connector_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/new_pipeline_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_pipeline_request.py
@@ -1,0 +1,111 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.attached_connector import AttachedConnector
+
+
+T = TypeVar("T", bound="NewPipelineRequest")
+
+
+@attr.s(auto_attribs=True)
+class NewPipelineRequest:
+    """Request to create a new program configuration.
+
+    Attributes:
+        config (str): YAML code for the config.
+        description (str): Config description.
+        name (str): Config name.
+        connectors (Union[Unset, None, List['AttachedConnector']]): Attached connectors.
+        program_id (Union[Unset, None, str]): Unique program id.
+    """
+
+    config: str
+    description: str
+    name: str
+    connectors: Union[Unset, None, List["AttachedConnector"]] = UNSET
+    program_id: Union[Unset, None, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        config = self.config
+        description = self.description
+        name = self.name
+        connectors: Union[Unset, None, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.connectors, Unset):
+            if self.connectors is None:
+                connectors = None
+            else:
+                connectors = []
+                for connectors_item_data in self.connectors:
+                    connectors_item = connectors_item_data.to_dict()
+
+                    connectors.append(connectors_item)
+
+        program_id = self.program_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "config": config,
+                "description": description,
+                "name": name,
+            }
+        )
+        if connectors is not UNSET:
+            field_dict["connectors"] = connectors
+        if program_id is not UNSET:
+            field_dict["program_id"] = program_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.attached_connector import AttachedConnector
+
+        d = src_dict.copy()
+        config = d.pop("config")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        connectors = []
+        _connectors = d.pop("connectors", UNSET)
+        for connectors_item_data in _connectors or []:
+            connectors_item = AttachedConnector.from_dict(connectors_item_data)
+
+            connectors.append(connectors_item)
+
+        program_id = d.pop("program_id", UNSET)
+
+        new_pipeline_request = cls(
+            config=config,
+            description=description,
+            name=name,
+            connectors=connectors,
+            program_id=program_id,
+        )
+
+        new_pipeline_request.additional_properties = d
+        return new_pipeline_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/new_pipeline_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_pipeline_response.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="NewPipelineResponse")
+
+
+@attr.s(auto_attribs=True)
+class NewPipelineResponse:
+    """Response to a config creation request.
+
+    Attributes:
+        pipeline_id (str): Unique pipeline id.
+        version (int): Version number.
+    """
+
+    pipeline_id: str
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        pipeline_id = self.pipeline_id
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "pipeline_id": pipeline_id,
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pipeline_id = d.pop("pipeline_id")
+
+        version = d.pop("version")
+
+        new_pipeline_response = cls(
+            pipeline_id=pipeline_id,
+            version=version,
+        )
+
+        new_pipeline_response.additional_properties = d
+        return new_pipeline_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/new_program_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_program_request.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="NewProgramRequest")
+
+
+@attr.s(auto_attribs=True)
+class NewProgramRequest:
+    """Request to create a new DBSP program.
+
+    Attributes:
+        code (str): SQL code of the program. Example: CREATE TABLE Example(name varchar);.
+        description (str): Program description. Example: Example description.
+        name (str): Program name. Example: Example program.
+        overwrite_existing (Union[Unset, bool]): Overwrite existing program with the same name, if any.
+    """
+
+    code: str
+    description: str
+    name: str
+    overwrite_existing: Union[Unset, bool] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        code = self.code
+        description = self.description
+        name = self.name
+        overwrite_existing = self.overwrite_existing
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "code": code,
+                "description": description,
+                "name": name,
+            }
+        )
+        if overwrite_existing is not UNSET:
+            field_dict["overwrite_existing"] = overwrite_existing
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        code = d.pop("code")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        overwrite_existing = d.pop("overwrite_existing", UNSET)
+
+        new_program_request = cls(
+            code=code,
+            description=description,
+            name=name,
+            overwrite_existing=overwrite_existing,
+        )
+
+        new_program_request.additional_properties = d
+        return new_program_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/new_program_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/new_program_response.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="NewProgramResponse")
+
+
+@attr.s(auto_attribs=True)
+class NewProgramResponse:
+    """Response to a new program request.
+
+    Attributes:
+        program_id (str): Unique program id.
+        version (int): Version number.
+    """
+
+    program_id: str
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        program_id = self.program_id
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "program_id": program_id,
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        program_id = d.pop("program_id")
+
+        version = d.pop("version")
+
+        new_program_response = cls(
+            program_id=program_id,
+            version=version,
+        )
+
+        new_program_response.additional_properties = d
+        return new_program_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/output_endpoint_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/output_endpoint_config.py
@@ -1,0 +1,95 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.format_config import FormatConfig
+    from ..models.transport_config import TransportConfig
+
+
+T = TypeVar("T", bound="OutputEndpointConfig")
+
+
+@attr.s(auto_attribs=True)
+class OutputEndpointConfig:
+    """
+    Attributes:
+        format_ (FormatConfig): Data format specification used to parse raw data received from the
+            endpoint or to encode data sent to the endpoint.
+        stream (str): The name of the output stream of the circuit that this endpoint is
+            connected to.
+        transport (TransportConfig): Transport endpoint configuration.
+        max_buffered_records (Union[Unset, int]): Backpressure threshold.
+
+            The default is 1 million.
+    """
+
+    format_: "FormatConfig"
+    stream: str
+    transport: "TransportConfig"
+    max_buffered_records: Union[Unset, int] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        format_ = self.format_.to_dict()
+
+        stream = self.stream
+        transport = self.transport.to_dict()
+
+        max_buffered_records = self.max_buffered_records
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "format": format_,
+                "stream": stream,
+                "transport": transport,
+            }
+        )
+        if max_buffered_records is not UNSET:
+            field_dict["max_buffered_records"] = max_buffered_records
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.format_config import FormatConfig
+        from ..models.transport_config import TransportConfig
+
+        d = src_dict.copy()
+        format_ = FormatConfig.from_dict(d.pop("format"))
+
+        stream = d.pop("stream")
+
+        transport = TransportConfig.from_dict(d.pop("transport"))
+
+        max_buffered_records = d.pop("max_buffered_records", UNSET)
+
+        output_endpoint_config = cls(
+            format_=format_,
+            stream=stream,
+            transport=transport,
+            max_buffered_records=max_buffered_records,
+        )
+
+        output_endpoint_config.additional_properties = d
+        return output_endpoint_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_config.py
@@ -1,0 +1,133 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.pipeline_config_inputs import PipelineConfigInputs
+    from ..models.pipeline_config_outputs import PipelineConfigOutputs
+
+
+T = TypeVar("T", bound="PipelineConfig")
+
+
+@attr.s(auto_attribs=True)
+class PipelineConfig:
+    """Pipeline configuration specified by the user when creating
+    a new pipeline instance.
+
+        Attributes:
+            inputs (PipelineConfigInputs): Input endpoint configuration.
+            cpu_profiler (Union[Unset, bool]): Enable CPU profiler.
+            max_buffering_delay_usecs (Union[Unset, int]): Maximal delay in microseconds to wait for
+                `min_batch_size_records` to
+                get buffered by the controller, defaults to 0.
+            min_batch_size_records (Union[Unset, int]): Minimal input batch size.
+
+                The controller delays pushing input records to the circuit until at
+                least `min_batch_size_records` records have been received (total
+                across all endpoints) or `max_buffering_delay_usecs` microseconds
+                have passed since at least one input records has been buffered.
+                Defaults to 0.
+            workers (Union[Unset, int]): Number of DBSP worker threads.
+            name (Union[Unset, None, str]): Pipeline name
+            outputs (Union[Unset, PipelineConfigOutputs]): Output endpoint configuration.
+    """
+
+    inputs: "PipelineConfigInputs"
+    cpu_profiler: Union[Unset, bool] = UNSET
+    max_buffering_delay_usecs: Union[Unset, int] = UNSET
+    min_batch_size_records: Union[Unset, int] = UNSET
+    workers: Union[Unset, int] = UNSET
+    name: Union[Unset, None, str] = UNSET
+    outputs: Union[Unset, "PipelineConfigOutputs"] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        inputs = self.inputs.to_dict()
+
+        cpu_profiler = self.cpu_profiler
+        max_buffering_delay_usecs = self.max_buffering_delay_usecs
+        min_batch_size_records = self.min_batch_size_records
+        workers = self.workers
+        name = self.name
+        outputs: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.outputs, Unset):
+            outputs = self.outputs.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "inputs": inputs,
+            }
+        )
+        if cpu_profiler is not UNSET:
+            field_dict["cpu_profiler"] = cpu_profiler
+        if max_buffering_delay_usecs is not UNSET:
+            field_dict["max_buffering_delay_usecs"] = max_buffering_delay_usecs
+        if min_batch_size_records is not UNSET:
+            field_dict["min_batch_size_records"] = min_batch_size_records
+        if workers is not UNSET:
+            field_dict["workers"] = workers
+        if name is not UNSET:
+            field_dict["name"] = name
+        if outputs is not UNSET:
+            field_dict["outputs"] = outputs
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.pipeline_config_inputs import PipelineConfigInputs
+        from ..models.pipeline_config_outputs import PipelineConfigOutputs
+
+        d = src_dict.copy()
+        inputs = PipelineConfigInputs.from_dict(d.pop("inputs"))
+
+        cpu_profiler = d.pop("cpu_profiler", UNSET)
+
+        max_buffering_delay_usecs = d.pop("max_buffering_delay_usecs", UNSET)
+
+        min_batch_size_records = d.pop("min_batch_size_records", UNSET)
+
+        workers = d.pop("workers", UNSET)
+
+        name = d.pop("name", UNSET)
+
+        _outputs = d.pop("outputs", UNSET)
+        outputs: Union[Unset, PipelineConfigOutputs]
+        if isinstance(_outputs, Unset):
+            outputs = UNSET
+        else:
+            outputs = PipelineConfigOutputs.from_dict(_outputs)
+
+        pipeline_config = cls(
+            inputs=inputs,
+            cpu_profiler=cpu_profiler,
+            max_buffering_delay_usecs=max_buffering_delay_usecs,
+            min_batch_size_records=min_batch_size_records,
+            workers=workers,
+            name=name,
+            outputs=outputs,
+        )
+
+        pipeline_config.additional_properties = d
+        return pipeline_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_config_inputs.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_config_inputs.py
@@ -1,0 +1,59 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+
+import attr
+
+if TYPE_CHECKING:
+    from ..models.input_endpoint_config import InputEndpointConfig
+
+
+T = TypeVar("T", bound="PipelineConfigInputs")
+
+
+@attr.s(auto_attribs=True)
+class PipelineConfigInputs:
+    """Input endpoint configuration."""
+
+    additional_properties: Dict[str, "InputEndpointConfig"] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        pass
+
+        field_dict: Dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop.to_dict()
+
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.input_endpoint_config import InputEndpointConfig
+
+        d = src_dict.copy()
+        pipeline_config_inputs = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = InputEndpointConfig.from_dict(prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        pipeline_config_inputs.additional_properties = additional_properties
+        return pipeline_config_inputs
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> "InputEndpointConfig":
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: "InputEndpointConfig") -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_config_outputs.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_config_outputs.py
@@ -1,0 +1,59 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+
+import attr
+
+if TYPE_CHECKING:
+    from ..models.output_endpoint_config import OutputEndpointConfig
+
+
+T = TypeVar("T", bound="PipelineConfigOutputs")
+
+
+@attr.s(auto_attribs=True)
+class PipelineConfigOutputs:
+    """Output endpoint configuration."""
+
+    additional_properties: Dict[str, "OutputEndpointConfig"] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        pass
+
+        field_dict: Dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop.to_dict()
+
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.output_endpoint_config import OutputEndpointConfig
+
+        d = src_dict.copy()
+        pipeline_config_outputs = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = OutputEndpointConfig.from_dict(prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        pipeline_config_outputs.additional_properties = additional_properties
+        return pipeline_config_outputs
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> "OutputEndpointConfig":
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: "OutputEndpointConfig") -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_descr.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_descr.py
@@ -1,0 +1,155 @@
+import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+from dateutil.parser import isoparse
+
+from ..models.pipeline_status import PipelineStatus
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.attached_connector import AttachedConnector
+
+
+T = TypeVar("T", bound="PipelineDescr")
+
+
+@attr.s(auto_attribs=True)
+class PipelineDescr:
+    """Pipeline descriptor.
+
+    Attributes:
+        attached_connectors (List['AttachedConnector']):
+        config (str):
+        description (str):
+        name (str):
+        pipeline_id (str): Unique pipeline id.
+        port (int):
+        status (PipelineStatus): Lifecycle of a pipeline.
+        version (int): Version number.
+        created (Union[Unset, None, datetime.datetime]):
+        program_id (Union[Unset, None, str]): Unique program id.
+    """
+
+    attached_connectors: List["AttachedConnector"]
+    config: str
+    description: str
+    name: str
+    pipeline_id: str
+    port: int
+    status: PipelineStatus
+    version: int
+    created: Union[Unset, None, datetime.datetime] = UNSET
+    program_id: Union[Unset, None, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        attached_connectors = []
+        for attached_connectors_item_data in self.attached_connectors:
+            attached_connectors_item = attached_connectors_item_data.to_dict()
+
+            attached_connectors.append(attached_connectors_item)
+
+        config = self.config
+        description = self.description
+        name = self.name
+        pipeline_id = self.pipeline_id
+        port = self.port
+        status = self.status.value
+
+        version = self.version
+        created: Union[Unset, None, str] = UNSET
+        if not isinstance(self.created, Unset):
+            created = self.created.isoformat() if self.created else None
+
+        program_id = self.program_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "attached_connectors": attached_connectors,
+                "config": config,
+                "description": description,
+                "name": name,
+                "pipeline_id": pipeline_id,
+                "port": port,
+                "status": status,
+                "version": version,
+            }
+        )
+        if created is not UNSET:
+            field_dict["created"] = created
+        if program_id is not UNSET:
+            field_dict["program_id"] = program_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.attached_connector import AttachedConnector
+
+        d = src_dict.copy()
+        attached_connectors = []
+        _attached_connectors = d.pop("attached_connectors")
+        for attached_connectors_item_data in _attached_connectors:
+            attached_connectors_item = AttachedConnector.from_dict(attached_connectors_item_data)
+
+            attached_connectors.append(attached_connectors_item)
+
+        config = d.pop("config")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        pipeline_id = d.pop("pipeline_id")
+
+        port = d.pop("port")
+
+        status = PipelineStatus(d.pop("status"))
+
+        version = d.pop("version")
+
+        _created = d.pop("created", UNSET)
+        created: Union[Unset, None, datetime.datetime]
+        if _created is None:
+            created = None
+        elif isinstance(_created, Unset):
+            created = UNSET
+        else:
+            created = isoparse(_created)
+
+        program_id = d.pop("program_id", UNSET)
+
+        pipeline_descr = cls(
+            attached_connectors=attached_connectors,
+            config=config,
+            description=description,
+            name=name,
+            pipeline_id=pipeline_id,
+            port=port,
+            status=status,
+            version=version,
+            created=created,
+            program_id=program_id,
+        )
+
+        pipeline_descr.additional_properties = d
+        return pipeline_descr
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_stats_response_200.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_stats_response_200.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="PipelineStatsResponse200")
+
+
+@attr.s(auto_attribs=True)
+class PipelineStatsResponse200:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pipeline_stats_response_200 = cls()
+
+        pipeline_stats_response_200.additional_properties = d
+        return pipeline_stats_response_200
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/pipeline_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/pipeline_status.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class PipelineStatus(str, Enum):
+    DEPLOYED = "Deployed"
+    FAILED = "Failed"
+    PAUSED = "Paused"
+    RUNNING = "Running"
+    SHUTDOWN = "Shutdown"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_code_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_code_response.py
@@ -1,0 +1,71 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+
+import attr
+
+if TYPE_CHECKING:
+    from ..models.program_descr import ProgramDescr
+
+
+T = TypeVar("T", bound="ProgramCodeResponse")
+
+
+@attr.s(auto_attribs=True)
+class ProgramCodeResponse:
+    """Response to a program code request.
+
+    Attributes:
+        code (str): Program code.
+        program (ProgramDescr): Program descriptor.
+    """
+
+    code: str
+    program: "ProgramDescr"
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        code = self.code
+        program = self.program.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "code": code,
+                "program": program,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.program_descr import ProgramDescr
+
+        d = src_dict.copy()
+        code = d.pop("code")
+
+        program = ProgramDescr.from_dict(d.pop("program"))
+
+        program_code_response = cls(
+            code=code,
+            program=program,
+        )
+
+        program_code_response.additional_properties = d
+        return program_code_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/program_descr.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_descr.py
@@ -1,0 +1,251 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.program_status_type_0 import ProgramStatusType0
+from ..models.program_status_type_1 import ProgramStatusType1
+from ..models.program_status_type_2 import ProgramStatusType2
+from ..models.program_status_type_3 import ProgramStatusType3
+from ..models.program_status_type_4 import ProgramStatusType4
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.program_status_type_5 import ProgramStatusType5
+    from ..models.program_status_type_6 import ProgramStatusType6
+    from ..models.program_status_type_7 import ProgramStatusType7
+
+
+T = TypeVar("T", bound="ProgramDescr")
+
+
+@attr.s(auto_attribs=True)
+class ProgramDescr:
+    """Program descriptor.
+
+    Attributes:
+        description (str): Program description.
+        name (str): Program name (doesn't have to be unique).
+        program_id (str): Unique program id.
+        status (Union['ProgramStatusType5', 'ProgramStatusType6', 'ProgramStatusType7', ProgramStatusType0,
+            ProgramStatusType1, ProgramStatusType2, ProgramStatusType3, ProgramStatusType4]): Program compilation status.
+        version (int): Version number.
+        schema (Union[Unset, None, str]): A JSON description of the SQL tables and view declarations including
+            field names and types.
+
+            The schema is set/updated whenever the `status` field reaches >=
+            `ProgramStatus::CompilingRust`.
+
+            # Example
+
+            The given SQL program:
+
+            ```no_run
+            CREATE TABLE USERS ( name varchar );
+            CREATE VIEW OUTPUT_USERS as SELECT * FROM USERS;
+            ```
+
+            Would lead the following JSON string in `schema`:
+
+            ```no_run
+            {
+            "inputs": [{
+            "name": "USERS",
+            "fields": [{ "name": "NAME", "type": "VARCHAR", "nullable": true }]
+            }],
+            "outputs": [{
+            "name": "OUTPUT_USERS",
+            "fields": [{ "name": "NAME", "type": "VARCHAR", "nullable": true }]
+            }]
+            }
+            ```
+    """
+
+    description: str
+    name: str
+    program_id: str
+    status: Union[
+        "ProgramStatusType5",
+        "ProgramStatusType6",
+        "ProgramStatusType7",
+        ProgramStatusType0,
+        ProgramStatusType1,
+        ProgramStatusType2,
+        ProgramStatusType3,
+        ProgramStatusType4,
+    ]
+    version: int
+    schema: Union[Unset, None, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        from ..models.program_status_type_5 import ProgramStatusType5
+        from ..models.program_status_type_6 import ProgramStatusType6
+
+        description = self.description
+        name = self.name
+        program_id = self.program_id
+        status: Union[Dict[str, Any], str]
+
+        if isinstance(self.status, ProgramStatusType0):
+            status = self.status.value
+
+        elif isinstance(self.status, ProgramStatusType1):
+            status = self.status.value
+
+        elif isinstance(self.status, ProgramStatusType2):
+            status = self.status.value
+
+        elif isinstance(self.status, ProgramStatusType3):
+            status = self.status.value
+
+        elif isinstance(self.status, ProgramStatusType4):
+            status = self.status.value
+
+        elif isinstance(self.status, ProgramStatusType5):
+            status = self.status.to_dict()
+
+        elif isinstance(self.status, ProgramStatusType6):
+            status = self.status.to_dict()
+
+        else:
+            status = self.status.to_dict()
+
+        version = self.version
+        schema = self.schema
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "description": description,
+                "name": name,
+                "program_id": program_id,
+                "status": status,
+                "version": version,
+            }
+        )
+        if schema is not UNSET:
+            field_dict["schema"] = schema
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.program_status_type_5 import ProgramStatusType5
+        from ..models.program_status_type_6 import ProgramStatusType6
+        from ..models.program_status_type_7 import ProgramStatusType7
+
+        d = src_dict.copy()
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        program_id = d.pop("program_id")
+
+        def _parse_status(
+            data: object,
+        ) -> Union[
+            "ProgramStatusType5",
+            "ProgramStatusType6",
+            "ProgramStatusType7",
+            ProgramStatusType0,
+            ProgramStatusType1,
+            ProgramStatusType2,
+            ProgramStatusType3,
+            ProgramStatusType4,
+        ]:
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_program_status_type_0 = ProgramStatusType0(data)
+
+                return componentsschemas_program_status_type_0
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_program_status_type_1 = ProgramStatusType1(data)
+
+                return componentsschemas_program_status_type_1
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_program_status_type_2 = ProgramStatusType2(data)
+
+                return componentsschemas_program_status_type_2
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_program_status_type_3 = ProgramStatusType3(data)
+
+                return componentsschemas_program_status_type_3
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                componentsschemas_program_status_type_4 = ProgramStatusType4(data)
+
+                return componentsschemas_program_status_type_4
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                componentsschemas_program_status_type_5 = ProgramStatusType5.from_dict(data)
+
+                return componentsschemas_program_status_type_5
+            except:  # noqa: E722
+                pass
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                componentsschemas_program_status_type_6 = ProgramStatusType6.from_dict(data)
+
+                return componentsschemas_program_status_type_6
+            except:  # noqa: E722
+                pass
+            if not isinstance(data, dict):
+                raise TypeError()
+            componentsschemas_program_status_type_7 = ProgramStatusType7.from_dict(data)
+
+            return componentsschemas_program_status_type_7
+
+        status = _parse_status(d.pop("status"))
+
+        version = d.pop("version")
+
+        schema = d.pop("schema", UNSET)
+
+        program_descr = cls(
+            description=description,
+            name=name,
+            program_id=program_id,
+            status=status,
+            version=version,
+            schema=schema,
+        )
+
+        program_descr.additional_properties = d
+        return program_descr
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_0.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_0.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ProgramStatusType0(str, Enum):
+    NONE = "None"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_1.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_1.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ProgramStatusType1(str, Enum):
+    PENDING = "Pending"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_2.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_2.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ProgramStatusType2(str, Enum):
+    COMPILINGSQL = "CompilingSql"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_3.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_3.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ProgramStatusType3(str, Enum):
+    COMPILINGRUST = "CompilingRust"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_4.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_4.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ProgramStatusType4(str, Enum):
+    SUCCESS = "Success"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_5.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_5.py
@@ -1,0 +1,72 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+
+import attr
+
+if TYPE_CHECKING:
+    from ..models.sql_compiler_message import SqlCompilerMessage
+
+
+T = TypeVar("T", bound="ProgramStatusType5")
+
+
+@attr.s(auto_attribs=True)
+class ProgramStatusType5:
+    """
+    Attributes:
+        sql_error (List['SqlCompilerMessage']):
+    """
+
+    sql_error: List["SqlCompilerMessage"]
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        sql_error = []
+        for sql_error_item_data in self.sql_error:
+            sql_error_item = sql_error_item_data.to_dict()
+
+            sql_error.append(sql_error_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "SqlError": sql_error,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.sql_compiler_message import SqlCompilerMessage
+
+        d = src_dict.copy()
+        sql_error = []
+        _sql_error = d.pop("SqlError")
+        for sql_error_item_data in _sql_error:
+            sql_error_item = SqlCompilerMessage.from_dict(sql_error_item_data)
+
+            sql_error.append(sql_error_item)
+
+        program_status_type_5 = cls(
+            sql_error=sql_error,
+        )
+
+        program_status_type_5.additional_properties = d
+        return program_status_type_5
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_6.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_6.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="ProgramStatusType6")
+
+
+@attr.s(auto_attribs=True)
+class ProgramStatusType6:
+    """
+    Attributes:
+        rust_error (str): Rust compiler returned an error.
+    """
+
+    rust_error: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        rust_error = self.rust_error
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "RustError": rust_error,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        rust_error = d.pop("RustError")
+
+        program_status_type_6 = cls(
+            rust_error=rust_error,
+        )
+
+        program_status_type_6.additional_properties = d
+        return program_status_type_6
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/program_status_type_7.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/program_status_type_7.py
@@ -1,0 +1,57 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="ProgramStatusType7")
+
+
+@attr.s(auto_attribs=True)
+class ProgramStatusType7:
+    """
+    Attributes:
+        system_error (str): System/OS returned an error when trying to invoke commands.
+    """
+
+    system_error: str
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        system_error = self.system_error
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "SystemError": system_error,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        system_error = d.pop("SystemError")
+
+        program_status_type_7 = cls(
+            system_error=system_error,
+        )
+
+        program_status_type_7.additional_properties = d
+        return program_status_type_7
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/sql_compiler_message.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/sql_compiler_message.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="SqlCompilerMessage")
+
+
+@attr.s(auto_attribs=True)
+class SqlCompilerMessage:
+    r"""A SQL compiler error.
+
+    The SQL compiler returns a list of errors in the following JSON format if
+    it's invoked with the `-je` option.
+
+    ```no_run
+    [ {
+    "startLineNumber" : 14,
+    "startColumn" : 13,
+    "endLineNumber" : 14,
+    "endColumn" : 13,
+    "warning" : false,
+    "errorType" : "Error parsing SQL",
+    "message" : "Encountered \"<EOF>\" at line 14, column 13."
+    } ]
+    ```
+
+        Attributes:
+            end_column (int):
+            end_line_number (int):
+            error_type (str):
+            message (str):
+            start_column (int):
+            start_line_number (int):
+            warning (bool):
+    """
+
+    end_column: int
+    end_line_number: int
+    error_type: str
+    message: str
+    start_column: int
+    start_line_number: int
+    warning: bool
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        end_column = self.end_column
+        end_line_number = self.end_line_number
+        error_type = self.error_type
+        message = self.message
+        start_column = self.start_column
+        start_line_number = self.start_line_number
+        warning = self.warning
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "endColumn": end_column,
+                "endLineNumber": end_line_number,
+                "errorType": error_type,
+                "message": message,
+                "startColumn": start_column,
+                "startLineNumber": start_line_number,
+                "warning": warning,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        end_column = d.pop("endColumn")
+
+        end_line_number = d.pop("endLineNumber")
+
+        error_type = d.pop("errorType")
+
+        message = d.pop("message")
+
+        start_column = d.pop("startColumn")
+
+        start_line_number = d.pop("startLineNumber")
+
+        warning = d.pop("warning")
+
+        sql_compiler_message = cls(
+            end_column=end_column,
+            end_line_number=end_line_number,
+            error_type=error_type,
+            message=message,
+            start_column=start_column,
+            start_line_number=start_line_number,
+            warning=warning,
+        )
+
+        sql_compiler_message.additional_properties = d
+        return sql_compiler_message
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/transport_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/transport_config.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.transport_config_config import TransportConfigConfig
+
+
+T = TypeVar("T", bound="TransportConfig")
+
+
+@attr.s(auto_attribs=True)
+class TransportConfig:
+    """Transport endpoint configuration.
+
+    Attributes:
+        name (str): Data transport name, e.g., "file", "kafka", "kinesis", etc.
+        config (Union[Unset, TransportConfigConfig]): Transport-specific endpoint configuration passed to
+            [`OutputTransport::new_endpoint`](`crate::OutputTransport::new_endpoint`)
+            and
+            [`InputTransport::new_endpoint`](`crate::InputTransport::new_endpoint`).
+    """
+
+    name: str
+    config: Union[Unset, "TransportConfigConfig"] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        config: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.config, Unset):
+            config = self.config.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+            }
+        )
+        if config is not UNSET:
+            field_dict["config"] = config
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.transport_config_config import TransportConfigConfig
+
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        _config = d.pop("config", UNSET)
+        config: Union[Unset, TransportConfigConfig]
+        if isinstance(_config, Unset):
+            config = UNSET
+        else:
+            config = TransportConfigConfig.from_dict(_config)
+
+        transport_config = cls(
+            name=name,
+            config=config,
+        )
+
+        transport_config.additional_properties = d
+        return transport_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/transport_config_config.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/transport_config_config.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="TransportConfigConfig")
+
+
+@attr.s(auto_attribs=True)
+class TransportConfigConfig:
+    """Transport-specific endpoint configuration passed to
+    [`OutputTransport::new_endpoint`](`crate::OutputTransport::new_endpoint`)
+    and
+    [`InputTransport::new_endpoint`](`crate::InputTransport::new_endpoint`).
+
+    """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        transport_config_config = cls()
+
+        transport_config_config.additional_properties = d
+        return transport_config_config
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_connector_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_connector_request.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UpdateConnectorRequest")
+
+
+@attr.s(auto_attribs=True)
+class UpdateConnectorRequest:
+    """Request to update an existing data-connector.
+
+    Attributes:
+        connector_id (str): Unique connector id.
+        description (str): New connector description.
+        name (str): New connector name.
+        config (Union[Unset, None, str]): New config YAML. If absent, existing YAML will be kept unmodified.
+    """
+
+    connector_id: str
+    description: str
+    name: str
+    config: Union[Unset, None, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        connector_id = self.connector_id
+        description = self.description
+        name = self.name
+        config = self.config
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "connector_id": connector_id,
+                "description": description,
+                "name": name,
+            }
+        )
+        if config is not UNSET:
+            field_dict["config"] = config
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        connector_id = d.pop("connector_id")
+
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        config = d.pop("config", UNSET)
+
+        update_connector_request = cls(
+            connector_id=connector_id,
+            description=description,
+            name=name,
+            config=config,
+        )
+
+        update_connector_request.additional_properties = d
+        return update_connector_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_connector_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_connector_response.py
@@ -1,0 +1,43 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="UpdateConnectorResponse")
+
+
+@attr.s(auto_attribs=True)
+class UpdateConnectorResponse:
+    """Response to a config update request."""
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        update_connector_response = cls()
+
+        update_connector_response.additional_properties = d
+        return update_connector_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_pipeline_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_pipeline_request.py
@@ -1,0 +1,124 @@
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.attached_connector import AttachedConnector
+
+
+T = TypeVar("T", bound="UpdatePipelineRequest")
+
+
+@attr.s(auto_attribs=True)
+class UpdatePipelineRequest:
+    """Request to update an existing program configuration.
+
+    Attributes:
+        description (str): New config description.
+        name (str): New config name.
+        pipeline_id (str): Unique pipeline id.
+        config (Union[Unset, None, str]): New config YAML. If absent, existing YAML will be kept unmodified.
+        connectors (Union[Unset, None, List['AttachedConnector']]): Attached connectors.
+
+            - If absent, existing connectors will be kept unmodified.
+
+            - If present all existing connectors will be replaced with the new
+            specified list.
+        program_id (Union[Unset, None, str]): Unique program id.
+    """
+
+    description: str
+    name: str
+    pipeline_id: str
+    config: Union[Unset, None, str] = UNSET
+    connectors: Union[Unset, None, List["AttachedConnector"]] = UNSET
+    program_id: Union[Unset, None, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        description = self.description
+        name = self.name
+        pipeline_id = self.pipeline_id
+        config = self.config
+        connectors: Union[Unset, None, List[Dict[str, Any]]] = UNSET
+        if not isinstance(self.connectors, Unset):
+            if self.connectors is None:
+                connectors = None
+            else:
+                connectors = []
+                for connectors_item_data in self.connectors:
+                    connectors_item = connectors_item_data.to_dict()
+
+                    connectors.append(connectors_item)
+
+        program_id = self.program_id
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "description": description,
+                "name": name,
+                "pipeline_id": pipeline_id,
+            }
+        )
+        if config is not UNSET:
+            field_dict["config"] = config
+        if connectors is not UNSET:
+            field_dict["connectors"] = connectors
+        if program_id is not UNSET:
+            field_dict["program_id"] = program_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        from ..models.attached_connector import AttachedConnector
+
+        d = src_dict.copy()
+        description = d.pop("description")
+
+        name = d.pop("name")
+
+        pipeline_id = d.pop("pipeline_id")
+
+        config = d.pop("config", UNSET)
+
+        connectors = []
+        _connectors = d.pop("connectors", UNSET)
+        for connectors_item_data in _connectors or []:
+            connectors_item = AttachedConnector.from_dict(connectors_item_data)
+
+            connectors.append(connectors_item)
+
+        program_id = d.pop("program_id", UNSET)
+
+        update_pipeline_request = cls(
+            description=description,
+            name=name,
+            pipeline_id=pipeline_id,
+            config=config,
+            connectors=connectors,
+            program_id=program_id,
+        )
+
+        update_pipeline_request.additional_properties = d
+        return update_pipeline_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_pipeline_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_pipeline_response.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="UpdatePipelineResponse")
+
+
+@attr.s(auto_attribs=True)
+class UpdatePipelineResponse:
+    """Response to a config update request.
+
+    Attributes:
+        version (int): Version number.
+    """
+
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        version = d.pop("version")
+
+        update_pipeline_response = cls(
+            version=version,
+        )
+
+        update_pipeline_response.additional_properties = d
+        return update_pipeline_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_program_request.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_program_request.py
@@ -1,0 +1,84 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="UpdateProgramRequest")
+
+
+@attr.s(auto_attribs=True)
+class UpdateProgramRequest:
+    """Update program request.
+
+    Attributes:
+        name (str): New name for the program.
+        program_id (str): Unique program id.
+        code (Union[Unset, None, str]): New SQL code for the program or `None` to keep existing program
+            code unmodified.
+        description (Union[Unset, str]): New description for the program.
+    """
+
+    name: str
+    program_id: str
+    code: Union[Unset, None, str] = UNSET
+    description: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        name = self.name
+        program_id = self.program_id
+        code = self.code
+        description = self.description
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "program_id": program_id,
+            }
+        )
+        if code is not UNSET:
+            field_dict["code"] = code
+        if description is not UNSET:
+            field_dict["description"] = description
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        name = d.pop("name")
+
+        program_id = d.pop("program_id")
+
+        code = d.pop("code", UNSET)
+
+        description = d.pop("description", UNSET)
+
+        update_program_request = cls(
+            name=name,
+            program_id=program_id,
+            code=code,
+            description=description,
+        )
+
+        update_program_request.additional_properties = d
+        return update_program_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/models/update_program_response.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/update_program_response.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="UpdateProgramResponse")
+
+
+@attr.s(auto_attribs=True)
+class UpdateProgramResponse:
+    """Response to a program update request.
+
+    Attributes:
+        version (int): Version number.
+    """
+
+    version: int
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        version = self.version
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "version": version,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        version = d.pop("version")
+
+        update_program_response = cls(
+            version=version,
+        )
+
+        update_program_response.additional_properties = d
+        return update_program_response
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/dbsp-api-client/dbsp_api_client/py.typed
+++ b/python/dbsp-api-client/dbsp_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/python/dbsp-api-client/dbsp_api_client/types.py
+++ b/python/dbsp-api-client/dbsp_api_client/types.py
@@ -1,0 +1,44 @@
+""" Contains some shared types for properties """
+from http import HTTPStatus
+from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
+
+import attr
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+FileJsonType = Tuple[Optional[str], BinaryIO, Optional[str]]
+
+
+@attr.s(auto_attribs=True)
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileJsonType:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@attr.s(auto_attribs=True)
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["File", "Response", "FileJsonType"]

--- a/python/dbsp-api-client/pyproject.toml
+++ b/python/dbsp-api-client/pyproject.toml
@@ -1,0 +1,39 @@
+[tool.poetry]
+name = "dbsp-api-client"
+version = "0.1.0"
+description = "A client library for accessing DBSP API"
+
+authors = []
+
+readme = "README.md"
+packages = [
+    {include = "dbsp_api_client"},
+]
+include = ["CHANGELOG.md", "dbsp_api_client/py.typed"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+httpx = ">=0.15.4,<0.25.0"
+attrs = ">=21.3.0"
+python-dateutil = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 120
+target_version = ['py38', 'py39', 'py310', 'py311']
+exclude = '''
+(
+  /(
+    | \.git
+    | \.venv
+    | \.mypy_cache
+  )/
+)
+'''
+
+[tool.isort]
+line_length = 120
+profile = "black"


### PR DESCRIPTION
- Fixes remaining issues in https://github.com/feldera/dbsp/issues/176
  -  e.g., caches the python and maven dependencies, avoid calling into `cargo make` from CI as it will unconditionally rebuild the SQL compiler and the python dependencies
- Formatting and linting for docs/
- Move sql-to-dbsp-compiler/temp under workspace so it benefits from target cache