### PR TITLE
Refactor `db` module to use strongly typed errors.

### DIFF
--- a/crates/pipeline_manager/src/auth.rs
+++ b/crates/pipeline_manager/src/auth.rs
@@ -63,7 +63,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::{
-    db::{storage::Storage, ApiPermission, ProjectDB},
+    db::{storage::Storage, ApiPermission, DBError, ProjectDB},
     ServerState,
 };
 
@@ -547,7 +547,7 @@ fn validate_field_is_str<'a>(key: &str, json: &'a Value) -> Option<&'a str> {
 async fn validate_api_keys(
     db: &ProjectDB,
     api_key: &str,
-) -> Result<(TenantId, Vec<ApiPermission>), anyhow::Error> {
+) -> Result<(TenantId, Vec<ApiPermission>), DBError> {
     db.validate_api_key(api_key.to_owned()).await
 }
 

--- a/crates/pipeline_manager/src/db/pg_setup.rs
+++ b/crates/pipeline_manager/src/db/pg_setup.rs
@@ -3,8 +3,8 @@
 //! It caches the downloaded binaries as well. Check the `pg_embed` crate for
 //! more details.
 
-use crate::AnyResult;
 use pg_embed::pg_enums::PgAuthMethod;
+use pg_embed::pg_errors::PgEmbedError;
 use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
 use pg_embed::postgres::{PgEmbed, PgSettings};
 use std::path::PathBuf;
@@ -22,7 +22,7 @@ pub(crate) async fn install(
     database_dir: PathBuf,
     persistent: bool,
     port: Option<u16>,
-) -> AnyResult<PgEmbed> {
+) -> Result<PgEmbed, PgEmbedError> {
     let pg_settings = PgSettings {
         database_dir,
         port: port.unwrap_or(5432),

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -305,7 +305,7 @@ impl LocalRunner {
                     .await
                 {
                     let _ = pipeline_process.kill().await;
-                    return Err(e);
+                    bail!(e);
                 };
                 Ok(HttpResponse::Ok().json("Pipeline successfully deployed."))
             }
@@ -336,8 +336,9 @@ impl LocalRunner {
         pipeline_id: PipelineId,
     ) -> AnyResult<bool> {
         let db = self.db.lock().await;
-        db.set_pipeline_status(tenant_id, pipeline_id, PipelineStatus::Paused)
-            .await
+        Ok(db
+            .set_pipeline_status(tenant_id, pipeline_id, PipelineStatus::Paused)
+            .await?)
     }
 
     pub(crate) async fn start_pipeline(
@@ -346,8 +347,9 @@ impl LocalRunner {
         pipeline_id: PipelineId,
     ) -> AnyResult<bool> {
         let db = self.db.lock().await;
-        db.set_pipeline_status(tenant_id, pipeline_id, PipelineStatus::Running)
-            .await
+        Ok(db
+            .set_pipeline_status(tenant_id, pipeline_id, PipelineStatus::Running)
+            .await?)
     }
 
     pub(crate) async fn delete_pipeline(


### PR DESCRIPTION
Replace all uses of `anyhow::Error` in `pipeline_manager::db` with strongly typed errors.