### PR TITLE
PR 328 postfix

### DIFF
--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -4,7 +4,7 @@ from dbsp import DBSPConnection
 
 
 def execute(dbsp_url, actions, name, code_file, make_pipeline_fn, prepare_fn=None, verify_fn=None):
-    dbsp = DBSPConnection(dbsp_url)
+    dbsp = DBSPConnection(dbsp_url + "/v0")
     sql_code = open(code_file, "r").read()
     program = dbsp.create_or_replace_program(
         name=name, sql_code=sql_code)

--- a/demo/demo_notebooks/fraud_detection.ipynb
+++ b/demo/demo_notebooks/fraud_detection.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "from dbsp import DBSPConnection\n",
     "\n",
-    "dbsp = DBSPConnection(\"http://localhost:8080\")\n",
+    "dbsp = DBSPConnection(\"http://localhost:8080/v0\")\n",
     "project = dbsp.create_or_replace_program(name = \"fraud_feature_query\", sql_code = \"\"\"\n",
     "CREATE TABLE demographics (\n",
     "    cc_num FLOAT64 NOT NULL,\n",

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/connector_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/connector_status.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     id: Union[Unset, None, str] = UNSET,
     name: Union[Unset, None, str] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/v0/connector".format(client.base_url)
+    url = "{}/connector".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/delete_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/delete_connector.py
@@ -14,7 +14,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/connectors/{connector_id}".format(client.base_url, connector_id=connector_id)
+    url = "{}/connectors/{connector_id}".format(client.base_url, connector_id=connector_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/list_connectors.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/list_connectors.py
@@ -13,7 +13,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/connectors".format(client.base_url)
+    url = "{}/connectors".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/new_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/new_connector.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     client: Client,
     json_body: NewConnectorRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/connectors".format(client.base_url)
+    url = "{}/connectors".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/connector/update_connector.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/connector/update_connector.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     json_body: UpdateConnectorRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/connectors".format(client.base_url)
+    url = "{}/connectors".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_input.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_input.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     format_: str,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/ingress/{table_name}".format(
+    url = "{}/pipelines/{pipeline_id}/ingress/{table_name}".format(
         client.base_url, pipeline_id=pipeline_id, table_name=table_name
     )
 

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_output.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/http_output.py
@@ -24,7 +24,7 @@ def _get_kwargs(
     mode: Union[Unset, None, EgressMode] = UNSET,
     quantiles: Union[Unset, None, int] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/egress/{table_name}".format(
+    url = "{}/pipelines/{pipeline_id}/egress/{table_name}".format(
         client.base_url, pipeline_id=pipeline_id, table_name=table_name
     )
 

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/list_pipelines.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/list_pipelines.py
@@ -13,7 +13,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines".format(client.base_url)
+    url = "{}/pipelines".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/new_pipeline.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/new_pipeline.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     json_body: NewPipelineRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines".format(client.base_url)
+    url = "{}/pipelines".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_action.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_action.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/{action}".format(client.base_url, pipeline_id=pipeline_id, action=action)
+    url = "{}/pipelines/{pipeline_id}/{action}".format(client.base_url, pipeline_id=pipeline_id, action=action)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_committed.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_committed.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/committed".format(client.base_url, pipeline_id=pipeline_id)
+    url = "{}/pipelines/{pipeline_id}/committed".format(client.base_url, pipeline_id=pipeline_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_delete.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_delete.py
@@ -14,7 +14,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}".format(client.base_url, pipeline_id=pipeline_id)
+    url = "{}/pipelines/{pipeline_id}".format(client.base_url, pipeline_id=pipeline_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_stats.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_stats.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/stats".format(client.base_url, pipeline_id=pipeline_id)
+    url = "{}/pipelines/{pipeline_id}/stats".format(client.base_url, pipeline_id=pipeline_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_status.py
@@ -17,7 +17,7 @@ def _get_kwargs(
     name: Union[Unset, None, str] = UNSET,
     toml: Union[Unset, None, bool] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipeline".format(client.base_url)
+    url = "{}/pipeline".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_validate.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/pipeline_validate.py
@@ -14,7 +14,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines/{pipeline_id}/validate".format(client.base_url, pipeline_id=pipeline_id)
+    url = "{}/pipelines/{pipeline_id}/validate".format(client.base_url, pipeline_id=pipeline_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/pipeline/update_pipeline.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/pipeline/update_pipeline.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     json_body: UpdatePipelineRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/pipelines".format(client.base_url)
+    url = "{}/pipelines".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/cancel_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/cancel_program.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     client: Client,
     json_body: CancelProgramRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs/compile".format(client.base_url)
+    url = "{}/programs/compile".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/compile_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/compile_program.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     client: Client,
     json_body: CompileProgramRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs/compile".format(client.base_url)
+    url = "{}/programs/compile".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/delete_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/delete_program.py
@@ -14,7 +14,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs/{program_id}".format(client.base_url, program_id=program_id)
+    url = "{}/programs/{program_id}".format(client.base_url, program_id=program_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/list_programs.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/list_programs.py
@@ -13,7 +13,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs".format(client.base_url)
+    url = "{}/programs".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/new_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/new_program.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     json_body: NewProgramRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs".format(client.base_url)
+    url = "{}/programs".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/program_code.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/program_code.py
@@ -15,7 +15,7 @@ def _get_kwargs(
     *,
     client: Client,
 ) -> Dict[str, Any]:
-    url = "{}/v0/program/{program_id}/code".format(client.base_url, program_id=program_id)
+    url = "{}/program/{program_id}/code".format(client.base_url, program_id=program_id)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/program_status.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/program_status.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     id: Union[Unset, None, str] = UNSET,
     name: Union[Unset, None, str] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/v0/program".format(client.base_url)
+    url = "{}/program".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/api/program/update_program.py
+++ b/python/dbsp-api-client/dbsp_api_client/api/program/update_program.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     client: Client,
     json_body: UpdateProgramRequest,
 ) -> Dict[str, Any]:
-    url = "{}/v0/programs".format(client.base_url)
+    url = "{}/programs".format(client.base_url)
 
     headers: Dict[str, str] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()

--- a/python/dbsp-api-client/dbsp_api_client/types.py
+++ b/python/dbsp-api-client/dbsp_api_client/types.py
@@ -1,12 +1,12 @@
 """ Contains some shared types for properties """
 from http import HTTPStatus
-from typing import BinaryIO, Generic, MutableMapping, Optional, Tuple, TypeVar
+from typing import BinaryIO, Generic, Literal, MutableMapping, Optional, Tuple, TypeVar
 
 import attr
 
 
 class Unset:
-    def __bool__(self) -> bool:
+    def __bool__(self) -> Literal[False]:
         return False
 
 

--- a/python/dbsp-api-client/pyproject.toml
+++ b/python/dbsp-api-client/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 include = ["CHANGELOG.md", "dbsp_api_client/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 httpx = ">=0.15.4,<0.25.0"
 attrs = ">=21.3.0"
 python-dateutil = "^2.8.0"
@@ -23,7 +23,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-target_version = ['py37', 'py38', 'py39']
+target_version = ['py38', 'py39', 'py310', 'py311']
 exclude = '''
 (
   /(

--- a/python/test.py
+++ b/python/test.py
@@ -119,6 +119,7 @@ CREATE VIEW transactions_with_demographics as
 
 def main():
     url = "http://localhost:8080" if len(sys.argv) <= 1 else sys.argv[1]
+    url = url + "/v0" # API endpoint
     dbsp = DBSPConnection(url)
     connector_type = "file" if len(sys.argv) <= 2 else "http"
     print("Connection established")
@@ -164,18 +165,18 @@ def main():
 
     if (connector_type == "http"):
         output = requests.get(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS',
+                f'{url}/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS',
                 stream = True)
 
         print("Sending demongraphics data")
         r = requests.post(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/ingress/DEMOGRAPHICS',
+                f'{url}/pipelines/{pipeline.pipeline_id}/ingress/DEMOGRAPHICS',
                 data = demographics)
         print("result: " + str(r))
 
         print("Sending transaction data")
         r = requests.post(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/ingress/TRANSACTIONS',
+                f'{url}/pipelines/{pipeline.pipeline_id}/ingress/TRANSACTIONS',
                 data = transactions)
         print("result: " + str(r))
 
@@ -191,7 +192,7 @@ def main():
 
         print("Sending neighborhood request")
         neighborhood = requests.get(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=neighborhood&mode=snapshot&format=csv',
+                f'{url}/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=neighborhood&mode=snapshot&format=csv',
                 json = {'before': 10, 'after': 20, 'anchor': ['2008-01-03 05:38:14', 0.0, 'John', 'New York'] })
         print("result: " + str(neighborhood))
         assert neighborhood.status_code == requests.codes.ok
@@ -202,7 +203,7 @@ def main():
 
         print("Sending invalid neighborhood request")
         response = requests.get(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=neighborhood&mode=snapshot&format=csv',
+                f'{url}/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=neighborhood&mode=snapshot&format=csv',
                 json = {'before': 10, 'after': 20, 'anchor': ['not_a_date', 0.0, 'John', 'New York'] })
         print("result: " + str(response))
         assert response.status_code != requests.codes.ok
@@ -211,7 +212,7 @@ def main():
 
         print("Sending quantiles request")
         quantiles = requests.get(
-                f'{url}/v0/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=quantiles&mode=snapshot&format=csv&quntiles=100')
+                f'{url}/pipelines/{pipeline.pipeline_id}/egress/TRANSACTIONS_WITH_DEMOGRAPHICS?query=quantiles&mode=snapshot&format=csv&quntiles=100')
         print("result: " + str(quantiles))
         assert quantiles.status_code == requests.codes.ok
 


### PR DESCRIPTION
The web::scope() change affected the OpenAPI endpoint URLs. It affects the python bindings which are based off of the OpenAPI spec. The fix is to pass `<dbsp_hostname>:<port>/v0` as the URL to the python client when opening a connection.