### PR TITLE
pipeline-manager: reintroduce tenant_id to attached_connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4641,16 +4641,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal_macros"
-version = "1.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e773fd3da1ed42472fdf3cfdb4972948a555bc3d73f5e0bdb99d17e7b54c687"
-dependencies = [
- "quote 1.0.28",
- "rust_decimal",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,10 +5123,8 @@ dependencies = [
  "geo-types",
  "num",
  "rust_decimal",
- "rust_decimal_macros",
  "serde",
  "size-of",
- "sqlx",
 ]
 
 [[package]]
@@ -5737,10 +5725,6 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 [[package]]
 name = "tuple"
 version = "0.1.0"
-dependencies = [
- "serde",
- "sqlvalue",
-]
 
 [[package]]
 name = "typedmap"

--- a/crates/pipeline_manager/src/db/ddl.sql
+++ b/crates/pipeline_manager/src/db/ddl.sql
@@ -44,12 +44,14 @@ CREATE TABLE IF NOT EXISTS connector (
 CREATE TABLE IF NOT EXISTS attached_connector (
             pipeline_id uuid NOT NULL,
             connector_id uuid NOT NULL,
+            tenant_id uuid NOT NULL,
             name varchar,
             config varchar,
             is_input bool NOT NULL,
             PRIMARY KEY (pipeline_id, name),
             FOREIGN KEY (pipeline_id) REFERENCES pipeline(id) ON DELETE CASCADE,
-            FOREIGN KEY (connector_id) REFERENCES connector(id) ON DELETE CASCADE);
+            FOREIGN KEY (connector_id) REFERENCES connector(id) ON DELETE CASCADE,
+            FOREIGN KEY (tenant_id) REFERENCES tenant(id) ON DELETE CASCADE);
 CREATE TABLE IF NOT EXISTS api_key (
             hash varchar PRIMARY KEY,
             tenant_id uuid NOT NULL,

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -247,6 +247,7 @@ pub(crate) trait Storage {
     /// Get input/output status for an attached connector.
     async fn attached_connector_is_input(
         &self,
+        tenant_id: TenantId,
         pipeline_id: PipelineId,
         name: &str,
     ) -> AnyResult<bool>;

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -1442,6 +1442,7 @@ impl Storage for Mutex<DbModel> {
 
     async fn attached_connector_is_input(
         &self,
+        _tenant_id: TenantId,
         _pipeline_id: PipelineId,
         _name: &str,
     ) -> anyhow::Result<bool> {

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -390,7 +390,7 @@ impl LocalRunner {
             .db
             .lock()
             .await
-            .attached_connector_is_input(pipeline_id, attached_connector_name)
+            .attached_connector_is_input(tenant_id, pipeline_id, attached_connector_name)
             .await?;
 
         // TODO: it might be better to have ?name={}, otherwise we have to


### PR DESCRIPTION
Even though attached_connector simply combines pipelines and connectors, and augments the result with additional config information, it's worth tagging it also with the tenant_id because some APIs do query attached_connector directly.

Not doing so requires us to take fragile precautions when invoking APIs like attached_connector_is_input(), where we have to be sure the caller has the right permissions via other calls.