### PR TITLE
More intuitive semantics of `neighborhood`.

### DIFF
--- a/crates/dbsp/src/operator/neighborhood.rs
+++ b/crates/dbsp/src/operator/neighborhood.rs
@@ -258,13 +258,13 @@ where
 
             // Forward pass: locate the anchor and `decr.after`
             // following rows.
-            let mut after = Vec::with_capacity(descr.after);
+            let mut after = Vec::with_capacity(descr.after + 1);
             let mut offset = 0;
 
             if let Some(anchor_key) = anchor_key {
                 cursor.seek_keyval(anchor_key, anchor_val);
             };
-            while cursor.keyval_valid() && offset < descr.after {
+            while cursor.keyval_valid() && offset <= descr.after {
                 let w = cursor.weight();
 
                 if !cursor.weight().is_zero() {
@@ -371,13 +371,13 @@ where
             let anchor_key = &descr.anchor;
             let anchor_val = &descr.anchor_val;
 
-            let mut after = Vec::with_capacity(descr.after);
+            let mut after = Vec::with_capacity(descr.after + 1);
             let mut offset = 0;
 
             if let Some(anchor_key) = anchor_key {
                 cursor.seek_keyval(anchor_key, anchor_val);
             }
-            while cursor.keyval_valid() && offset < descr.after {
+            while cursor.keyval_valid() && offset <= descr.after {
                 let w = cursor.weight();
 
                 if !cursor.weight().is_zero() {
@@ -480,7 +480,7 @@ mod test {
                 };
 
                 let mut from = start - descr.before as isize;
-                let mut to = start + descr.after as isize;
+                let mut to = start + descr.after as isize + 1;
 
                 from = max(from, 0);
                 to = min(to, tuples.len() as isize);
@@ -664,7 +664,8 @@ mod test {
                 ((1, (12, 0), ()), 1),
                 ((2, (13, 0), ()), 1),
                 ((3, (14, 0), ()), 1),
-                ((4, (14, 1), ()), 1)
+                ((4, (14, 1), ()), 1),
+                ((5, (14, 2), ()), 1)
             ]
         );
 
@@ -680,6 +681,7 @@ mod test {
                 ((2, (9, 0), ()), 1),
                 ((3, (9, 1), ()), 1),
                 ((4, (10, 11), ()), 1),
+                ((5, (12, 0), ()), 1),
             ]
         );
     }


### PR DESCRIPTION
Given a descriptor of the form `{anchor, before, after}`, the `neighborhood` operator used to return up to `before + after` rows, including `before` rows preceding the anchor, the anchor, and `after - 1` rows following the anchor.  If `before` and `after` were both set to `0`, the output neighborhood was empty. I am no longer sure why this seemed like a good idea, but users (@gz) found this confusing.

This commit changes the semantics of `neighborhood` to always return the `anchor` (unless the specified `anchor` exceeds the largest value in the collection), and up to `before` preceding and `after` succeeding rows, up to a total of `before + after + 1` rows.