### PR TITLE
Pr358 postfix

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -547,6 +547,8 @@ test-docker-compose:
 integration-test-container:
     FROM +install-deps
     COPY +test-manager/test_binary .
+    # Check that the binary does indeed run integration tests
+    RUN ./test_binary integration_test --list | grep integration_test
     ENV TEST_DBSP_URL=http://dbsp:8080
     ENTRYPOINT ["./test_binary", "integration_test::"]
     SAVE IMAGE itest:latest

--- a/Earthfile
+++ b/Earthfile
@@ -421,7 +421,7 @@ test-manager:
     END
     # We keep the test binary around so we can run integration tests later. This incantation is used to find the
     # test binary path, adapted from: https://github.com/rust-lang/cargo/issues/3670
-    RUN cp `cargo test --features integration-test --no-run --package dbsp_pipeline_manager --message-format=json | jq -r 'select(.target.kind[0] == "bin") | .executable' | grep -v null | grep dbsp_pipeline_manager` test_binary
+    RUN cp `cargo test --features integration-test --no-run --package dbsp_pipeline_manager --message-format=json | jq -r 'select(.target.kind[0] == "lib") | .executable' | grep -v null ` test_binary
     SAVE ARTIFACT test_binary
 
 python-bindings-checker:


### PR DESCRIPTION
Before https://github.com/feldera/dbsp/pull/358, we had dbsp_pipeline_manager as the package and binary name. So we ran integration tests by invoking a binary named dbsp_pipeline_manager. This behavior changed with https://github.com/feldera/dbsp/pull/358, where we have multiple binaries being generated, and the package itself is now a library. This patch fixes the Earthfile to accommodate this change.