### PR TITLE
Support REPLACE, PRIMARY KEY, FOREIGN KEY in SQL compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ described in the accompanying paper:
 - [Budiu, Chajed, McSherry, Ryzhyk, Tannen. DBSP: Automatic
   Incremental View Maintenance for Rich Query Languages, Conference on
   Very Large Databases, August 2023, Vancouver,
-  Canada](https://github.com/feldera/dbsp/blob/main/doc/vldb23/main.pdf)
+  Canada](https://github.com/feldera/dbsp/blob/main/docs/static/vldb23.pdf)
 
 - Here is the [video of a DBSP
 presentation](https://www.youtube.com/watch?v=iT4k5DCnvPU) at the 2023

--- a/demo/project_demo00-SecOps/project.sql
+++ b/demo/project_demo00-SecOps/project.sql
@@ -41,7 +41,7 @@ create table artifact (
     artifact_size_in_bytes bigint not null,
     artifact_type varchar not null,
     builtby_pipeline_id bigint not null /* foreign key references pipeline(pipeline_id) */,
-    parent_artifact_id bigint /* foreign key references artifact(artifact_id) */
+    parent_artifact_id bigint foreign key references artifact(artifact_id)
 );
 
 -- Vulnerabilities discovered in source code.
@@ -71,14 +71,14 @@ create table k8scluster (
 -- Deployed k8s objects.
 create table k8sobject (
     k8sobject_id bigint not null,
-    artifact_id bigint not null /* foreign key references artifact(artifact_id) */,
+    artifact_id bigint not null foreign key references artifact(artifact_id),
     create_date timestamp not null,
     createdby_user_id bigint not null,
     update_date timestamp,
     updatedby_user_id bigint,
     checksum varchar not null,
     checksum_type varchar not null,
-    deployed_id bigint not null /* foreign key references k8scluster(k8scluster_id) */,
+    deployed_id bigint not null foreign key references k8scluster(k8scluster_id),
     deployment_type varchar not null,
     k8snamespace varchar not null
 );
@@ -158,7 +158,7 @@ create view k8scluster_vulnerability_stats (
     total_vulnerabilities,
     most_severe_vulnerability
 ) as
-    SELECT 
+    SELECT
         cluster_id,
         k8scluster.name as k8scluster_name,
         total_vulnerabilities,

--- a/docs/docs/papers.md
+++ b/docs/docs/papers.md
@@ -1,3 +1,9 @@
 # Publications
 
-[DBPS specification](/spec.pdf)
+[DBPS mathematical specification](/spec.pdf)
+
+[DBSP: Automatic Incremental View Maintenance for Rich Query
+Languages](http://budiu.info/work/budiu-vldb23.pdf) *Mihai Budiu, Tej
+Chajed, Frank McSherry, Leonid Ryzhyk, and Val Tannen*, Proceedings of
+the VLDB Endowment (VLDB), Vancouver, Canada, August, 2023, pages
+1601-1614

--- a/docs/docs/papers.md
+++ b/docs/docs/papers.md
@@ -1,6 +1,6 @@
 # Publications
 
-[DBPS mathematical specification](/spec.pdf)
+[DBSP mathematical specification](/spec.pdf)
 
 [DBSP: Automatic Incremental View Maintenance for Rich Query
 Languages](http://budiu.info/work/budiu-vldb23.pdf) *Mihai Budiu, Tej

--- a/docs/docs/sql/casts.md
+++ b/docs/docs/sql/casts.md
@@ -12,3 +12,7 @@ An explicit cast can be specified in three ways:
 * using an infix operator <code>::</code> from Postgres:
   <code>value :: type</code>
 * using the `CONVERT` function: `CONVERT(value, type)`
+
+The rules for implicit casts are complex; we [inherit these
+rules](https://calcite.apache.org/docs/reference.html#conversion-contexts-and-strategies)
+from Calcite.

--- a/docs/docs/sql/float.md
+++ b/docs/docs/sql/float.md
@@ -31,6 +31,20 @@ Division or modulus by zero return `NaN`.
 Casting a string to a floating-point value will produce the value
 `0` when parsing fails.
 
+Please note that numeric values with a decimal point have the
+`decimal` type by default.  To write a floating-point literal you have
+to include the `e` for exponent using the following grammar:
+
+digits`.`digits[`e`[`+-`]digits]
+
+[digits]`.`digits[`e`[`+-`]digits]
+
+Alternatively, you can use an explicit cast:
+
+```SQL
+REAL '1.23'  -- string style
+1.23::REAL   -- PostgreSQL style
+```
 
 ## Predefined functions on Floating-point Values
 

--- a/docs/docs/sql/grammar.md
+++ b/docs/docs/sql/grammar.md
@@ -25,15 +25,20 @@ tableElement
   |   tableConstraint
 
 columnConstraint
-  :   [ CONSTRAINT name ]
-      [ NOT ] NULL
+  :   [ PRIMARY KEY ]
+  |   [ NOT ] NULL
+  |   [ FOREIGN KEY REFERENCES identifier '(' identifier ')' ]
+
+parensColumnList
+  :   '(' columnName [, columnName ]* ')'
 
 tableConstraint
   :   [ CONSTRAINT name ]
       {
           CHECK '(' expression ')'
-      |   PRIMARY KEY '(' columnName [, columnName ]* ')'
+      |   PRIMARY KEY parensColumnList
       }
+  |   FOREIGN KEY parensColumnList REFERENCES identifier parensColumnList
 
 query
   :   values
@@ -114,6 +119,9 @@ windowSpec
        ]
       ')'
 ```
+
+Note: `PRIMARY KEY` and `FOREIGN KEY` information is parsed, but
+ignored.
 
 In `orderItem`, if expression is a positive integer n, it denotes the
 nth item in the `SELECT` clause.

--- a/docs/docs/sql/identifiers.md
+++ b/docs/docs/sql/identifiers.md
@@ -40,3 +40,24 @@ single quotes, not double quotes, after UESCAPE.
 
 To include the escape character in the identifier literally, write it
 twice.
+
+## Comments
+
+A comment is a sequence of characters beginning with double dashes and
+extending to the end of the line, e.g.:
+
+```SQL
+-- This is a standard SQL comment
+```
+
+Alternatively, C-style block comments can be used:
+
+```
+/* multiline comment
+ * with nesting: /* nested block comment */
+ */
+```
+
+where the comment begins with `/*` and extends to the matching
+occurrence of `*/`.  Note that block comments cannot be nested unlike
+the requirements of the SQL standard.

--- a/docs/docs/sql/intro.mdx
+++ b/docs/docs/sql/intro.mdx
@@ -1,5 +1,15 @@
 # Introduction
 
+## Documentation sources
+
+Parts of this documentation are adapted from the Postgres Database
+documentation, governed by the [Postgres
+license](https://postgrespro.com/postgresql_license).
+
+Parts of this documentation are adapted from the Calcite
+documentation, governed by the [Apache 2.0
+License](https://github.com/apache/calcite/blob/main/LICENSE).
+
 ## DBSP and incremental view maintenance
 
 DBSP stands for Database Stream Processor.  DBSP is a query engine

--- a/docs/docs/sql/string.md
+++ b/docs/docs/sql/string.md
@@ -138,7 +138,20 @@ addition to the normal way of `''`.
     <td><code>INITCAP ( string )</code></td>
     <td>Converts the first letter of each word to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.</td>
   </tr>
+  <tr>
+    <td><code>REPLACE ( haystack, needle, replacement )</code></td>
+    <td>Replaces all occurrences of `needle` in `haystack` with `replacement`.</td>
+  </tr>
 </table>
+
+<!--
+  <tr>
+    <td><code>REGEXP_REPLACE(expr, pat, repl[, pos[, occurrence[, match_type]]])</code></td>
+    <td>Replaces occurrences in the string expr that match the regular expression
+        specified by the pattern pat with the replacement string repl, and returns
+        the resulting string. If `expr`, `pat`, or `repl` is `NULL`, the return value is `NULL`.</td>
+  </tr>
+-->
 
 ## `LIKE`
 
@@ -186,3 +199,273 @@ SELECT 'h%wkeye' LIKE 'h#%%' ESCAPE '#'        true
 SELECT 'h%wkeye' NOT LIKE 'h#%%' ESCAPE '#'    false
 SELECT 'h%awkeye' LIKE 'h#%a%k%e' ESCAPE '#'   true
 ```
+
+## POSIX regular expressions
+
+POSIX regular expressions provide a more powerful means for pattern
+matching than the `LIKE` and `SIMILAR TO` operators.  Many Unix tools
+such as `egrep`, `sed`, or `awk` use a pattern matching language that
+is similar to the one described here.
+
+Currently our compiler does not support `SIMILAR TO` regular
+expressions.
+
+A regular expression is a character sequence that is an abbreviated
+definition of a set of strings (a regular set). A string is said to
+match a regular expression if it is a member of the regular set
+described by the regular expression. As with `LIKE`, pattern
+characters match string characters exactly unless they are special
+characters in the regular expression language — but regular
+expressions use different special characters than `LIKE` does. Unlike
+`LIKE` patterns, a regular expression is allowed to match anywhere
+within a string, unless the regular expression is explicitly anchored
+to the beginning or end of the string.
+
+The description below is from the Postgres documentation, where credit
+is given to Henry Spencer.
+
+A *regular expression* is defined as one or more *branches*, separated
+by `|`. It matches anything that matches one of the branches.
+
+A *branch* is zero or more *quantified atoms* or *constraints*,
+concatenated. It matches a match for the first, followed by a match
+for the second, etc.; an empty branch matches the empty string.
+
+A *quantified atom* is an *atom* possibly followed by a single
+*quantifier*. Without a quantifier, it matches a match for the
+atom. With a quantifier, it can match some number of matches of the
+atom. An atom can be any of the possibilities shown in the Table
+below.
+
+<table>
+   <tr>
+      <th>Atom</th>
+      <th>Description</th>
+   </tr>
+   <tr>
+      <td><code>(re)</code></td>
+      <td>where <code>re</code> is any regular expression: matches a match for <code>re</code>, with the match noted for possible reporting</td>
+   </tr>
+   <tr>
+      <td><code>(?:re)</code></td>
+      <td>as above, but the match is not noted for reporting (a “non-capturing” set of parentheses)</td>
+   </tr>
+   <tr>
+      <td><code>.</code></td>
+      <td>matches any single character</td>
+   </tr>
+   <tr>
+      <td><code>[chars]</code></td>
+      <td>a bracket expression, matching any one of the chars (see below for more details)</td>
+   </tr>
+   <tr>
+      <td><code>\k</code></td>
+      <td>where <code>k</code> is a non-alphanumeric character): matches that character taken as an ordinary character, e.g.,
+          <code>\\</code> matches a backslash character</td>
+   </tr>
+   <tr>
+      <td><code>\c</code></td>
+      <td>where <code>c</code> is alphanumeric (possibly followed by other characters): is an escape, see below</td>
+   </tr>
+   <tr>
+      <td><code>&#123;</code></td>
+      <td>when followed by a character other than a digit, matches the left-brace character <code>&#123;</code>;
+          when followed by a digit, it is the beginning of a bound (see below)</td>
+   </tr>
+   <tr>
+      <td>x</td>
+      <td>where <code>x</code> is a single character with no other significance, matches that character</td>
+   </tr>
+</table>
+
+The possible quantifiers and their meanings are shown the Table below.
+
+|Quantifier|Matches|
+|----------|-------|
+|`*`  | a sequence of 0 or more matches of the atom|
+|`+`    | a sequence of 1 or more matches of the atom|
+|`?`    | a sequence of 0 or 1 matches of the atom|
+|`{`m`}`  | a sequence of exactly m matches of the atom|
+|`{`m`,}` | a sequence of m or more matches of the atom|
+|`{`m`,`n`}`| a sequence of m through n (inclusive) matches of the atom; m cannot exceed n|
+
+<!--
+|`*?`   | non-greedy version of *|
+|`+?`   | non-greedy version of +|
+|`??`   | non-greedy version of ?|
+|`{`m`}?` | non-greedy version of {m}|
+|`{`m`,}?`| non-greedy version of {m,}|
+|`{`m`,`n`}?` | non-greedy version of {m,n}|
+-->
+
+A constraint matches an empty string, but matches only when specific
+conditions are met. A constraint can be used where an atom could be
+used, except it cannot be followed by a quantifier. The simple
+constraints are shown in the Table below; some more constraints are
+described later.
+
+|Constraint|    Description|
+|----------|---------------|
+|`^`       |    matches at the beginning of the string |
+|`$`       |    matches at the end of the string       |
+
+<!--
+|(?=re)    |    positive lookahead matches at any point where a substring matching re begins (AREs only)
+|(?!re)    |    negative lookahead matches at any point where no substring matching re begins (AREs only)
+|(?<=re)   |    positive lookbehind matches at any point where a substring matching re ends (AREs only)
+|(?<!re)   |    negative lookbehind matches at any point where no substring matching re ends (AREs only)
+-->
+
+
+### Bracket Expressions
+
+A bracket expression is a list of characters enclosed in `[]`. It
+normally matches any single character from the list (but see
+below). If the list begins with `^`, it matches any single character
+not from the rest of the list. If two characters in the list are
+separated by `-`, this is shorthand for the full range of characters
+between those two (inclusive) in the collating sequence, e.g., `[0-9]`
+in ASCII matches any decimal digit. It is illegal for two ranges to
+share an endpoint, e.g., `a-c-e`.  Ranges are very
+collating-sequence-dependent, so portable programs should avoid
+relying on them.
+
+To include a literal `]` in the list, make it the first character
+(after `^`, if that is used). To include a literal `-`, make it the
+first or last character, or the second endpoint of a range. To use a
+literal `-` as the first endpoint of a range, enclose it in `[.` and
+`.]`.  With the exception of these characters, some combinations using
+`[`, all other special characters lose their special significance
+within a bracket expression. In particular, `\` is not special.
+
+Within a bracket expression, the name of a character class enclosed in
+`[:` and `:]` stands for the list of all characters belonging to that
+class. A character class cannot be used as an endpoint of a range. The
+POSIX standard defines these character class names:
+
+|Class|Description|
+|-----|-----------|
+|`alnum`|letters and numeric digits
+|`alpha`|letters    |
+|`blank`|space and tab|
+|`cntrl`|control characters|
+|`digit`|numeric digits|
+|`graph`|printable characters except space|
+|`lower`|lower-case letters|
+|`print`|printable characters including space|
+|`punct`|punctuation|
+|`space`|any white space|
+|`upper`|upper-case letters|
+|`xdigit`|hexadecimal digits|
+
+Class-shorthand escapes provide shorthands for certain commonly-used
+character classes. They are shown in the table below.
+
+|Escape|        Description|
+|------|-------------------|
+|`\d`    |matches any digit, like [[:digit:]] |
+|`\s`    |matches any whitespace character, like [[:space:]] |
+|`\w`    |matches any word character, like [[:word:]] |
+|`\D`    |matches any non-digit, like [^[:digit:]] |
+|`\S`    |matches any non-whitespace character, like [^[:space:]] |
+|`\W`    |matches any non-word character, like [^[:word:]] |
+
+The behavior of these standard character classes is generally
+consistent across platforms for characters in the 7-bit ASCII set.
+Whether a given non-ASCII character is considered to belong to one of
+these classes depends on the collation that is used for the
+regular-expression function or operator.
+
+### Regular Expression Escapes
+
+Escapes are special sequences beginning with `\` followed by an
+alphanumeric character.  Escapes come in several varieties: character
+entry, class shorthands, constraint escapes, and back references. A
+`\` followed by an alphanumeric character but not constituting a valid
+escape is illegal.
+
+Character-entry escapes exist to make it easier to specify
+non-printing and other inconvenient characters in REs. They are shown
+in the Table below.
+
+|Escape|        Description|
+|------|-------------------|
+|`\a`     |alert (bell) character, as in C|
+|`\b`     |backspace, as in C |
+|`\B`     |synonym for backslash (\) to help reduce the need for backslash doubling|
+|`\c`X    |(where X is any character) the character whose low-order 5 bits are the same as those of X, and whose other bits are all zero|
+|`\e`     |the character whose collating-sequence name is ESC, or failing that, the character with octal value 033 |
+|`\f`     |form feed, as in C |
+|`\n`     |newline, as in C |
+|`\r`     |carriage return, as in C |
+|`\t`     |horizontal tab, as in C |
+|`\u`wxyz |(where wxyz is exactly four hexadecimal digits) the character whose hexadecimal value is 0xwxyz |
+|`\v`     |vertical tab, as in C|
+|`\x`hhh  |(where hhh is any sequence of hexadecimal digits) the character whose hexadecimal value is 0xhhh (a single character no matter how many hexadecimal digits are used)|
+|`\0`     |the character whose value is 0 (the null byte)|
+|`\`xy    |(where xy is exactly two octal digits, and is not a back reference) the character whose octal value is 0xy|
+|`\`xyz   |(where xyz is exactly three octal digits, and is not a back reference) the character whose octal value is 0xyz|
+
+Hexadecimal digits are 0-9, a-f, and A-F. Octal digits are 0-7.
+
+A constraint escape is a constraint, matching the empty string if
+specific conditions are met, written as an escape. They are shown in
+the Table below.
+
+|Escape|Description|
+|------|-----------|
+|`\A`     |matches only at the beginning of the string (see Section 9.7.3.5 for how this differs from ^)|
+|`\m`     |matches only at the beginning of a word|
+|`\M`     |matches only at the end of a word|
+|`\y`     |matches only at the beginning or end of a word|
+|`\Y`     |matches only at a point that is not the beginning or end of a word|
+|`\Z`     |matches only at the end of the string|
+
+A back reference `(\`n`)` matches the same string matched by the
+previous parenthesized subexpression specified by the number n (see
+the Table below). For example, `([bc])\1` matches `bb` or `cc` but not
+`bc` or `cb`. The subexpression must entirely precede the back
+reference in the RE. Subexpressions are numbered in the order of their
+leading parentheses. Non-capturing parentheses do not define
+subexpressions. The back reference considers only the string
+characters matched by the referenced subexpression, not any
+constraints contained in it. For example, `(^\d)\1` will match `22`.
+
+|Escape|        Description|
+|------|-------------------|
+|`\`m     |(where m is a nonzero digit) a back reference to the m'th subexpression|
+|`\`mnn   |(where m is a nonzero digit, and nn is some more digits, and the decimal value mnn is not greater than the number of closing capturing parentheses seen so far) a back reference to the mnn'th subexpression|
+
+<!--
+### Regular expression functions
+
+```sql
+REGEXP_REPLACE(expr, pat, repl[, pos[, occurrence[, match_type]]])
+```
+
+Replaces occurrences in the string `expr` that match the regular
+expression specified by the pattern `pat` with the replacement string
+`repl`, and returns the resulting string. If any of `expr`, `pat`, or
+`repl` is `NULL`, the return value is `NULL`.
+
+`REGEXP_REPLACE()` takes these optional arguments:
+
+- `pos`: The position in expr at which to start the search. If omitted, the default is 1.
+
+- `occurrence`: Which occurrence of a match to replace. If omitted, the default is 0 (which
+  means “replace all occurrences”).
+
+- `match_type`: A string that specifies how to perform matching.  It is a string that may
+  contain any or all the following characters specifying how to perform matching:
+
+  - `c`: Case-sensitive matching.
+
+  - `i`: Case-insensitive matching.
+
+  - `m`: Multiple-line mode. Recognize line terminators within the string. The default
+     behavior is to match line terminators only at the start and end of the string expression.
+
+  - `n`: The `.` character matches line terminators. The default is for `.` matching to stop at the end of a line.
+
+  - `u`: Unix-only line endings. Only the newline character is recognized as a line ending by the ., ^, and $ match operators.
+-->

--- a/docs/docs/sql/string.md
+++ b/docs/docs/sql/string.md
@@ -202,6 +202,10 @@ SELECT 'h%awkeye' LIKE 'h#%a%k%e' ESCAPE '#'   true
 
 ## POSIX regular expressions
 
+The description below is from the [Postgres
+documentation](https://www.postgresql.org/docs/15/functions-matching.html#FUNCTIONS-POSIX-REGEXP),
+where credit is given to Henry Spencer.
+
 POSIX regular expressions provide a more powerful means for pattern
 matching than the `LIKE` and `SIMILAR TO` operators.  Many Unix tools
 such as `egrep`, `sed`, or `awk` use a pattern matching language that
@@ -220,9 +224,6 @@ expressions use different special characters than `LIKE` does. Unlike
 `LIKE` patterns, a regular expression is allowed to match anywhere
 within a string, unless the regular expression is explicitly anchored
 to the beginning or end of the string.
-
-The description below is from the Postgres documentation, where credit
-is given to Henry Spencer.
 
 A *regular expression* is defined as one or more *branches*, separated
 by `|`. It matches anything that matches one of the branches.

--- a/sql-to-dbsp-compiler/README.md
+++ b/sql-to-dbsp-compiler/README.md
@@ -103,8 +103,7 @@ See the [documentation](https://docs.feldera.io/guides/sql)
 
 ## Compiler architecture
 
-[A
-presentation](http://budiu.info/work/sql-compiler-architecture23.pptx)
+[A presentation](https://github.com/feldera/dbsp/blob/main/docs/static/sql-compiler-architecture.pptx)
 about the internals of the compiler implementation.
 
 Compilation proceeds in several stages:
@@ -158,11 +157,11 @@ Options:
 -u username   Postgres user name
 -p password   Postgres password
 Registered executors:
-	hybrid
-	dbsp
-	hsql
-	psql
-	none
+        hybrid
+        dbsp
+        hsql
+        psql
+        none
 ```
 
 We have multiple executors.  Some executors are inherited

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/codegen/config.fmpp
@@ -38,6 +38,7 @@ data: {
     # List of keywords from "keywords" section that are not reserved.
     # We might want the full list from here: https://github.com/apache/calcite/blob/main/core/src/main/codegen/default_config.fmpp
     nonReservedKeywords: [
+      "REPLACE"
     ]
 
     # List of non-reserved keywords to add
@@ -579,7 +580,7 @@ data: {
     # Each must accept arguments "(SqlParserPos pos, boolean replace)".
     createStatementParserMethods: [
       "SqlCreateView"
-      "SqlCreateTable"
+      "SqlCreateExtendedTable"
     ]
 
     # List of methods for parsing extensions to "DROP" calls.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -605,6 +605,7 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                                 ops, 2);
                     }
                     case "overlay":
+                    // case "regexp_replace":
                         return this.compileFunction(call, node, type, ops, 3, 4);
                     case "char_length":
                     case "ascii":
@@ -615,6 +616,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                         return this.compileFunction(call, node, type, ops, 1);
                     case "repeat":
                         return this.compileFunction(call, node, type, ops, 2);
+                    case "replace":
+                        return this.compileFunction(call, node, type, ops, 3);
                     case "division":
                         return makeBinaryExpression(node, type, DBSPOpcode.DIV, ops);
                     case "cardinality": {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/CalciteCompilerTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/CalciteCompilerTests.java
@@ -87,4 +87,48 @@ public class CalciteCompilerTests {
         SqlNode node = calcite.parse(query);
         Assert.assertNotNull(node);
     }
+
+    @Test
+    public void commentsTest() throws SqlParseException {
+        String query = "--- Line comment\n" +
+                "/* Second comment\n" +
+                "SELECT * FROM T\n" +
+                "*/\n" +
+                "CREATE VIEW V AS SELECT 0";
+        CalciteCompiler calcite = new CalciteCompiler(options);
+        SqlNode node = calcite.parseStatements(query);
+        Assert.assertNotNull(node);
+    }
+
+    @Test
+    public void primaryKeyTest() throws SqlParseException {
+        // MYSQL syntax for primary keys
+        String query =
+                "create table git_commit (\n" +
+                "    git_commit_id bigint not null primary key\n" +
+                ")";
+        CalciteCompiler calcite = new CalciteCompiler(options);
+        SqlNode node = calcite.parseStatements(query);
+        Assert.assertNotNull(node);
+    }
+
+    @Test
+    public void foreignKeyTest() throws SqlParseException {
+        // MYSQL syntax for FOREIGN KEY
+        String query = "-- Commit inside a Git repo.\n" +
+                "create table git_commit (\n" +
+                "    git_commit_id bigint not null,\n" +
+                "    repository_id bigint not null,\n" +
+                "    commit_id varchar not null,\n" +
+                "    commit_date timestamp not null,\n" +
+                "    commit_owner varchar not null\n" +
+                ");\n" +
+                "create table pipeline_sources (\n" +
+                "    git_commit_id bigint not null foreign key references git_commit(git_commit_id),\n" +
+                "    pipeline_id bigint not null\n" +
+                ")";
+        CalciteCompiler calcite = new CalciteCompiler(options);
+        SqlNode node = calcite.parseStatements(query);
+        Assert.assertNotNull(node);
+    }
 }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/JitTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/JitTests.java
@@ -1,7 +1,6 @@
 package org.dbsp.sqlCompiler.compiler;
 
 import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
-import org.dbsp.sqlCompiler.compiler.backend.jit.ToJitVisitor;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
@@ -15,7 +14,6 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
-import org.dbsp.util.Logger;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -32,24 +30,6 @@ public class JitTests extends EndToEndTests {
     }
 
     // All the @Ignore-ed tests below should eventually pass.
-
-    @Test @Override @Ignore("https://github.com/feldera/dbsp/issues/241")
-    public void averageTest() {
-        Logger.INSTANCE.setLoggingLevel(ToJitVisitor.class, 4);
-        String query = "SELECT AVG(T.COL1) FROM T";
-        this.testQuery(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPI32Literal(10, true))));
-    }
-
-    @Test @Override @Ignore("https://github.com/feldera/dbsp/issues/241")
-    public void constAggregateExpression2() {
-        Logger.INSTANCE.setLoggingLevel(ToJitVisitor.class, 4);
-        String query = "SELECT 34 / AVG (1) FROM T GROUP BY COL1";
-        this.testQuery(query, new DBSPZSetLiteral.Contents(
-                new DBSPTupleExpression(
-                        new DBSPI32Literal(34, true))));
-    }
 
     @Test @Override @Ignore("Uses Decimals, not yet supported by JIT https://github.com/feldera/dbsp/issues/158")
     public void divZero() {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
@@ -459,7 +459,6 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         Assert.assertTrue(success);
     }
 
-
     @Test
     public void testCompilerToJson() throws IOException {
         String[] statements = new String[]{

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
@@ -307,7 +307,79 @@ public class PostgresStringTests extends PostgresBaseTest {
                 "bubba");
     }
 
-    // TODO: regexp_replace
+    @Test @Ignore("Not yet implemented")
+    public void testRegexpReplace() {
+        this.queryWithOutput("SELECT regexp_replace('1112223333', E'(\\\\d{3})(\\\\d{3})(\\\\d{4})', E'(\\\\1) \\\\2-\\\\3');\n" +
+                " regexp_replace \n" +
+                "----------------\n" +
+                "(111) 222-3333");
+        this.queryWithOutput("SELECT regexp_replace('foobarrbazz', E'(.)\\\\1', E'X\\\\&Y', 'g');\n" +
+                "  regexp_replace   \n" +
+                "-------------------\n" +
+                "fXooYbaXrrYbaXzzY");
+        this.queryWithOutput("SELECT regexp_replace('foobarrbazz', E'(.)\\\\1', E'X\\\\\\\\Y', 'g');\n" +
+                " regexp_replace \n" +
+                "----------------\n" +
+                "fX\\YbaX\\YbaX\\Y");
+        this.queryWithOutput("SELECT regexp_replace('foobarrbazz', E'(.)\\\\1', E'X\\\\Y\\\\1Z\\\\');\n" +
+                " regexp_replace  \n" +
+                "-----------------\n" +
+                "fX\\YoZ\\barrbazz");
+        this.queryWithOutput("SELECT regexp_replace('AAA   BBB   CCC   ', E'\\\\s+', ' ', 'g');\n" +
+                " regexp_replace \n" +
+                "----------------\n" +
+                "AAA BBB CCC ");
+        this.queryWithOutput("SELECT regexp_replace('AAA', '^|$', 'Z', 'g');\n" +
+                " regexp_replace \n" +
+                "----------------\n" +
+                " ZAAAZ");
+        this.queryWithOutput("SELECT regexp_replace('AAA aaa', 'A+', 'Z', 'gi');\n" +
+                " regexp_replace \n" +
+                "----------------\n" +
+                " Z Z");
+        this.queryWithOutput(
+                "-- invalid regexp option\n" +
+                "SELECT regexp_replace('AAA aaa', 'A+', 'Z', 'z');\n" +
+                "ERROR:  invalid regular expression option: \"z\"");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'A|e|i|o|u', 'X', 1);\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " X PostgreSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'A|e|i|o|u', 'X', 1, 2);\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PXstgreSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 0, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " X PXstgrXSQL fXnctXXn");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " X PostgreSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 2, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PXstgreSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 3, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PostgrXSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 9, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PostgreSQL function");
+        this.queryWithOutput("SELECT regexp_replace('A PostgreSQL function', 'A|e|i|o|u', 'X', 7, 0, 'i');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PostgrXSQL fXnctXXn");
+        this.queryWithOutput("-- 'g' flag should be ignored when N is specified\n" +
+                "SELECT regexp_replace('A PostgreSQL function', 'a|e|i|o|u', 'X', 1, 1, 'g');\n" +
+                "    regexp_replace     \n" +
+                "-----------------------\n" +
+                " A PXstgreSQL function");
+    }
+
     // TODO: regexp_count
     // TODO: regexp_like
     // TODO: regexp_instr
@@ -598,20 +670,20 @@ public class PostgresStringTests extends PostgresBaseTest {
                 "     1");
     }
 
-    @Test @Ignore("No 'replace' yet in Calcite")
+    @Test
     public void testReplace() {
-        this.queryWithOutput("SELECT replace('abcdef', 'de', '45') AS \"abc45f\";\n" +
+        this.queryWithOutput("SELECT REPLACE('abcdef', 'de', '45') AS \"abc45f\";\n" +
                 " abc45f \n" +
                 "--------\n" +
-                " abc45f");
+                "abc45f");
         this.queryWithOutput("SELECT replace('yabadabadoo', 'ba', '123') AS \"ya123da123doo\";\n" +
                 " ya123da123doo \n" +
                 "---------------\n" +
-                " ya123da123doo");
+                "ya123da123doo");
         this.queryWithOutput("SELECT replace('yabadoo', 'bad', '') AS \"yaoo\";\n" +
                 " yaoo \n" +
                 "------\n" +
-                " yaoo");
+                "yaoo");
     }
 
     // TODO: replace

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PostgresStringTests.java
@@ -670,7 +670,7 @@ public class PostgresStringTests extends PostgresBaseTest {
                 "     1");
     }
 
-    @Test
+    @Test @Ignore("https://issues.apache.org/jira/browse/CALCITE-5813")
     public void testReplace() {
         this.queryWithOutput("SELECT REPLACE('abcdef', 'de', '45') AS \"abc45f\";\n" +
                 " abc45f \n" +

--- a/sql-to-dbsp-compiler/lib/sqllib/src/string.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/string.rs
@@ -194,3 +194,10 @@ pub fn initcap_(source: String) -> String {
 }
 
 some_function1!(initcap, String, String);
+
+pub fn replace___(haystack: String, needle: String, replacement: String) -> String {
+    haystack.replace(&needle, &replacement)
+}
+
+some_function3!(replace, String, String, String, String);
+


### PR DESCRIPTION
This PR includes documentation about POSIX regular expressions, but currently there is no function implemented that supports them. I was about to implement regexp_replace, when I realized that the Postgres version of this function is completely different than the Calcite version (which implements the MYSQL version). 