### PR TITLE
Workaround for actix-web bug.

### DIFF
--- a/crates/adapters/src/controller/mod.rs
+++ b/crates/adapters/src/controller/mod.rs
@@ -70,7 +70,7 @@ pub use stats::{ControllerStatus, InputEndpointStatus, OutputEndpointStatus};
 /// Maximal number of concurrent API connections per circuit
 /// (including both input and output connecions).
 // TODO: make this configurable.
-const MAX_API_CONNECTIONS: u64 = 100;
+pub(crate) const MAX_API_CONNECTIONS: u64 = 100;
 
 pub(crate) type EndpointId = u64;
 


### PR DESCRIPTION
There is a bug in actix (https://github.com/actix/actix-web/issues/1313) that prevents it from dropping HTTP connections on client disconnect unless the endpoint periodically sends some data.  As a result, all API-based data transfers eventually start to fail in the UI.  As a workaround, we generate an empty output chunk if there is no real payload to send for more than 3 seconds.