### PR TITLE
kubernetes: update DBSP Kind deployment setup

### DIFF
--- a/deploy/kind/dbsp-deploy.yml
+++ b/deploy/kind/dbsp-deploy.yml
@@ -98,6 +98,7 @@ metadata:
   name: cluster-ingress
   namespace: dbsp
   annotations:
+    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:

--- a/deploy/kind/setup.sh
+++ b/deploy/kind/setup.sh
@@ -5,22 +5,8 @@ set -e
 #### Refresh kind
 kind delete cluster
 
-#### Script from https://kind.sigs.k8s.io/docs/user/local-registry/
-#### Sets it up so the kind cluster uses the local docker image registry
-
-set -o errexit
-
-# create registry container unless it already exists
-reg_name='kind-registry'
-reg_port='5001'
-if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
-  docker run \
-    -d --restart=always -p "127.0.0.1:${reg_port}:5000" --name "${reg_name}" \
-    registry:2
-fi
-
 # create a cluster with the local registry enabled in containerd
-cat <<EOF | kind create cluster --image=kindest/node:v1.23.13 --config=-
+cat <<EOF | kind create cluster --image=kindest/node:v1.25.0 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
@@ -41,38 +27,12 @@ nodes:
   - role: worker
   - role: worker
   - role: worker
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
-    endpoint = ["http://${reg_name}:5000"]
-EOF
-
-# connect the registry to the cluster network if not already connected
-if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
-  docker network connect "kind" "${reg_name}"
-fi
-
-# Document the local registry
-# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: local-registry-hosting
-  namespace: kube-public
-data:
-  localRegistryHosting.v1: |
-    host: "localhost:${reg_port}"
-    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 
 #### Install Redpanda helm charts
 helm repo add redpanda https://charts.redpanda.com/
 helm repo update
 helm install redpanda redpanda/redpanda --version 2.6.1 --set statefulset.replicas=1
-
-docker tag dbspmanager localhost:5001/dbspmanager && docker push localhost:5001/dbspmanager
-
 
 #### Set up ingress controller
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml


### PR DESCRIPTION
* Removes local registry, which we no longer need due to GHCR
* Add ingress.class annotation to DBSP Ingress object. Without this annotation, the AWS nginx controller will ignore the entry.