### PR TITLE
Make `NeighborhoodDescr::anchor` field optional.

### DIFF
--- a/crates/adapters/src/catalog.rs
+++ b/crates/adapters/src/catalog.rs
@@ -18,7 +18,7 @@ use utoipa::ToSchema;
 /// and the number of rows preceding and following the anchor to output.
 #[derive(Deserialize, ToSchema)]
 pub struct NeighborhoodQuery {
-    pub anchor: utoipa::openapi::Object,
+    pub anchor: Option<utoipa::openapi::Object>,
     pub before: u32,
     pub after: u32,
 }

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -1005,6 +1005,18 @@ outputs:
         let body = serde_json::from_slice::<JsonValue>(&body.unwrap()).unwrap();
         println!("Neighborhood: {body}");
 
+        // Request default neighborhood snapshot.
+        let mut hood_resp_default = server
+            .get("/egress/test_output1?mode=snapshot&query=neighborhood")
+            .send_json(&json!({"before": 50, "after": 30}))
+            .await
+            .unwrap();
+        assert!(hood_resp_default.status().is_success());
+        let body = hood_resp_default.body().await;
+        // println!("Response: {body:?}");
+        let body = serde_json::from_slice::<JsonValue>(&body.unwrap()).unwrap();
+        println!("Default neighborhood: {body}");
+
         // Request neighborhood snapshot: invalid request.
         let mut hood_inv_resp = server
             .get("/egress/test_output1?mode=snapshot&query=neighborhood")

--- a/crates/pipeline_manager/src/main.rs
+++ b/crates/pipeline_manager/src/main.rs
@@ -1853,6 +1853,7 @@ async fn http_input(
         ("format" = String, Query, description = "Output data format, e.g., 'csv' or 'json'."),
         ("query" = Option<OutputQuery>, Query, description = "Query to execute on the table. Must be one of 'table', 'neighborhood', or 'quantiles'. The default value is 'table'"),
         ("mode" = Option<EgressMode>, Query, description = "Output mode. Must be one of 'watch' or 'snapshot'. The default value is 'watch'"),
+        ("quantiles" = Option<u32>, Query, description = "For 'quantiles' queries: the number of quantiles to output. The default value is 100."),
     ),
     request_body(
         content = Option<NeighborhoodQuery>,

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_output.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_output.py
@@ -22,6 +22,7 @@ def _get_kwargs(
     format_: str,
     query: Union[Unset, None, OutputQuery] = UNSET,
     mode: Union[Unset, None, EgressMode] = UNSET,
+    quantiles: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/v0/pipelines/{pipeline_id}/egress/{table_name}".format(
         client.base_url, pipeline_id=pipeline_id, table_name=table_name
@@ -44,6 +45,8 @@ def _get_kwargs(
         json_mode = mode.value if mode else None
 
     params["mode"] = json_mode
+
+    params["quantiles"] = quantiles
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -106,6 +109,7 @@ def sync_detailed(
     format_: str,
     query: Union[Unset, None, OutputQuery] = UNSET,
     mode: Union[Unset, None, EgressMode] = UNSET,
+    quantiles: Union[Unset, None, int] = UNSET,
 ) -> Response[Union[Chunk, ErrorResponse]]:
     """Subscribe to a stream of updates to a SQL view or table.
 
@@ -127,6 +131,7 @@ def sync_detailed(
             We currently do not support ad hoc queries.  Instead the client can use
             three pre-defined queries to inspect the contents of a table or view.
         mode (Union[Unset, None, EgressMode]):
+        quantiles (Union[Unset, None, int]):
         json_body (Optional[NeighborhoodQuery]): A request to output a specific neighborhood of a
             table or view.
             The neighborhood is defined in terms of its central point (`anchor`)
@@ -148,6 +153,7 @@ def sync_detailed(
         format_=format_,
         query=query,
         mode=mode,
+        quantiles=quantiles,
     )
 
     response = httpx.request(
@@ -167,6 +173,7 @@ def sync(
     format_: str,
     query: Union[Unset, None, OutputQuery] = UNSET,
     mode: Union[Unset, None, EgressMode] = UNSET,
+    quantiles: Union[Unset, None, int] = UNSET,
 ) -> Optional[Union[Chunk, ErrorResponse]]:
     """Subscribe to a stream of updates to a SQL view or table.
 
@@ -188,6 +195,7 @@ def sync(
             We currently do not support ad hoc queries.  Instead the client can use
             three pre-defined queries to inspect the contents of a table or view.
         mode (Union[Unset, None, EgressMode]):
+        quantiles (Union[Unset, None, int]):
         json_body (Optional[NeighborhoodQuery]): A request to output a specific neighborhood of a
             table or view.
             The neighborhood is defined in terms of its central point (`anchor`)
@@ -209,6 +217,7 @@ def sync(
         format_=format_,
         query=query,
         mode=mode,
+        quantiles=quantiles,
     ).parsed
 
 
@@ -221,6 +230,7 @@ async def asyncio_detailed(
     format_: str,
     query: Union[Unset, None, OutputQuery] = UNSET,
     mode: Union[Unset, None, EgressMode] = UNSET,
+    quantiles: Union[Unset, None, int] = UNSET,
 ) -> Response[Union[Chunk, ErrorResponse]]:
     """Subscribe to a stream of updates to a SQL view or table.
 
@@ -242,6 +252,7 @@ async def asyncio_detailed(
             We currently do not support ad hoc queries.  Instead the client can use
             three pre-defined queries to inspect the contents of a table or view.
         mode (Union[Unset, None, EgressMode]):
+        quantiles (Union[Unset, None, int]):
         json_body (Optional[NeighborhoodQuery]): A request to output a specific neighborhood of a
             table or view.
             The neighborhood is defined in terms of its central point (`anchor`)
@@ -263,6 +274,7 @@ async def asyncio_detailed(
         format_=format_,
         query=query,
         mode=mode,
+        quantiles=quantiles,
     )
 
     async with httpx.AsyncClient(verify=client.verify_ssl) as _client:
@@ -280,6 +292,7 @@ async def asyncio(
     format_: str,
     query: Union[Unset, None, OutputQuery] = UNSET,
     mode: Union[Unset, None, EgressMode] = UNSET,
+    quantiles: Union[Unset, None, int] = UNSET,
 ) -> Optional[Union[Chunk, ErrorResponse]]:
     """Subscribe to a stream of updates to a SQL view or table.
 
@@ -301,6 +314,7 @@ async def asyncio(
             We currently do not support ad hoc queries.  Instead the client can use
             three pre-defined queries to inspect the contents of a table or view.
         mode (Union[Unset, None, EgressMode]):
+        quantiles (Union[Unset, None, int]):
         json_body (Optional[NeighborhoodQuery]): A request to output a specific neighborhood of a
             table or view.
             The neighborhood is defined in terms of its central point (`anchor`)
@@ -323,5 +337,6 @@ async def asyncio(
             format_=format_,
             query=query,
             mode=mode,
+            quantiles=quantiles,
         )
     ).parsed

--- a/python/dbsp-api-client/dbsp_api_client/models/neighborhood_query.py
+++ b/python/dbsp-api-client/dbsp_api_client/models/neighborhood_query.py
@@ -1,6 +1,8 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union
 
 import attr
+
+from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.neighborhood_query_anchor import NeighborhoodQueryAnchor
@@ -17,30 +19,32 @@ class NeighborhoodQuery:
 
         Attributes:
             after (int):
-            anchor (NeighborhoodQueryAnchor):
             before (int):
+            anchor (Union[Unset, None, NeighborhoodQueryAnchor]):
     """
 
     after: int
-    anchor: "NeighborhoodQueryAnchor"
     before: int
+    anchor: Union[Unset, None, "NeighborhoodQueryAnchor"] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         after = self.after
-        anchor = self.anchor.to_dict()
-
         before = self.before
+        anchor: Union[Unset, None, Dict[str, Any]] = UNSET
+        if not isinstance(self.anchor, Unset):
+            anchor = self.anchor.to_dict() if self.anchor else None
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "after": after,
-                "anchor": anchor,
                 "before": before,
             }
         )
+        if anchor is not UNSET:
+            field_dict["anchor"] = anchor
 
         return field_dict
 
@@ -51,14 +55,21 @@ class NeighborhoodQuery:
         d = src_dict.copy()
         after = d.pop("after")
 
-        anchor = NeighborhoodQueryAnchor.from_dict(d.pop("anchor"))
-
         before = d.pop("before")
+
+        _anchor = d.pop("anchor", UNSET)
+        anchor: Union[Unset, None, NeighborhoodQueryAnchor]
+        if _anchor is None:
+            anchor = None
+        elif isinstance(_anchor, Unset):
+            anchor = UNSET
+        else:
+            anchor = NeighborhoodQueryAnchor.from_dict(_anchor)
 
         neighborhood_query = cls(
             after=after,
-            anchor=anchor,
             before=before,
+            anchor=anchor,
         )
 
         neighborhood_query.additional_properties = d


### PR DESCRIPTION
The `anchor` value of `None` behaves equivalent to specifying the smallest value of the corresponding type.