### PR TITLE
Support for CHAR(n).  Automate more of the testing.

### DIFF
--- a/docs/docs/sql/string.md
+++ b/docs/docs/sql/string.md
@@ -6,15 +6,13 @@ can store strings up to n characters (not bytes) in length. An attempt
 to store a longer string into a column of these types will result in
 an error, unless the excess characters are all spaces, in which case
 the string will be truncated to the maximum length. (This somewhat
-bizarre exception is required by the SQL standard.) If the string to
+bizarre exception is required by the SQL standard.)  If the string to
 be stored is shorter than the declared length, values of type
 character will be space-padded; values of type character varying will
 simply store the shorter string.
 
 In addition, we provides the `text`, or `varchar` type, which stores
-strings of any length.  Although the type `text` is not in the SQL
-standard, several other SQL database management systems have it as
-well.
+strings of any length.
 
 ## String constants (literals)
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -241,7 +241,7 @@ public class RustSqlRuntimeLibrary {
                 DBSPTypeBool.INSTANCE
         };
         DBSPType[] stringTypes = new DBSPType[] {
-                DBSPTypeString.INSTANCE
+                DBSPTypeString.UNLIMITED_INSTANCE
         };
         DBSPType[] fpTypes = new DBSPType[] {
                 DBSPTypeDouble.INSTANCE,

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -438,6 +438,14 @@ public class ToRustInnerVisitor extends InnerVisitor {
                     .append(", ")
                     .append(dec.scale);
         }
+        DBSPTypeString str = baseDest.as(DBSPTypeString.class);
+        if (str != null) {
+            // pass precision and scale as arguments to cast method too
+            this.builder.append(", ")
+                    .append(str.precision)
+                    .append(", ")
+                    .append(Boolean.toString(str.fixed));
+        }
         this.builder.append(")");
         return VisitDecision.STOP;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.dbsp.sqlCompiler.compiler.ICompilerComponent;
 import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.errors.SourcePositionRange;
+import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
 import org.dbsp.sqlCompiler.ir.type.*;
 import org.dbsp.sqlCompiler.ir.type.primitive.*;
 import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
@@ -99,8 +100,14 @@ public class TypeCompiler implements ICompilerComponent {
                 case DOUBLE:
                     return DBSPTypeDouble.INSTANCE.setMayBeNull(nullable);
                 case CHAR:
-                case VARCHAR:
-                    return DBSPTypeString.INSTANCE.setMayBeNull(nullable);
+                case VARCHAR: {
+                    int precision = dt.getPrecision();
+                    if (precision == 0)
+                        throw new UnsupportedException("0 size string", node);
+                    if (precision == RelDataType.PRECISION_NOT_SPECIFIED)
+                        precision = 0;
+                    return new DBSPTypeString(node, precision, tn.equals(SqlTypeName.CHAR), nullable);
+                }
                 case NULL:
                     return DBSPTypeNull.INSTANCE;
                 case SYMBOL:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPStringLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPStringLiteral.java
@@ -29,6 +29,7 @@ import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
 import org.dbsp.util.IIndentStream;
+import org.dbsp.util.Utilities;
 
 import javax.annotation.Nullable;
 import java.nio.charset.Charset;
@@ -68,13 +69,13 @@ public class DBSPStringLiteral extends DBSPLiteral {
     }
 
     public DBSPStringLiteral(@Nullable String value, Charset charset, boolean nullable) {
-        this(CalciteObject.EMPTY, DBSPTypeString.INSTANCE.setMayBeNull(nullable), value, charset);
+        this(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_INSTANCE.setMayBeNull(nullable), value, charset);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }
 
     public DBSPStringLiteral(@Nullable String value, boolean nullable) {
-        this(CalciteObject.EMPTY, DBSPTypeString.INSTANCE.setMayBeNull(nullable), value, StandardCharsets.UTF_8);
+        this(CalciteObject.EMPTY, DBSPTypeString.UNLIMITED_INSTANCE.setMayBeNull(nullable), value, StandardCharsets.UTF_8);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }
@@ -99,6 +100,6 @@ public class DBSPStringLiteral extends DBSPLiteral {
                     .append(this.type)
                     .append(")null");
         else
-            return builder.append(this.value);
+            return builder.append(Utilities.doubleQuote(this.value));
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeBaseType.java
@@ -26,6 +26,7 @@ package org.dbsp.sqlCompiler.ir.type.primitive;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
 import org.dbsp.sqlCompiler.ir.type.DBSPType;
 import org.dbsp.util.IIndentStream;
@@ -66,6 +67,13 @@ public abstract class DBSPTypeBaseType extends DBSPType {
      * Default value for this type.
      */
     public abstract DBSPLiteral defaultValue();
+
+    /**
+     * The null value with this type.
+     */
+    public DBSPExpression nullValue() {
+        return DBSPLiteral.none(this);
+    }
 
     @Override
     public IIndentStream toString(IIndentStream builder) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeMillisInterval.java
@@ -39,7 +39,7 @@ import java.util.Objects;
  * Always stores the interval value in milliseconds.
  */
 public class DBSPTypeMillisInterval extends DBSPTypeBaseType implements IsNumericType, IsDateType {
-    public static final DBSPType INSTANCE =new DBSPTypeMillisInterval(CalciteObject.EMPTY, false);
+    public static final DBSPType INSTANCE = new DBSPTypeMillisInterval(CalciteObject.EMPTY, false);
     public static final DBSPType NULLABLE_INSTANCE = new DBSPTypeMillisInterval(CalciteObject.EMPTY, true);
 
     public DBSPTypeMillisInterval(CalciteObject node, boolean mayBeNull) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DBSPExecutor.java
@@ -588,14 +588,14 @@ public class DBSPExecutor extends SqlSltTestExecutor {
                 throw new RuntimeException("Expected hash to be supplied");
             String hash = isVector ? "hash_vectors" : "hash";
             list.add(new DBSPLetStatement("_hash",
-                    new DBSPApplyExpression(hash, DBSPTypeString.INSTANCE,
+                    new DBSPApplyExpression(hash, DBSPTypeString.UNLIMITED_INSTANCE,
                             output0.borrow(),
                             columnTypes,
                             sort)));
             list.add(
                     new DBSPExpressionStatement(
                             new DBSPApplyExpression("assert_eq!", DBSPTypeVoid.INSTANCE,
-                                    DBSPTypeString.INSTANCE.var("_hash"),
+                                    DBSPTypeString.UNLIMITED_INSTANCE.var("_hash"),
                                     new DBSPStringLiteral(description.hash))));
         }
         DBSPExpression body = new DBSPBlockExpression(list, null);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/executors/DbspJdbcExecutor.java
@@ -102,7 +102,7 @@ public class DbspJdbcExecutor extends DBSPExecutor {
                         break;
                     case VARCHAR:
                     case LONGVARCHAR:
-                        colTypes[i1] = DBSPTypeString.INSTANCE.setMayBeNull(nullable);
+                        colTypes[i1] = DBSPTypeString.UNLIMITED_INSTANCE.setMayBeNull(nullable);
                         break;
                     default:
                         throw new RuntimeException("Unexpected column type " + columnType);
@@ -128,7 +128,7 @@ public class DbspJdbcExecutor extends DBSPExecutor {
                     } else {
                         String s = rs.getString(i + 1);
                         if (s == null)
-                            exp = DBSPLiteral.none(DBSPTypeString.NULLABLE_INSTANCE);
+                            exp = DBSPLiteral.none(DBSPTypeString.UNLIMITED_INSTANCE.setMayBeNull(true));
                         else
                             exp = new DBSPStringLiteral(s, StandardCharsets.UTF_8, type.mayBeNull);
                     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/Utilities.java
@@ -123,6 +123,7 @@ public class Utilities {
      * @param map  Map to look for.
      * @param key  Key the value is indexed with.
      */
+    @SuppressWarnings("unused")
     public static <K, V> V removeExists(Map<K, V> map, K key) {
         V result = map.remove(key);
         if (result == null)

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/CastTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/CastTests.java
@@ -37,9 +37,8 @@ public class CastTests extends BaseSQLTests {
     final DBSPTypeDecimal tenTwo = new DBSPTypeDecimal(CalciteObject.EMPTY, 10, 2, true);
     final DBSPTypeDecimal tenFour = new DBSPTypeDecimal(CalciteObject.EMPTY, 10, 4, false);
 
-    @Override
-    public DBSPCompiler compileQuery(String query, boolean incremental, boolean optimize, boolean jit) {
-        DBSPCompiler compiler = testCompiler(incremental, optimize, jit);
+   public DBSPCompiler compileQuery(String query) {
+        DBSPCompiler compiler = this.testCompiler();
         String ddl = "CREATE TABLE T (\n" +
                 "COL1 INT NOT NULL" +
                 ", COL2 DOUBLE NOT NULL" +
@@ -52,7 +51,6 @@ public class CastTests extends BaseSQLTests {
         return compiler;
     }
 
-    @Override
     DBSPZSetLiteral.Contents createInput() {
         return new DBSPZSetLiteral.Contents(new DBSPTupleExpression(
                 new DBSPI32Literal(10),
@@ -64,7 +62,7 @@ public class CastTests extends BaseSQLTests {
 
     void testQuery(String query, DBSPZSetLiteral.Contents expectedOutput) {
         query = "CREATE VIEW V AS " + query;
-        DBSPCompiler compiler = this.compileQuery(query, false, true, false);
+        DBSPCompiler compiler = this.compileQuery(query);
         DBSPCircuit circuit = getCircuit(compiler);
         InputOutputPair streams = new InputOutputPair(this.createInput(), expectedOutput);
         this.addRustTestCase(query, compiler, circuit, streams);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ComplexQueriesTest.java
@@ -33,9 +33,7 @@ import org.dbsp.util.Utilities;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 @SuppressWarnings("SpellCheckingInspection")
 public class ComplexQueriesTest extends BaseSQLTests {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DBSPCompilerTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/DBSPCompilerTests.java
@@ -27,7 +27,6 @@ package org.dbsp.sqlCompiler.compiler;
 
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.backend.jit.ToJitVisitor;
 import org.dbsp.sqlCompiler.compiler.backend.rust.RustFileWriter;
 import org.dbsp.sqlCompiler.compiler.frontend.TableContents;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
@@ -39,15 +38,14 @@ import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static org.dbsp.sqlCompiler.compiler.BaseSQLTests.getCircuit;
 import static org.dbsp.sqlCompiler.compiler.BaseSQLTests.testFilePath;
 
 /**
  * Tests that invoke the CalciteToDBSPCompiler.
  */
 public class DBSPCompilerTests {
-    static final CompilerOptions options = new CompilerOptions();
-    final String ddl = "CREATE TABLE T (\n" +
+    static final CompilerOptions OPTIONS = new CompilerOptions();
+    private static final String DDL = "CREATE TABLE T (\n" +
             "COL1 INT NOT NULL" +
             ", COL2 DOUBLE NOT NULL" +
             ", COL3 BOOLEAN NOT NULL" +
@@ -65,7 +63,7 @@ public class DBSPCompilerTests {
                 "    present BOOLEAN\n" +
                 ");\n" +
                 "CREATE VIEW Adult AS SELECT Person.name FROM Person WHERE Person.age > 18;";
-        DBSPCompiler compiler = BaseSQLTests.testCompiler();
+        DBSPCompiler compiler = new DBSPCompiler(OPTIONS);
         compiler.compileStatements(statements);
         DBSPCircuit dbsp = compiler.getFinalCircuit("circuit");
         PrintStream outputStream = new PrintStream(Files.newOutputStream(Paths.get(testFilePath)));
@@ -77,52 +75,17 @@ public class DBSPCompilerTests {
 
     @Test
     public void DDLTest() {
-        DBSPCompiler compiler = new DBSPCompiler(options);
-        compiler.compileStatement(ddl);
+        DBSPCompiler compiler = new DBSPCompiler(OPTIONS);
+        compiler.compileStatement(DDL);
         DBSPCircuit dbsp = compiler.getFinalCircuit("circuit");
         Assert.assertNotNull(dbsp);
     }
 
     @Test
-    public void circuitToJitTest() {
-        DBSPCompiler compiler = new DBSPCompiler(options);
-        compiler.compileStatement(ddl);
-        compiler.compileStatement("CREATE VIEW V AS SELECT T.COL1 FROM T WHERE COL1 > 5");
-        DBSPCircuit dbsp = compiler.getFinalCircuit("circuit");
-        ToJitVisitor.validateJson(compiler, dbsp, false);
-    }
-
-    @Test
-    public void floatJitTest() {
-        String ddl = "CREATE TABLE bid (\n" +
-                "    auction BIGINT,\n" +
-                "    bidder BIGINT,\n" +
-                "    price BIGINT,\n" +
-                "    channel VARCHAR,\n" +
-                "    url VARCHAR,\n" +
-                "    dateTime TIMESTAMP(3),\n" +
-                "    extra VARCHAR\n" +
-                ");\n" +
-                "\n" +
-                "CREATE VIEW q2 AS\n" +
-                "SELECT\n" +
-                "    auction,\n" +
-                "    bidder,\n" +
-                "    CAST(0.908 AS FLOAT) * price as price, -- convert dollar to euro\n" +
-                "    dateTime,\n" +
-                "    extra\n" +
-                "FROM bid;";
-        DBSPCompiler compiler = new DBSPCompiler(options);
-        compiler.compileStatements(ddl);
-        DBSPCircuit circuit = getCircuit(compiler);
-        ToJitVisitor.validateJson(compiler, circuit, false);
-    }
-
-    @Test
     public void DDLAndInsertTest() {
-        DBSPCompiler compiler = new DBSPCompiler(options);
+        DBSPCompiler compiler = new DBSPCompiler(OPTIONS);
         String insert = "INSERT INTO T VALUES(0, 0.0, true, 'Hi')";
-        compiler.compileStatement(ddl);
+        compiler.compileStatement(DDL);
         compiler.compileStatement(insert);
         TableContents tableContents = compiler.getTableContents();
         DBSPZSetLiteral.Contents t = tableContents.getTableContents("T");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/InputOutputPair.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/InputOutputPair.java
@@ -1,0 +1,43 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeWeight;
+import org.dbsp.util.Linq;
+
+/**
+ * A pair of inputs and outputs used in a test.
+ */
+public class InputOutputPair {
+    /**
+     * An input value for every input table.
+     */
+    public final DBSPZSetLiteral.Contents[] inputs;
+    /**
+     * An expected output value for every output view.
+     */
+    public final DBSPZSetLiteral.Contents[] outputs;
+
+    public InputOutputPair(DBSPZSetLiteral.Contents[] inputs, DBSPZSetLiteral.Contents[] outputs) {
+        this.inputs = inputs;
+        this.outputs = outputs;
+    }
+
+    public InputOutputPair(DBSPZSetLiteral.Contents input, DBSPZSetLiteral.Contents output) {
+        this.inputs = new DBSPZSetLiteral.Contents[1];
+        this.inputs[0] = input;
+        this.outputs = new DBSPZSetLiteral.Contents[1];
+        this.outputs[0] = output;
+    }
+
+    static DBSPZSetLiteral[] toZSets(DBSPZSetLiteral.Contents[] data) {
+        return Linq.map(data, s -> new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, s), DBSPZSetLiteral.class);
+    }
+
+    public DBSPZSetLiteral[] getInputs() {
+        return toZSets(this.inputs);
+    }
+
+    public DBSPZSetLiteral[] getOutputs() {
+        return toZSets(this.outputs);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/JitTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/JitTests.java
@@ -1,5 +1,6 @@
 package org.dbsp.sqlCompiler.compiler;
 
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.backend.jit.ToJitVisitor;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
@@ -25,9 +26,9 @@ import java.math.BigDecimal;
  */
 public class JitTests extends EndToEndTests {
     @Override
-    void testQuery(String query, DBSPZSetLiteral.Contents expectedOutput) {
-        DBSPZSetLiteral.Contents input = this.createInput();
-        super.testQueryBase(query, false, true, true, new InputOutputPair(input, expectedOutput));
+    public DBSPCompiler testCompiler() {
+        CompilerOptions options = this.testOptions(false, true, true);
+        return new DBSPCompiler(options);
     }
 
     // All the @Ignore-ed tests below should eventually pass.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/MultiViewTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/MultiViewTests.java
@@ -35,16 +35,7 @@ import org.junit.Test;
 /**
  * Tests where multiple views are defined in the same circuit.
  */
-public class MultiViewTests extends BaseSQLTests {
-    static final String ddl = "CREATE TABLE T (\n" +
-            "COL1 INT NOT NULL" +
-            ", COL2 DOUBLE NOT NULL" +
-            ", COL3 BOOLEAN NOT NULL" +
-            ", COL4 VARCHAR NOT NULL" +
-            ", COL5 INT" +
-            ", COL6 DOUBLE" +
-            ")";
-
+public class MultiViewTests extends EndToEndTests {
     /**
      * Two output views.
      */
@@ -54,7 +45,7 @@ public class MultiViewTests extends BaseSQLTests {
         String query2 = "CREATE VIEW V2 as SELECT T.COL2 FROM T";
 
         DBSPCompiler compiler = testCompiler();
-        compiler.compileStatement(ddl);
+        compiler.compileStatement(E2E_TABLE);
         compiler.compileStatement(query1);
         compiler.compileStatement(query2);
 
@@ -82,7 +73,7 @@ public class MultiViewTests extends BaseSQLTests {
         String query2 = "CREATE VIEW V2 as SELECT * FROM V1";
 
         DBSPCompiler compiler = testCompiler();
-        compiler.compileStatement(ddl);
+        compiler.compileStatement(E2E_TABLE);
         compiler.compileStatement(query1);
         compiler.compileStatement(query2);
 
@@ -110,7 +101,7 @@ public class MultiViewTests extends BaseSQLTests {
         String query2 = "CREATE VIEW V2 as SELECT DISTINCT COL1 FROM (SELECT * FROM V1 JOIN T ON V1.COL3 = T.COL3)";
 
         DBSPCompiler compiler = testCompiler();
-        compiler.compileStatement(ddl);
+        compiler.compileStatement(E2E_TABLE);
         compiler.compileStatement(query1);
         compiler.compileStatement(query2);
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/NaiveIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/NaiveIncrementalTests.java
@@ -23,6 +23,7 @@
 
 package org.dbsp.sqlCompiler.compiler;
 
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.*;
@@ -38,8 +39,14 @@ import java.math.BigDecimal;
 // Runs the EndToEnd tests but on an input stream with 3 elements each and
 // using an incremental non-optimized circuit.
 public class NaiveIncrementalTests extends EndToEndTests {
+    @Override
+    public DBSPCompiler testCompiler() {
+        CompilerOptions options = this.testOptions(true, false, false);
+        return new DBSPCompiler(options);
+    }
+
     public void invokeTestQueryBase(String query, InputOutputPair... streams) {
-        super.testQueryBase(query, true, false, false, streams);
+        super.testQueryBase(query, streams);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OptimizedIncrementalTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OptimizedIncrementalTests.java
@@ -23,8 +23,16 @@
 
 package org.dbsp.sqlCompiler.compiler;
 
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
+
 public class OptimizedIncrementalTests extends NaiveIncrementalTests {
-    public void invokeTestQueryBase(String query, BaseSQLTests.InputOutputPair... streams) {
-        super.testQueryBase(query, true, true, false, streams);
+    @Override
+    public DBSPCompiler testCompiler() {
+        CompilerOptions options = this.testOptions(true, true, false);
+        return new DBSPCompiler(options);
+    }
+
+    public void invokeTestQueryBase(String query, InputOutputPair... streams) {
+        super.testQueryBase(query, streams);
     }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
@@ -125,14 +125,14 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         DBSPCircuit circuit = getCircuit(compiler);
         String str = circuit.toString();
         String expected = "Circuit circuit0 {\n" +
-                "    // DBSPSourceOperator 13\n" +
+                "    // DBSPSourceOperator 15\n" +
                 "    // CREATE TABLE T (\n" +
                 "    // COL1 INT NOT NULL, COL2 DOUBLE NOT NULL, COL3 BOOLEAN NOT NULL, COL4 VARCHAR NOT NULL, COL5 INT, COL6 DOUBLE)\n" +
                 "    let T = T();\n" +
-                "    // DBSPMapOperator 60\n" +
+                "    // DBSPMapOperator 63\n" +
                 "    let stream1: stream<OrdZSet<Tuple1<b>, Weight>> = T.map((|t: &Tuple6<i32, d, b, s, i32?, d?>| Tuple1::new((t.2))));\n" +
                 "    // CREATE VIEW V AS SELECT T.COL3 FROM T\n" +
-                "    // DBSPSinkOperator 64\n" +
+                "    // DBSPSinkOperator 67\n" +
                 "    let V: stream<OrdZSet<Tuple1<b>, Weight>> = stream1;\n" +
                 "}";
         Assert.assertEquals(expected, str);
@@ -232,7 +232,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
     @Test
     public void toCsvTest() {
         DBSPCompiler compiler = testCompiler();
-        DBSPZSetLiteral s = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, BaseSQLTests.e0, BaseSQLTests.e1);
+        DBSPZSetLiteral s = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, EndToEndTests.e0, EndToEndTests.e1);
         StringBuilder builder = new StringBuilder();
         ToCsvVisitor visitor = new ToCsvVisitor(compiler, builder, () -> "");
         visitor.traverse(s);
@@ -247,7 +247,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
     @Test
     public void rustCsvTest() throws IOException, InterruptedException {
         DBSPCompiler compiler = testCompiler();
-        DBSPZSetLiteral data = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, BaseSQLTests.e0, BaseSQLTests.e1);
+        DBSPZSetLiteral data = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, EndToEndTests.e0, EndToEndTests.e1);
         String fileName = BaseSQLTests.rustDirectory + "/" + "test.csv";
         File file = ToCsvVisitor.toCsv(compiler, fileName, data);
         List<DBSPStatement> list = new ArrayList<>();
@@ -286,14 +286,14 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         DBSPCompiler compiler = testCompiler();
 
         DBSPZSetLiteral data = new DBSPZSetLiteral(
-                DBSPTypeWeight.INSTANCE, BaseSQLTests.e0NoDouble, BaseSQLTests.e1NoDouble);
+                DBSPTypeWeight.INSTANCE, EndToEndTests.e0NoDouble, EndToEndTests.e1NoDouble);
         List<DBSPStatement> list = new ArrayList<>();
 
         String connectionString = "sqlite://" + filepath;
         // Generates a read_table(<conn>, <table_name>, <mapper from |AnyRow| -> Tuple type>) invocation
         DBSPTypeUser sqliteRowType = new DBSPTypeUser(CalciteObject.EMPTY, "AnyRow", false);
         DBSPVariablePath rowVariable = new DBSPVariablePath("row", sqliteRowType);
-        DBSPExpression[] fields = BaseSQLTests.e0NoDouble.fields; // Should be the same for e1NoDouble too
+        DBSPExpression[] fields = EndToEndTests.e0NoDouble.fields; // Should be the same for e1NoDouble too
         final List<DBSPExpression> rowGets = new ArrayList<>(fields.length);
         for (int i = 0; i < fields.length; i++) {
             DBSPApplyMethodExpression rowGet =

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestCase.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TestCase.java
@@ -1,0 +1,244 @@
+package org.dbsp.sqlCompiler.compiler;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ToJitVisitor;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ToRustJitLiteral;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ir.JITProgram;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ir.operators.JITSinkOperator;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ir.operators.JITSourceOperator;
+import org.dbsp.sqlCompiler.compiler.errors.UnsupportedException;
+import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
+import org.dbsp.sqlCompiler.ir.DBSPFunction;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPApplyMethodExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPBlockExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPIndexExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPStructExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPVariablePath;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStrLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPU32Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPUSizeLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.path.DBSPPath;
+import org.dbsp.sqlCompiler.ir.statement.DBSPComment;
+import org.dbsp.sqlCompiler.ir.statement.DBSPConstItem;
+import org.dbsp.sqlCompiler.ir.statement.DBSPExpressionStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPLetStatement;
+import org.dbsp.sqlCompiler.ir.statement.DBSPStatement;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeAny;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeStr;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeVoid;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeWeight;
+import org.dbsp.util.Linq;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a test case that will be executed.
+ */
+class TestCase {
+    /**
+     * Name of the test case.
+     */
+    public final String name;
+    /**
+     * Compiler used to compile the test case.
+     * Used for code generation.
+     */
+    public final DBSPCompiler compiler;
+    /**
+     * Circuit that is being tested.
+     */
+    public final DBSPCircuit circuit;
+    /**
+     * Supplied input and expected outputs for the circuit.
+     */
+    public final InputOutputPair[] data;
+
+    TestCase(String name, DBSPCompiler compiler, DBSPCircuit circuit, InputOutputPair... data) {
+        this.name = name;
+        this.circuit = circuit;
+        this.data = data;
+        this.compiler = compiler;
+    }
+
+    /**
+     * Generates a Rust function which tests a DBSP circuit.
+     *
+     * @return The code for a function that runs the circuit with the specified
+     * input and tests the produced output.
+     */
+    DBSPFunction createTesterCode(int testNumber) {
+        List<DBSPStatement> list = new ArrayList<>();
+        DBSPLetStatement circuit = new DBSPLetStatement("circuit",
+                new DBSPApplyExpression(this.circuit.name, DBSPTypeAny.INSTANCE), true);
+        list.add(circuit);
+        for (InputOutputPair pairs : this.data) {
+            DBSPZSetLiteral[] inputs = pairs.getInputs();
+            DBSPZSetLiteral[] outputs = pairs.getOutputs();
+            DBSPLetStatement out = new DBSPLetStatement("output",
+                    circuit.getVarReference().call(inputs));
+            list.add(out);
+            for (int i = 0; i < pairs.outputs.length; i++) {
+                DBSPStatement compare = new DBSPExpressionStatement(
+                        new DBSPApplyExpression("assert!", DBSPTypeVoid.INSTANCE,
+                                new DBSPApplyExpression("must_equal", DBSPTypeBool.INSTANCE,
+                                        out.getVarReference().field(i).borrow(),
+                                        outputs[i].borrow()),
+                                new DBSPStrLiteral(this.name, false, true)));
+                list.add(compare);
+            }
+        }
+        DBSPExpression body = new DBSPBlockExpression(list, null);
+        return new DBSPFunction("test" + testNumber, new ArrayList<>(),
+                DBSPTypeVoid.INSTANCE, body, Linq.list("#[test]"));
+    }
+
+    /**
+     * Generates a Rust function which tests a DBSP circuit using the JIT compiler.
+     *
+     * @return The code for a function that runs the circuit with the specified input
+     * and tests the produced output.
+     */
+    DBSPFunction createJITTesterCode(int testNumber) {
+        List<DBSPStatement> list = new ArrayList<>();
+        // Logger.INSTANCE.setDebugLevel(ToJitVisitor.class, 4);
+        JITProgram program = ToJitVisitor.circuitToJIT(this.compiler, this.circuit);
+        DBSPComment comment = new DBSPComment(program.toAssembly());
+        list.add(comment);
+
+        String json = program.asJson().toPrettyString();
+        DBSPStrLiteral value = new DBSPStrLiteral(json, false, true);
+        DBSPConstItem item = new DBSPConstItem("CIRCUIT", DBSPTypeStr.INSTANCE.ref(), value);
+        list.add(item);
+        DBSPExpression read = new DBSPApplyMethodExpression("rematerialize", DBSPTypeAny.INSTANCE,
+                new DBSPApplyExpression("serde_json::from_str::<SqlGraph>",
+                        DBSPTypeAny.INSTANCE, item.getVariable()).unwrap());
+        DBSPLetStatement graph = new DBSPLetStatement("graph", read);
+        list.add(graph);
+
+        DBSPLetStatement graphNodes = new DBSPLetStatement("graph_nodes",
+                new DBSPApplyMethodExpression("nodes", DBSPTypeAny.INSTANCE,
+                        graph.getVarReference()));
+        list.add(graphNodes);
+
+        DBSPLetStatement demands = new DBSPLetStatement("demands",
+                new DBSPStructExpression(
+                        DBSPTypeAny.INSTANCE.path(
+                                new DBSPPath("Demands", "new")),
+                        DBSPTypeAny.INSTANCE), true);
+        list.add(demands);
+
+        List<JITSourceOperator> tables = program.getSources();
+        for (JITSourceOperator source : tables) {
+            String table = source.table;
+            long index = source.id;
+            DBSPExpression nodeId = new DBSPStructExpression(
+                    DBSPTypeAny.INSTANCE.path(
+                            new DBSPPath("NodeId", "new")),
+                    DBSPTypeAny.INSTANCE,
+                    new DBSPU32Literal((int) index));
+            DBSPLetStatement id = new DBSPLetStatement(table + "_id", nodeId);
+            list.add(id);
+
+            DBSPIndexExpression indexExpr = new DBSPIndexExpression(CalciteObject.EMPTY,
+                    graphNodes.getVarReference(), id.getVarReference().borrow(), false);
+            DBSPExpression layout = new DBSPApplyMethodExpression(
+                    "layout", DBSPTypeAny.INSTANCE,
+                    new DBSPApplyMethodExpression("unwrap_source", DBSPTypeAny.INSTANCE,
+                            indexExpr.applyClone()));
+            DBSPLetStatement stat = new DBSPLetStatement(table + "_layout", layout);
+            list.add(stat);
+        }
+
+        DBSPExpression debug = new DBSPStructExpression(
+                DBSPTypeAny.INSTANCE.path(new DBSPPath("CodegenConfig", "debug")),
+                DBSPTypeAny.INSTANCE);
+        DBSPExpression allocateCircuit = new DBSPStructExpression(
+                DBSPTypeAny.INSTANCE.path(new DBSPPath("DbspCircuit", "new")),
+                DBSPTypeAny.INSTANCE,
+                graph.getVarReference(),
+                DBSPBoolLiteral.TRUE,
+                new DBSPUSizeLiteral(1),
+                debug,
+                demands.getVarReference());
+        DBSPLetStatement circuit = new DBSPLetStatement("circuit", allocateCircuit, true);
+        list.add(circuit);
+
+        if (this.data.length > 1) {
+            throw new UnsupportedException("Only support 1 input/output pair for tests", CalciteObject.EMPTY);
+        }
+
+        ToRustJitLiteral converter = new ToRustJitLiteral(this.compiler);
+        if (data.length > 0) {
+            InputOutputPair pair = this.data[0];
+            int index = 0;
+            for (JITSourceOperator source : tables) {
+                String table = source.table;
+                DBSPZSetLiteral input = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, pair.inputs[index]);
+                DBSPExpression contents = converter.apply(input).to(DBSPExpression.class);
+                DBSPExpressionStatement append = new DBSPExpressionStatement(
+                        new DBSPApplyMethodExpression(
+                                "append_input",
+                                DBSPTypeAny.INSTANCE,
+                                circuit.getVarReference(),
+                                new DBSPVariablePath(table + "_id", DBSPTypeAny.INSTANCE),
+                                contents.borrow()));
+                list.add(append);
+                index++;
+            }
+        }
+
+        DBSPExpressionStatement step = new DBSPExpressionStatement(
+                new DBSPApplyMethodExpression("step", DBSPTypeAny.INSTANCE,
+                        circuit.getVarReference()).unwrap());
+        list.add(step);
+
+        // read outputs
+        if (data.length > 0) {
+            InputOutputPair pair = this.data[0];
+            int index = 0;
+            for (JITSinkOperator sink : program.getSinks()) {
+                String view = sink.viewName;
+                DBSPZSetLiteral output = new DBSPZSetLiteral(DBSPTypeWeight.INSTANCE, pair.outputs[index]);
+                DBSPExpression sinkId = new DBSPStructExpression(
+                        DBSPTypeAny.INSTANCE.path(
+                                new DBSPPath("NodeId", "new")),
+                        DBSPTypeAny.INSTANCE,
+                        new DBSPU32Literal((int) sink.id));
+                DBSPLetStatement getOutput = new DBSPLetStatement(
+                        view, new DBSPApplyMethodExpression("consolidate_output",
+                        DBSPTypeAny.INSTANCE, circuit.getVarReference(), sinkId));
+                list.add(getOutput);
+                index++;
+                /*
+                DBSPExpressionStatement print = new DBSPExpressionStatement(
+                        new DBSPApplyExpression("println!", null,
+                                new DBSPStrLiteral("{:?}"),
+                                getOutput.getVarReference()));
+                list.add(print);
+                 */
+                DBSPExpression contents = converter.apply(output).to(DBSPExpression.class);
+                DBSPStatement compare = new DBSPExpressionStatement(
+                        new DBSPApplyExpression("assert!", DBSPTypeVoid.INSTANCE,
+                                new DBSPApplyExpression("must_equal_sc", DBSPTypeBool.INSTANCE,
+                                        getOutput.getVarReference().borrow(), contents.borrow())));
+                list.add(compare);
+            }
+        }
+
+        DBSPStatement kill = new DBSPExpressionStatement(
+                new DBSPApplyMethodExpression(
+                        "kill", DBSPTypeAny.INSTANCE, circuit.getVarReference()).unwrap());
+        list.add(kill);
+
+        DBSPExpression body = new DBSPBlockExpression(list, null);
+        return new DBSPFunction("test" + testNumber, new ArrayList<>(),
+                DBSPTypeVoid.INSTANCE, body, Linq.list("#[test]"));
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TimeTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/TimeTests.java
@@ -31,9 +31,8 @@ import org.dbsp.sqlCompiler.ir.expression.literal.*;
 import org.junit.Test;
 
 public class TimeTests extends BaseSQLTests {
-    @Override
-    public DBSPCompiler compileQuery(String query, boolean incremental, boolean optimize, boolean jit) {
-        DBSPCompiler compiler = testCompiler(incremental, optimize, jit);
+    public DBSPCompiler compileQuery(String query) {
+        DBSPCompiler compiler = this.testCompiler();
         String ddl = "CREATE TABLE T (\n" +
                 "COL1 TIMESTAMP NOT NULL" +
                 ")";
@@ -45,14 +44,13 @@ public class TimeTests extends BaseSQLTests {
     public void testQuery(String query, DBSPExpression... fields) {
         // T contains a date with timestamp '100'.
         query = "CREATE VIEW V AS " + query;
-        DBSPCompiler compiler = this.compileQuery(query, false, true, false);
+        DBSPCompiler compiler = this.compileQuery(query);
         DBSPCircuit circuit = getCircuit(compiler);
         DBSPZSetLiteral.Contents expectedOutput = new DBSPZSetLiteral.Contents(new DBSPTupleExpression(fields));
         InputOutputPair streams = new InputOutputPair(this.createInput(), expectedOutput);
         this.addRustTestCase(query, compiler, circuit, streams);
     }
 
-    @Override
     public DBSPZSetLiteral.Contents createInput() {
         return new DBSPZSetLiteral.Contents(new DBSPTupleExpression(new DBSPTimestampLiteral(100)));
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBaseTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBaseTest.java
@@ -1,0 +1,217 @@
+package org.dbsp.sqlCompiler.compiler.postgres;
+
+import org.apache.calcite.config.Lex;
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.compiler.BaseSQLTests;
+import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.InputOutputPair;
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.errors.UnimplementedException;
+import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
+import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
+import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDateLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDecimalLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI16Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPIntervalMillisLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPStringLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPTimestampLiteral;
+import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeTuple;
+import org.dbsp.sqlCompiler.ir.type.DBSPTypeZSet;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBaseType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDate;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeFP;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeMillisInterval;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeStr;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeString;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeTimestamp;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public abstract class PostgresBaseTest extends BaseSQLTests {
+    /**
+     * Override this method to prepare the tables on
+     * which the tests are built.
+     */
+    public void prepareData(DBSPCompiler compiler) {}
+
+    public DBSPCompiler testCompiler(boolean optimize) {
+        CompilerOptions options = new CompilerOptions();
+        options.ioOptions.lexicalRules = Lex.ORACLE;
+        options.optimizerOptions.throwOnError = true;
+        options.optimizerOptions.optimizationLevel = optimize ? 2 : 1;
+        options.optimizerOptions.generateInputForEveryTable = true;
+        options.optimizerOptions.incrementalize = false;
+        return new DBSPCompiler(options);
+    }
+
+    // Calcite is not very flexible regarding timestamp formats
+    public DBSPCompiler compileQuery(String query, boolean optimize) {
+        DBSPCompiler compiler = this.testCompiler(optimize);
+        this.prepareData(compiler);
+        compiler.compileStatement(query);
+        return compiler;
+    }
+
+    static final SimpleDateFormat[] TIMESTAMP_INPUT_FORMAT = {
+            new SimpleDateFormat("EEE MMM d HH:mm:ss.SSS yyyy"),
+            new SimpleDateFormat("EEE MMM d HH:mm:ss yyyy G"),
+            new SimpleDateFormat("EEE MMM d HH:mm:ss yyyy")
+    };
+    static final SimpleDateFormat TIMESTAMP_OUTPUT_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+
+    /**
+     * Convert a timestamp from a format like Sat Feb 16 17:32:01 1996 to
+     * a format like 1996-02-16 17:32:01
+     */
+    public static DBSPExpression convertTimestamp(@Nullable String timestamp) {
+        if (timestamp == null)
+            return DBSPLiteral.none(DBSPTypeTimestamp.NULLABLE_INSTANCE);
+        for (SimpleDateFormat input: TIMESTAMP_INPUT_FORMAT) {
+            String out;
+            try {
+                // Calcite problems: does not support negative years, or fractional seconds ending in 0
+                Date zero = new SimpleDateFormat("yyyy-MM-dd").parse("0000-01-01");
+                Date converted = input.parse(timestamp);
+                out = TIMESTAMP_OUTPUT_FORMAT.format(converted);
+                if (converted.before(zero))
+                    out = "-" + out;
+            } catch (ParseException ignored) {
+                continue;
+            }
+            return new DBSPTimestampLiteral(out, true);
+        }
+        throw new RuntimeException("Could not parse " + timestamp);
+    }
+
+    static final SimpleDateFormat DATE_INPUT_FORMAT = new SimpleDateFormat("MM-dd-yyyy");
+    static final SimpleDateFormat DATE_OUTPUT_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+    /**
+     * Convert a date from the MM-DD-YYYY format (which is used in the Postgres output)
+     * to a DBSPLiteral.
+     */
+    static DBSPExpression convertDate(@Nullable String date) {
+        if (date == null || date.isEmpty() || date.equalsIgnoreCase("null"))
+            return DBSPLiteral.none(DBSPTypeDate.NULLABLE_INSTANCE);
+        try {
+            Date converted = DATE_INPUT_FORMAT.parse(date);
+            String out = DATE_OUTPUT_FORMAT.format(converted);
+            return new DBSPDateLiteral(out, true);
+        } catch (ParseException ex) {
+            throw new RuntimeException("Could not parse " + date);
+        }
+    }
+
+    public DBSPZSetLiteral.Contents parseTable(String table, DBSPType outputType) {
+        DBSPTypeZSet zset = outputType.to(DBSPTypeZSet.class);
+        DBSPZSetLiteral.Contents result = DBSPZSetLiteral.Contents.emptyWithElementType(zset.elementType);
+        DBSPTypeTuple tuple = zset.elementType.to(DBSPTypeTuple.class);
+
+        String[] lines = table.split("\n");
+        boolean inHeader = true;
+        for (String line: lines) {
+            if (line.startsWith("---")) {
+                inHeader = false;
+                continue;
+            }
+            if (inHeader)
+                continue;
+            String[] columns = line.split("[|]");
+            if (columns.length != tuple.size())
+                throw new RuntimeException("Row has " + columns.length + " columns, but expected " + tuple.size());
+            DBSPExpression[] values = new DBSPExpression[columns.length];
+            for (int i = 0; i < columns.length; i++) {
+                String column = columns[i].trim();
+                DBSPType fieldType = tuple.getFieldType(i);
+                if (!fieldType.is(DBSPTypeString.class) &&
+                        (column.isEmpty() ||
+                         column.equalsIgnoreCase("null"))) {
+                    if (!fieldType.mayBeNull)
+                        throw new RuntimeException("Null value in non-nullable column " + fieldType);
+                    values[i] = fieldType.to(DBSPTypeBaseType.class).nullValue();
+                    continue;
+                }
+                DBSPExpression columnValue;
+                if (fieldType.is(DBSPTypeFP.class)) {
+                    double value = Double.parseDouble(column);
+                    columnValue = new DBSPDoubleLiteral(value, fieldType.mayBeNull);
+                } else if (fieldType.is(DBSPTypeDecimal.class)) {
+                    BigDecimal value = new BigDecimal(column);
+                    columnValue = new DBSPDecimalLiteral(fieldType, value);
+                } else if (fieldType.is(DBSPTypeTimestamp.class)) {
+                    columnValue = convertTimestamp(column);
+                } else if (fieldType.is(DBSPTypeDate.class)) {
+                    columnValue = convertDate(column);
+                } else if (fieldType.is(DBSPTypeInteger.class)) {
+                    DBSPTypeInteger intType = fieldType.to(DBSPTypeInteger.class);
+                    switch (intType.getWidth()) {
+                        case 16:
+                            columnValue = new DBSPI16Literal(Short.parseShort(column), fieldType.mayBeNull);
+                            break;
+                        case 32:
+                            columnValue = new DBSPI32Literal(Integer.parseInt(column), fieldType.mayBeNull);
+                            break;
+                        case 64:
+                            columnValue = new DBSPI64Literal(Long.parseLong(column), fieldType.mayBeNull);
+                            break;
+                        default:
+                            throw new UnimplementedException(intType);
+                    }
+                } else if (fieldType.is(DBSPTypeMillisInterval.class)) {
+                    long value = Long.parseLong(column);
+                    columnValue = new DBSPIntervalMillisLiteral(value * 86400000, fieldType.mayBeNull);
+                } else if (fieldType.is(DBSPTypeString.class)) {
+                    // No trim
+                    columnValue = new DBSPStringLiteral(CalciteObject.EMPTY, fieldType, columns[i], StandardCharsets.UTF_8);
+                } else {
+                    throw new UnimplementedException(fieldType);
+                }
+                values[i] = columnValue;
+            }
+            result.add(new DBSPTupleExpression(values));
+        }
+        if (inHeader)
+            throw new RuntimeException("Could not find end of header for table");
+        return result;
+    }
+
+    DBSPZSetLiteral.Contents[] getPreparedInputs(DBSPCompiler compiler) {
+        DBSPZSetLiteral.Contents[] inputs = new DBSPZSetLiteral.Contents[
+                compiler.getTableContents().tablesCreated.size()];
+        int index = 0;
+        for (String table: compiler.getTableContents().tablesCreated) {
+            DBSPZSetLiteral.Contents data = compiler.getTableContents().getTableContents(table.toUpperCase());
+            inputs[index++] = data;
+        }
+        return inputs;
+    }
+
+    void compare(String query, String expected) {
+        DBSPCompiler compiler = this.testCompiler(true);
+        this.prepareData(compiler);
+        compiler.compileStatement("CREATE VIEW VV AS " + query);
+        compiler.optimize();
+        DBSPCircuit circuit = getCircuit(compiler);
+        DBSPType outputType = circuit.getOutputType(0);
+        DBSPZSetLiteral.Contents result = this.parseTable(expected, outputType);
+        InputOutputPair streams = new InputOutputPair(
+                this.getPreparedInputs(compiler),
+                new DBSPZSetLiteral.Contents[] { result }
+        );
+        this.addRustTestCase(query, compiler, circuit, streams);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBoolTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresBoolTests.java
@@ -3,6 +3,7 @@ package org.dbsp.sqlCompiler.compiler.postgres;
 import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
 import org.dbsp.sqlCompiler.compiler.BaseSQLTests;
 import org.dbsp.sqlCompiler.compiler.CompilerOptions;
+import org.dbsp.sqlCompiler.compiler.InputOutputPair;
 import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPBoolLiteral;
@@ -13,7 +14,7 @@ import org.junit.Test;
 /**
  * <a href="https://github.com/postgres/postgres/blob/master/src/test/regress/expected/boolean.out">boolean.out</a>
  */
-public class PostgresBoolTests extends BaseSQLTests {
+public class PostgresBoolTests extends PostgresBaseTest {
     public DBSPCompiler compileQuery(String query, boolean optimize) {
         CompilerOptions options = new CompilerOptions();
         options.optimizerOptions.optimizationLevel = optimize ? 2 : 1;

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -985,58 +985,99 @@ where
     }
 }
 
-#[inline]
-pub fn cast_to_s_b(value: bool) -> String {
-    value.to_string()
+#[inline(always)]
+pub fn truncate(value: String, size: usize) -> String {
+    let mut result = value.clone();
+    result.truncate(size);
+    result
+}
+
+/// Make sure the specified string has exactly the
+/// specified size.
+#[inline(always)]
+pub fn size_string(value: String, size: usize) -> String {
+    if size == 0 || value.len() == size { value }
+    else if value.len() > size { truncate(value, size) }
+    else { format!("{value:>size$}") }
+}
+
+/// Make sure that the specified string does not exceed
+/// the specified size.
+#[inline(always)]
+pub fn limit_string(value: String, size: usize) -> String {
+    if size == 0 || value.len() < size { value }
+    // TODO: this is legal only of all excess characters are spaces
+    else { truncate(value, size) }
+}
+
+#[inline(always)]
+pub fn limit_or_size_string(value: String, size: usize, fixed: bool) -> String {
+    if fixed { size_string(value, size) }
+    else { limit_string(value, size) }
 }
 
 #[inline]
-pub fn cast_to_s_bN(value: Option<bool>) -> String {
-    s_helper(value)
+pub fn cast_to_s_b(value: bool, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_decimal(value: Decimal) -> String {
-    value.to_string()
+pub fn cast_to_s_bN(value: Option<bool>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_decimalN(value: Option<Decimal>) -> String {
-    s_helper(value)
+pub fn cast_to_s_decimal(value: Decimal, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_d(value: F64) -> String {
-    value.to_string()
+pub fn cast_to_s_decimalN(value: Option<Decimal>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_dN(value: Option<F64>) -> String {
-    s_helper(value)
+pub fn cast_to_s_d(value: F64, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_f(value: F32) -> String {
-    value.to_string()
+pub fn cast_to_s_dN(value: Option<F64>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_fN(value: Option<F32>) -> String {
-    s_helper(value)
+pub fn cast_to_s_f(value: F32, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_s(value: String) -> String {
-    value
+pub fn cast_to_s_fN(value: Option<F32>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_sN(value: Option<String>) -> String {
-    value.unwrap()
+pub fn cast_to_s_s(value: String, size: usize, fixed: bool) -> String {
+    let result = value;
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_Timestamp(value: Timestamp) -> String {
+pub fn cast_to_s_sN(value: Option<String>, size: usize, fixed: bool) -> String {
+    let result = value.unwrap();
+    limit_or_size_string(result, size, fixed)
+}
+
+#[inline]
+pub fn cast_to_s_Timestamp(value: Timestamp, size: usize, fixed: bool) -> String {
     let dt = value.to_dateTime();
     let month = dt.month();
     let day = dt.day();
@@ -1044,155 +1085,173 @@ pub fn cast_to_s_Timestamp(value: Timestamp) -> String {
     let hr = dt.hour();
     let min = dt.minute();
     let sec = dt.second();
-    format!(
+    let result = format!(
         "{}-{:02}-{:02} {:02}:{:02}:{:02}",
         year, month, day, hr, min, sec
-    )
+    );
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i(value: isize) -> String {
-    value.to_string()
+pub fn cast_to_s_i(value: isize, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i16(value: i16) -> String {
-    value.to_string()
+pub fn cast_to_s_i16(value: i16, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i16N(value: Option<i16>) -> String {
-    s_helper(value)
+pub fn cast_to_s_i16N(value: Option<i16>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i32(value: i32) -> String {
-    value.to_string()
+pub fn cast_to_s_i32(value: i32, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i32N(value: Option<i32>) -> String {
-    s_helper(value)
+pub fn cast_to_s_i32N(value: Option<i32>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i64(value: i64) -> String {
-    value.to_string()
+pub fn cast_to_s_i64(value: i64, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_i64N(value: Option<i64>) -> String {
-    s_helper(value)
+pub fn cast_to_s_i64N(value: Option<i64>, size: usize, fixed: bool) -> String {
+    let result = s_helper(value);
+    limit_or_size_string(result, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_s_u(value: usize) -> String {
-    value.to_string()
+pub fn cast_to_s_u(value: usize, size: usize, fixed: bool) -> String {
+    let result = value.to_string();
+    limit_or_size_string(result, size, fixed)
 }
 
 /////////// cast to StringN
 
 #[inline]
-pub fn cast_to_sN_nullN(_value: Option<()>) -> Option<String> {
+pub fn cast_to_sN_nullN(_value: Option<()>, _size: usize, _fixed: bool) -> Option<String> {
     None
 }
 
 #[inline]
-pub fn sN_helper<T>(value: Option<T>) -> Option<String>
+pub fn sN_helper<T>(value: Option<T>, size: usize, fixed: bool) -> Option<String>
 where
     T: ToString,
 {
-    value.map(|x| x.to_string())
+    value.map(|x| limit_or_size_string(x.to_string(), size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_b(value: bool) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_b(value: bool, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_bN(value: Option<bool>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_bN(value: Option<bool>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_decimal(value: Decimal) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_decimal(value: Decimal, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_decimalN(value: Option<Decimal>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_decimalN(value: Option<Decimal>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_d(value: F64) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_d(value: F64, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_dN(value: Option<F64>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_dN(value: Option<F64>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_f(value: F32) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_f(value: F32, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_fN(value: Option<F32>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_fN(value: Option<F32>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_s(value: String) -> Option<String> {
-    Some(value)
+pub fn cast_to_sN_s(value: String, size: usize, fixed: bool) -> Option<String> {
+    Some(limit_or_size_string(value, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_sN(value: Option<String>) -> Option<String> {
-    value
+pub fn cast_to_sN_sN(value: Option<String>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_i(value: isize) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_i(value: isize, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_i16(value: i16) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_i16(value: i16, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_i16N(value: Option<i16>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_i16N(value: Option<i16>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_i32(value: i32) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_i32(value: i32, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_i32N(value: Option<i32>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_i32N(value: Option<i32>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_i64(value: i64) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_i64(value: i64, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 #[inline]
-pub fn cast_to_sN_i64N(value: Option<i64>) -> Option<String> {
-    sN_helper(value)
+pub fn cast_to_sN_i64N(value: Option<i64>, size: usize, fixed: bool) -> Option<String> {
+    sN_helper(value, size, fixed)
 }
 
 #[inline]
-pub fn cast_to_sN_u(value: usize) -> Option<String> {
-    Some(value.to_string())
+pub fn cast_to_sN_u(value: usize, size: usize, fixed: bool) -> Option<String> {
+    let result = value.to_string();
+    Some(limit_or_size_string(result, size, fixed))
 }
 
 /////////// cast to i16


### PR DESCRIPTION
This commit makes it easier to port tests from Postgres by automating the parsing of the input and output.
The compiler helps a lot.
Now you can write tests like this:

```Java
    @Override
    public void prepareData(DBSPCompiler compiler) {
        String data =
                "CREATE TABLE CHAR_TBL(f1 char(4));\n" +
                "INSERT INTO CHAR_TBL (f1) VALUES\n" +
                "  ('a'),\n" +
                "  ('ab'),\n" +
                "  ('abcd'),\n" +
                "  ('abcd    ');" +
                "CREATE TABLE VARCHAR_TBL(f1 varchar(4));\n" +
                "INSERT INTO VARCHAR_TBL (f1) VALUES\n" +
                "  ('a'),\n" +
                "  ('ab'),\n" +
                "  ('abcd'),\n" +
                "  ('abcd    ');";
        compiler.compileStatements(data);
    }

    @Test
    public void testVarcharN() {
        String query = "SELECT CAST(f1 AS text) AS \"text(varchar)\" FROM VARCHAR_TBL";
        String expected =
                " text(char) \n" +
                "------------\n" +
                "a   \n" +
                "ab  \n" +
                "abcd\n" +
                "abcd";
        this.compare(query, expected);
    }
```

This is almost a literal copy-and-paste from the "golden" Postgres test files.