### PR TITLE
Introduce aggregate_simple_linear function

### DIFF
--- a/crates/dbsp/examples/tutorial/tutorial4.rs
+++ b/crates/dbsp/examples/tutorial/tutorial4.rs
@@ -47,7 +47,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     Ok((input_handle, monthly_totals.output()))
 }
 

--- a/crates/dbsp/examples/tutorial/tutorial5.rs
+++ b/crates/dbsp/examples/tutorial/tutorial5.rs
@@ -51,7 +51,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     let moving_averages = monthly_totals
         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
         .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))

--- a/crates/dbsp/examples/tutorial/tutorial6.rs
+++ b/crates/dbsp/examples/tutorial/tutorial6.rs
@@ -51,7 +51,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     let moving_averages = monthly_totals
         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
         .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))

--- a/crates/dbsp/examples/tutorial/tutorial7.rs
+++ b/crates/dbsp/examples/tutorial/tutorial7.rs
@@ -56,7 +56,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     let most_vax = monthly_totals
         .map_index(|((l, y, m), sum)| {
             (

--- a/crates/dbsp/examples/tutorial/tutorial8.rs
+++ b/crates/dbsp/examples/tutorial/tutorial8.rs
@@ -53,7 +53,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     let running_monthly_totals = monthly_totals
         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
         .partitioned_rolling_aggregate_linear(

--- a/crates/dbsp/examples/tutorial/tutorial9.rs
+++ b/crates/dbsp/examples/tutorial/tutorial9.rs
@@ -56,7 +56,7 @@ fn build_circuit(
                 r.daily_vaccinations.unwrap_or(0),
             )
         })
-        .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+        .aggregate_linear(|v| *v as isize);
     let most_vax = monthly_totals
         .map_index(|((l, y, m), sum)| {
             (

--- a/crates/dbsp/src/operator/aggregate/average.rs
+++ b/crates/dbsp/src/operator/aggregate/average.rs
@@ -180,9 +180,7 @@ impl<T, R> MulByRef<R> for Avg<T, R>
 where
     T: MulByRef<Output = T>,
     T: From<R>,
-    R: MulByRef<Output = R>,
-    // This bound is only here to prevent conflict with `MulByRef<Present>` :(
-    R: From<i8> + Clone,
+    R: MulByRef<Output = R> + Clone,
 {
     type Output = Avg<T, R>;
 
@@ -230,9 +228,9 @@ where
         Z::R: ZRingValue,
         Avg<A, Z::R>: MulByRef<Z::R, Output = Avg<A, Z::R>>,
         A: DBData + From<Z::R> + Div<Output = A> + GroupValue,
-        F: Fn(&Z::Key, &Z::Val) -> A + Clone + 'static,
+        F: Fn(&Z::Val) -> A + Clone + 'static,
     {
-        let aggregate = self.aggregate_linear(move |key, val| Avg::new(f(key, val), Z::R::one()));
+        let aggregate = self.aggregate_linear(move |val| Avg::new(f(val), Z::R::one()));
 
         // We're the only possible consumer of the aggregated stream so we can use an
         // owned consumer to skip any cloning

--- a/crates/dbsp/src/operator/count.rs
+++ b/crates/dbsp/src/operator/count.rs
@@ -27,7 +27,7 @@ where
     where
         O: Batch<Key = Z::Key, Val = Z::R, R = Z::R, Time = ()>,
     {
-        self.aggregate_linear_generic(|_k, _v| Z::R::one())
+        self.aggregate_linear_generic(|_v| Z::R::one())
     }
 
     /// Incrementally, for each key in `self`, counts the number of unique
@@ -68,7 +68,7 @@ where
         O: IndexedZSet<Key = Z::Key, Val = Z::R, R = Z::R, Time = ()>,
         Z: Send,
     {
-        self.stream_aggregate_linear_generic(|_k, _v| Z::R::one())
+        self.stream_aggregate_linear_generic(|_v| Z::R::one())
     }
 
     /// Incrementally, for each key in `self`, counts the number of unique

--- a/crates/dbsp/src/tutorial.rs
+++ b/crates/dbsp/src/tutorial.rs
@@ -573,13 +573,13 @@
 //!
 //! Then we can call [`Stream::aggregate_linear`], the simplest form of
 //! aggregation in DBSP, to sum across months.  This function sums the output of
-//! a function of key-value pairs across each unique key.  To get monthly
+//! a function.  To get monthly
 //! vaccinations, we just sum the values from our indexed Z-set (we have to
 //! convert to `isize` because aggregation implicitly multiplies by record
 //! weights):
 //!
 //! ```ignore
-//!         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//!         .aggregate_linear(|v| *v as isize);
 //! ```
 //!
 //! We output the indexed Z-set as before, and then in `main` print it record by
@@ -622,7 +622,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //!     // ...
 //!     Ok((input_handle, monthly_totals.output()))
 //! }
@@ -762,7 +762,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let moving_averages = monthly_totals
 //! #         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //! #         .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))
@@ -903,7 +903,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let moving_averages = monthly_totals
 //! #         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //! #         .partitioned_rolling_average(RelRange::new(RelOffset::Before(2), RelOffset::Before(0)))
@@ -946,7 +946,7 @@
 //!
 //! The whole program is in `tutorial6.rs`.  If we run it, it prints both per-month
 //! vaccination numbers and 3-month moving averages:
-//!  
+//!
 //!  ```text
 //! England          2021-01    5600174    5600174: +1
 //! England          2021-02    9377418    7488796: +1
@@ -1055,7 +1055,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let most_vax = monthly_totals
 //! #         .map_index(|((l, y, m), sum)| {
 //! #             (
@@ -1178,7 +1178,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let running_monthly_totals = monthly_totals
 //! #         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //! #         .partitioned_rolling_aggregate_linear(
@@ -1281,7 +1281,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let running_monthly_totals = monthly_totals
 //! #         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //! #         .partitioned_rolling_aggregate_linear(
@@ -1387,7 +1387,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //!    let running_monthly_totals = monthly_totals
 //!        .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //!        .partitioned_rolling_aggregate_linear(
@@ -1454,7 +1454,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let running_monthly_totals = monthly_totals
 //! #         .map_index(|((l, y, m), v)| (l.clone(), (*y as u32 * 12 + (*m as u32 - 1), *v)))
 //! #         .partitioned_rolling_aggregate_linear(
@@ -1584,7 +1584,7 @@
 //! #                 r.daily_vaccinations.unwrap_or(0),
 //! #             )
 //! #         })
-//! #         .aggregate_linear(|(_l, _y, _m), v| *v as isize);
+//! #         .aggregate_linear(|v| *v as isize);
 //! #     let most_vax = monthly_totals
 //! #         .map_index(|((l, y, m), sum)| {
 //! #             (

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPAggregate.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/DBSPAggregate.java
@@ -244,7 +244,7 @@ public class DBSPAggregate extends DBSPNode implements IDBSPInnerNode {
      * The linear functions have the signature:
      * '|row| value', where 'row' is always the same variable.
      * The result function will have the signature:
-     * |_k, row| (value0, value1, ...).
+     * |row| (value0, value1, ...).
      */
     public DBSPClosureExpression combineLinear() {
         DBSPClosureExpression[] closures = Linq.map(this.components, c -> c.linearFunction, DBSPClosureExpression.class);
@@ -253,10 +253,9 @@ public class DBSPAggregate extends DBSPNode implements IDBSPInnerNode {
                 throw new RuntimeException("Expected exactly 1 parameter for linear closure" + expr);
         }
         DBSPParameter row = closures[0].parameters[0];
-        DBSPParameter key = new DBSPVariablePath("_k", DBSPTypeAny.INSTANCE).asParameter();
         DBSPExpression[] bodies = Linq.map(closures, c -> c.body, DBSPExpression.class);
         DBSPTupleExpression tuple = new DBSPTupleExpression(bodies);
-        return tuple.closure(key, row);
+        return tuple.closure(row);
     }
 
     /**


### PR DESCRIPTION
Aggregation functions almost never care about the key. So I added a aggregate_simple_linear method which takes a function that ignores the key and just calls aggregate_linear. 

In fact, I am wondering whether the aggregation function can ever depend on the key while still being linear.