### PR TITLE
Fix some broken links in docs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -329,7 +329,7 @@ install-docs-deps:
     COPY docs/package.json ./docs/package.json
     COPY docs/yarn.lock ./docs/yarn.lock
     RUN cd docs && yarn install
-    COPY docs/rust-api ./docs/rust-api
+    COPY ( +docs/rust-api ) ./docs/rust-api
 
 build-docs:
     FROM +install-docs-deps

--- a/Earthfile
+++ b/Earthfile
@@ -324,11 +324,13 @@ install-docs-deps:
     COPY docs/package.json ./docs/package.json
     COPY docs/yarn.lock ./docs/yarn.lock
     RUN cd docs && yarn install
+    COPY target/doc/dbsp ./docs/rust
 
 build-docs:
     FROM +install-docs-deps
     COPY docs/ docs/
     COPY ( +build-manager/dbsp_pipeline_manager ) ./docs/dbsp_pipeline_manager
+    RUN cargo doc
     RUN cd docs && ./dbsp_pipeline_manager --dump-openapi
     RUN cd docs && yarn format:check
     RUN cd docs && yarn lint

--- a/crates/dataflow-jit/src/ir/exprs/mem.rs
+++ b/crates/dataflow-jit/src/ir/exprs/mem.rs
@@ -176,10 +176,10 @@ where
 /// Both the `src` and `dest` rows must have the same layout.
 ///
 /// Semantically equivalent to [`Load`]-ing each column within `src`, calling
-/// [`struct@Copy`] on the loaded value and then [`Store`]-ing the copied value
-/// to `dest` (along with any required [`IsNull`]/[`SetNull`] juggling that has
-/// to be done due to nullable columns)
-// TODO: We need to offer a drop operator of some kind so that rows can be deinitialized if needed
+/// [`trait@struct@Copy`] on the loaded value and then [`Store`]-ing the copied value
+/// to `dest` (along with any required [`crate::ir::exprs::IsNull`]/
+/// [`crate::ir::exprs::SetNull`]
+/// juggling that has to be done due to nullable columns)
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct CopyRowTo {
     src: ExprId,

--- a/crates/dataflow-jit/src/ir/row_or_scalar.rs
+++ b/crates/dataflow-jit/src/ir/row_or_scalar.rs
@@ -31,7 +31,7 @@ pub enum RowOrScalar {
 impl RowOrScalar {
     /// Returns `true` if the arg type is a [`Row`].
     ///
-    /// [`Row`]: ArgType::Row
+    /// [`Row`]: RowOrScalar::Row
     #[must_use]
     #[inline]
     pub const fn is_row(&self) -> bool {
@@ -40,7 +40,7 @@ impl RowOrScalar {
 
     /// Returns `true` if the arg type is a [`Scalar`].
     ///
-    /// [`Scalar`]: ArgType::Scalar
+    /// [`Scalar`]: RowOrScalar::Scalar
     #[must_use]
     #[inline]
     pub const fn is_scalar(&self) -> bool {
@@ -85,7 +85,8 @@ impl RowOrScalar {
 
     /// Returns `true` if the current layout or column type needs dropping
     ///
-    /// Calls [`RowLayout::needs_drop()`] or [`ColumnType::needs_drop()`]
+    /// Calls [`RowLayout::needs_drop()`](`crate::ir::RowLayout::needs_drop()`)
+    /// or [`ColumnType::needs_drop()`]
     /// depending on what's inside of `self`
     pub fn needs_drop(self, cache: &RowLayoutCache) -> bool {
         match self {

--- a/crates/pipeline_manager/src/auth.rs
+++ b/crates/pipeline_manager/src/auth.rs
@@ -9,7 +9,7 @@
 //!
 //! The expected workflow is for users to login via a browser to receive a JWT
 //! access token. Clients then issue pipeline manager APIs using an HTTP
-//! authorization header for bearer tokens (Authorization: Bearer <token>). With
+//! authorization header for bearer tokens (Authorization: Bearer \<token\>). With
 //! a bearer token, users may generate API keys that can be used for
 //! programmatic access (see below).
 //!
@@ -287,7 +287,7 @@ pub(crate) struct AuthConfiguration {
 /// The shape of a claim provided to clients by AwsCognito, following
 /// the guide below:
 ///
-/// https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html
+/// <https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html>
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct AwsCognitoClaim {
     /// The user pool app client that authenticated the client
@@ -366,8 +366,8 @@ impl From<jsonwebtoken::errors::ErrorKind> for AuthError {
 /// Follows the guidelines in the following links, except that JWK refreshes are
 /// not yet implemented
 ///
-/// https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html
-/// JWT claims: https://datatracker.ietf.org/doc/html/rfc7519#section-4
+/// <https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-access-token.html>
+/// JWT claims: <https://datatracker.ietf.org/doc/html/rfc7519#section-4>
 async fn decode_aws_cognito_token(
     token: &str,
     req: &ServiceRequest,

--- a/docs/docs/rust.md
+++ b/docs/docs/rust.md
@@ -1,0 +1,3 @@
+# Rust API documentation
+
+TODO: this should link to the automatically generated rust docs.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -41,6 +41,11 @@ const sidebars = {
     },
     {
       type: "category",
+      label: "Rust DBSP library Reference",
+      link: { type: "doc", id: "docs/rust" },
+    },
+    {
+      type: "category",
       label: "SQL Reference",
       link: { type: "doc", id: "sql/intro" },
       items: [
@@ -62,7 +67,7 @@ const sidebars = {
     {
       type: "category",
       label: "API Reference",
-      items: ["api/rest", "api/dbsp", "api/python"],
+      items: ["api/rest", "api/python"],
     },
     "papers",
     "contribute-to-dbsp",

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -42,7 +42,9 @@ const sidebars = {
     {
       type: "category",
       label: "Rust DBSP library Reference",
-      link: { type: "doc", id: "docs/rust" },
+      items: [
+          "rust"
+      ],
     },
     {
       type: "category",

--- a/sql-to-dbsp-compiler/lib/tuple/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/tuple/src/lib.rs
@@ -1,6 +1,6 @@
 //! This file contains a macro which can be used to define tuples
-//! with any number of fields.  The type names are Tuple0<>, Tuple1<T0>,
-//! Tuple2<T0, T1>, etc.  The macro defines many traits which
+//! with any number of fields.  The type names are `Tuple0<>`, `Tuple1<T0>`,
+//! `Tuple2<T0, T1>`, etc.  The macro defines many traits which
 //! are useful for tuples to be used as DBSP values in Z-Sets.
 //! Rust tuples only go up to 12 fields, but we may need more.
 


### PR DESCRIPTION
I have also added some code to Earthfile to deploy the Rust docs, but that's based on copy-and-paste, since I am not sure how to test it. I hope that the changes to Earthfile will also cause `cargo doc` to run in CI. A few more fixes to docs are needed, but they are in #306 