### PR TITLE
Capture background process output in files instead of inheriting file descriptors

### DIFF
--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
@@ -89,7 +89,7 @@ public class BaseSQLTests {
             testNumber++;
         }
         writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, false, extraArgs);
+        Utilities.compileAndTestRust(rustDirectory, true, extraArgs);
         testsToRun.clear();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ComplexQueriesTest.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/ComplexQueriesTest.java
@@ -203,7 +203,7 @@ public class ComplexQueriesTest extends BaseSQLTests {
         writer.emitCodeWithHandle(true);
         writer.add(circuit);
         writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, false);
+        Utilities.compileAndTestRust(rustDirectory, true);
     }
 
     @Test
@@ -359,7 +359,7 @@ public class ComplexQueriesTest extends BaseSQLTests {
         writer.emitCodeWithHandle(true);
         writer.add(circuit);
         writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, false);
+        Utilities.compileAndTestRust(rustDirectory, true);
     }
 
     @Test

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
@@ -173,7 +173,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         File file = this.createInputScript(statements);
         CompilerMain.execute("-TCalciteCompiler=2", "-TPasses=2",
                 "-o", BaseSQLTests.testFilePath, file.getPath());
-        Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
+        Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, true);
         boolean success = file.delete();
         Assert.assertTrue(success);
         Logger.INSTANCE.setDebugStream(save);
@@ -227,7 +227,7 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
         RustFileWriter writer = new RustFileWriter(compiler, testFilePath);
         writer.add(circuit);
         writer.writeAndClose();
-        Utilities.compileAndTestRust(rustDirectory, false);
+        Utilities.compileAndTestRust(rustDirectory, true);
     }
 
     @Test


### PR DESCRIPTION
Fixes #353 
This also gets rid of the annoying surefire plugin warnings during tests:
`Corrupted channel by directly writing to native stream in forked JVM 1.`.
