### PR TITLE
Update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,23 @@
 {
 	"name": "DBSP",
-	"extensions": [
-		"cschleiden.vscode-github-actions",
-		"ms-vsliveshare.vsliveshare",
-		"matklad.rust-analyzer",
-		"serayuzgur.crates",
-		"vadimcn.vscode-lldb"
-	],
 	"dockerFile": "Dockerfile",
-	"settings": {
-		"editor.formatOnSave": true,
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"files.exclude": {
-			"**/CODE_OF_CONDUCT.md": true,
-			"**/LICENSE": true
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"GitHub.vscode-github-actions",
+				"ms-vsliveshare.vsliveshare",
+				"rust-lang.rust-analyzer",
+				"serayuzgur.crates",
+				"vadimcn.vscode-lldb"
+			],
+			"settings": {
+				"editor.formatOnSave": true,
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"files.exclude": {
+					"**/CODE_OF_CONDUCT.md": true,
+					"**/LICENSE": true
+				}
+			}
 		}
 	}
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,8 +10,6 @@ apt-get install -y \
   cmake \
   pkg-config \
   libssl-dev \
-  nodejs \
-  npm
 
 ## Install rustup and common components
 curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -19,8 +17,11 @@ source "$HOME/.cargo/env"
 rustup install nightly
 rustup component add rustfmt
 rustup component add rustfmt --toolchain nightly
-rustup component add clippy 
+rustup component add clippy
 rustup component add clippy --toolchain nightly
-#curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
+
+## Install nodejs and npm packages
+curl -fsSL https://deb.nodesource.com/setup_19.x | bash -
+apt-get install -y nodejs
 npm install --global yarn
 npm install --global openapi-typescript-codegen


### PR DESCRIPTION
The contents in `devcontainer.json` is a little outdated, this PR contains the following changes:

1. Using vscode `extensions` and `settings` as top-level properties has been deprecated. They are moved into `customizations.vscode`.
2. The extensions`vscode-github-actions` and `rust-analyzer` have been moved to the official `GitHub` and `rust-lang` publishers, respectively.
3. `terminal.integrated.shell.linux` has been deprecated, using `terminal.integrated.defaultProfile.linux` instead. Actually I think this setting may be safe to be removed.

In addition, `setup.sh` currently installs `nodejs` from the Ubuntu 22.04 default repositories, which is version 12.x. This version is too low to build docs. This PR switches to version 19.x from [NodeSource](https://github.com/nodesource/distributions) instead. `Earthfile` and `deploy/Dockerfile` also use the same version from NodeSource.