### PR TITLE
[JIT] Date and Timestamp constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4848,6 +4848,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",

--- a/crates/dataflow-jit/Cargo.toml
+++ b/crates/dataflow-jit/Cargo.toml
@@ -38,8 +38,8 @@ pretty = { version = "0.12.1", features = ["termcolor"] }
 
 # JSON schema validation
 # TODO: Feature-gate schema support
-schemars = "0.8.12"
 jsonschema = "0.17.0"
+schemars = { version = "0.8.12", features = ["chrono"] }
 
 # FIXME: Better serialization protocol
 # TODO: Feature gate serde/json support
@@ -58,7 +58,7 @@ clap = { version = "4.1.8", features = ["derive"], optional = true }
     [dependencies.chrono]
     version = "0.4.23"
     default-features = false
-    features = ["std"]
+    features = ["std", "serde"]
 
     [dependencies.derive_more]
     version = "0.99.17"

--- a/crates/dataflow-jit/src/codegen/intrinsics.rs
+++ b/crates/dataflow-jit/src/codegen/intrinsics.rs
@@ -5,7 +5,9 @@ use crate::{
     thin_str::ThinStrRef,
     ThinStr,
 };
-use chrono::{DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Timelike, Utc};
+use chrono::{
+    DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Timelike, Utc,
+};
 use cranelift::{
     codegen::ir::{FuncRef, Function},
     prelude::{types, AbiParam, FunctionBuilder, Signature as ClifSignature},
@@ -1168,7 +1170,7 @@ unsafe extern "C" fn csv_get_date(
     record
         .get(column)
         .and_then(|date| match NaiveDate::parse_from_str(date, format) {
-            Ok(date) => date.and_hms_opt(0, 0, 0),
+            Ok(date) => Some(date.and_time(NaiveTime::MIN)),
             Err(error) => {
                 tracing::error!("error parsing csv date from column {column}: {error}");
                 None
@@ -1189,7 +1191,7 @@ unsafe extern "C" fn csv_get_nullable_date(
         .get(column)
         .filter(|column| !column.trim().eq_ignore_ascii_case("null"))
         .and_then(|date| match NaiveDate::parse_from_str(date, format) {
-            Ok(date) => date.and_hms_opt(0, 0, 0),
+            Ok(date) => Some(date.and_time(NaiveTime::MIN)),
             Err(error) => {
                 tracing::error!("error parsing csv date from column {column}: {error}");
                 None

--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -10,6 +10,7 @@ mod timestamp;
 mod utils;
 mod vtable;
 
+use chrono::NaiveTime;
 pub use layout::{BitSetType, InvalidBitsetType, NativeLayout, NativeType};
 pub use layout_cache::NativeLayoutCache;
 pub use vtable::{LayoutVTable, VTable};
@@ -766,6 +767,13 @@ impl<'a> CodegenCtx<'a> {
             Constant::Usize(int) => int as i64,
             Constant::Isize(int) => int as i64,
             Constant::Bool(bool) => bool as i64,
+            Constant::Date(date) => {
+                date.and_time(NaiveTime::MIN).timestamp_millis()
+                    / (86400 * 1000)
+                    // Truncate to 32 bits
+                    as i32 as i64
+            }
+            Constant::Timestamp(timestamp) => timestamp.timestamp_millis(),
 
             Constant::Unit | Constant::F32(_) | Constant::F64(_) | Constant::String(_) => {
                 unreachable!()

--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -768,8 +768,7 @@ impl<'a> CodegenCtx<'a> {
             Constant::Isize(int) => int as i64,
             Constant::Bool(bool) => bool as i64,
             Constant::Date(date) => {
-                date.and_time(NaiveTime::MIN).timestamp_millis()
-                    / (86400 * 1000)
+                (date.and_time(NaiveTime::MIN).timestamp_millis() / (86400 * 1000))
                     // Truncate to 32 bits
                     as i32 as i64
             }

--- a/crates/dataflow-jit/src/row.rs
+++ b/crates/dataflow-jit/src/row.rs
@@ -12,6 +12,7 @@ use bincode::{
     error::{DecodeError, EncodeError},
     Decode, Encode,
 };
+use chrono::NaiveTime;
 use size_of::SizeOf;
 use std::{
     alloc::Layout,
@@ -452,7 +453,10 @@ unsafe fn write_constant_to(constant: &Constant, ptr: *mut u8) {
         Constant::Bool(value) => ptr.cast::<bool>().write(value),
 
         Constant::String(ref value) => ptr.cast::<ThinStr>().write(ThinStr::from(&**value)),
-        // Constant::Date(date) => ptr.cast::<i32>().write(date),
-        // Constant::Timestamp(timestamp) => ptr.cast::<i64>().write(timestamp),
+
+        Constant::Date(date) => ptr
+            .cast::<i32>()
+            .write((date.and_time(NaiveTime::MIN).timestamp_millis() / (86400 * 1000)) as i32),
+        Constant::Timestamp(timestamp) => ptr.cast::<i64>().write(timestamp.timestamp_millis()),
     }
 }

--- a/crates/dataflow-jit/src/tests/issue_146.rs
+++ b/crates/dataflow-jit/src/tests/issue_146.rs
@@ -207,11 +207,6 @@ const CIRCUIT: &str = r#"{
 fn issue_146() {
     utils::test_logger();
 
-    println!(
-        "{:?}",
-        Constant::F64(f64::NAN).cmp(&Constant::F64(f64::NAN)),
-    );
-
     let graph = serde_json::from_str::<SqlGraph>(CIRCUIT)
         .unwrap()
         .rematerialize();

--- a/crates/dataflow-jit/src/tests/issue_288.rs
+++ b/crates/dataflow-jit/src/tests/issue_288.rs
@@ -1,0 +1,106 @@
+//! Test for https://github.com/feldera/dbsp/issues/288
+
+use chrono::{NaiveDate, NaiveDateTime};
+
+use crate::{
+    codegen::CodegenConfig,
+    facade::Demands,
+    ir::{
+        literal::{NullableConstant, RowLiteral, StreamCollection},
+        Constant, NodeId,
+    },
+    sql_graph::SqlGraph,
+    tests::must_equal_sc,
+    utils, DbspCircuit,
+};
+
+const CIRCUIT: &str = r#"{
+    "nodes": {
+        "1": {
+            "ConstantStream": {
+                "layout": {
+                    "Set": 1
+                },
+                "value": {
+                    "layout": {
+                        "Set": 1
+                    },
+                    "value": {
+                        "Set": [
+                            [
+                                {
+                                    "rows": [
+                                        {
+                                            "NonNull": {
+                                                "Date": "2001-07-08"
+                                            }
+                                        },
+                                        {
+                                            "NonNull": {
+                                                "Timestamp": "2001-07-08T00:34:59.026+09:30"
+                                            }
+                                        }
+                                    ]
+                                },
+                                1
+                            ]
+                        ]
+                    }
+                }
+            }
+        },
+        "2": {
+            "Sink": {
+                "input": 1,
+                "input_layout": {
+                    "Set": 1
+                }
+            }
+        }
+    },
+    "layouts": {
+        "1": {
+            "columns": [
+                {
+                    "nullable": false,
+                    "ty": "Date"
+                },
+                {
+                    "nullable": false,
+                    "ty": "Timestamp"
+                }
+            ]
+        }
+    }
+}"#;
+
+#[test]
+fn issue_288() {
+    utils::test_logger();
+
+    let graph = serde_json::from_str::<SqlGraph>(CIRCUIT)
+        .unwrap()
+        .rematerialize();
+
+    let mut circuit = DbspCircuit::new(graph, true, 1, CodegenConfig::debug(), Demands::new());
+
+    circuit.step().unwrap();
+
+    let result = circuit.consolidate_output(NodeId::new(2));
+    assert!(must_equal_sc(
+        dbg!(&result),
+        dbg!(&StreamCollection::Set(vec![(
+            RowLiteral::new(vec![
+                NullableConstant::NonNull(Constant::Date(
+                    NaiveDate::parse_from_str("2001-07-08", "%F").unwrap(),
+                )),
+                NullableConstant::NonNull(Constant::Timestamp(
+                    NaiveDateTime::parse_from_str("2001-07-08T00:34:59.026+09:30", "%+").unwrap(),
+                )),
+            ]),
+            1,
+        )])),
+    ));
+
+    circuit.kill().unwrap();
+}

--- a/crates/dataflow-jit/src/tests/mod.rs
+++ b/crates/dataflow-jit/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod issue_184;
 mod issue_186;
 mod issue_189;
 mod issue_195;
+mod issue_288;
 
 use crate::ir::literal::{RowLiteral, StreamCollection};
 use std::collections::BTreeMap;


### PR DESCRIPTION
Addresses #288, dates and timestamps can be used in json.

@mihaibudiu The json should look like this, you can also use `Date` and `Timestamp` values within `ConstantStream`, `RowLiteral`, etc.
```json
{
    "Constant": {
        "Date": "2001-07-08"
    }
}
```

```json
{
    "Constant": {
        "Timestamp": "2001-07-08T00:34:59.026+09:30"
    }
}
```