### PR TITLE
Fix doc for dataflow-jit

### DIFF
--- a/crates/dataflow-jit/src/ir/exprs/mem.rs
+++ b/crates/dataflow-jit/src/ir/exprs/mem.rs
@@ -176,9 +176,10 @@ where
 /// Both the `src` and `dest` rows must have the same layout.
 ///
 /// Semantically equivalent to [`Load`]-ing each column within `src`, calling
-/// [`struct@Copy`] on the loaded value and then [`Store`]-ing the copied value
-/// to `dest` (along with any required [`IsNull`]/[`SetNull`] juggling that has
-/// to be done due to nullable columns)
+/// [`trait@Copy`] on the loaded value and then [`Store`]-ing the copied value
+/// to `dest` (along with any required
+/// [`IsNull`](`crate::ir::IsNull`)/[`SetNull`](`crate::ir::SetNull`) juggling
+/// that has to be done due to nullable columns)
 // TODO: We need to offer a drop operator of some kind so that rows can be deinitialized if needed
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct CopyRowTo {

--- a/crates/dataflow-jit/src/ir/row_or_scalar.rs
+++ b/crates/dataflow-jit/src/ir/row_or_scalar.rs
@@ -31,7 +31,7 @@ pub enum RowOrScalar {
 impl RowOrScalar {
     /// Returns `true` if the arg type is a [`Row`].
     ///
-    /// [`Row`]: ArgType::Row
+    /// [`Row`]: RowOrScalar::Row
     #[must_use]
     #[inline]
     pub const fn is_row(&self) -> bool {
@@ -40,7 +40,7 @@ impl RowOrScalar {
 
     /// Returns `true` if the arg type is a [`Scalar`].
     ///
-    /// [`Scalar`]: ArgType::Scalar
+    /// [`Scalar`]: RowOrScalar::Scalar
     #[must_use]
     #[inline]
     pub const fn is_scalar(&self) -> bool {
@@ -85,8 +85,8 @@ impl RowOrScalar {
 
     /// Returns `true` if the current layout or column type needs dropping
     ///
-    /// Calls [`RowLayout::needs_drop()`] or [`ColumnType::needs_drop()`]
-    /// depending on what's inside of `self`
+    /// Calls [`RowLayout::needs_drop()`](`crate::ir::RowLayout::needs_drop()`)
+    /// or [`ColumnType::needs_drop()`] depending on what's inside of `self`
     pub fn needs_drop(self, cache: &RowLayoutCache) -> bool {
         match self {
             Self::Row(layout) => cache.get(layout).needs_drop(),


### PR DESCRIPTION
Fixes the following errors in `cargo doc`
```
 Documenting dataflow-jit v0.1.0 (/workspaces/dbsp/crates/dataflow-jit)
warning: incompatible link kind for `Copy`
   --> crates/dataflow-jit/src/ir/exprs/mem.rs:179:7
    |
179 | /// [`struct@Copy`] on the loaded value and then [`Store`]-ing the copied value
    |       ^^^^^^^^^^^ this link resolved to a trait, which is not a struct
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
help: to link to the trait, prefix with `trait@`
    |
179 | /// [`trait@opy`] on the loaded value and then [`Store`]-ing the copied value
    |       ~~~~~~

warning: unresolved link to `IsNull`
   --> crates/dataflow-jit/src/ir/exprs/mem.rs:180:42
    |
180 | /// to `dest` (along with any required [`IsNull`]/[`SetNull`] juggling that has
    |                                          ^^^^^^ no item named `IsNull` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `SetNull`
   --> crates/dataflow-jit/src/ir/exprs/mem.rs:180:53
    |
180 | /// to `dest` (along with any required [`IsNull`]/[`SetNull`] juggling that has
    |                                                     ^^^^^^^ no item named `SetNull` in scope
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `ArgType::Row`
  --> crates/dataflow-jit/src/ir/row_or_scalar.rs:34:18
   |
34 |     /// [`Row`]: ArgType::Row
   |                  ^^^^^^^^^^^^ no item named `ArgType` in scope

warning: unresolved link to `ArgType::Scalar`
  --> crates/dataflow-jit/src/ir/row_or_scalar.rs:43:21
   |
43 |     /// [`Scalar`]: ArgType::Scalar
   |                     ^^^^^^^^^^^^^^^ no item named `ArgType` in scope

warning: unresolved link to `RowLayout::needs_drop`
  --> crates/dataflow-jit/src/ir/row_or_scalar.rs:88:17
   |
88 |     /// Calls [`RowLayout::needs_drop()`] or [`ColumnType::needs_drop()`]
   |                 ^^^^^^^^^^^^^^^^^^^^^^^ no item named `RowLayout` in scope

warning: `dataflow-jit` (lib doc) generated 6 warnings
    Finished dev [unoptimized + debuginfo] target(s) in 3.11s
```