### PR TITLE
Support for i8, Time.  Documented PIVOT operation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,29 @@ it on as an open-source patch.  The e-mail address used to sign must match the e
 author. If you set your `user.name` and `user.email` git config values, you can sign your commit automatically
 with `git commit -s`.
 
+## Dependencies
+
+We develop and test under Linux.  Windows Subsystem for Linux works fine.
+The setup can be seen in this [Earthfile](Earthfile).
+
+Our known dependencies are:
+- Runtime
+  - a Rust tool chain (install rustup and the default toolchain)
+    - this will need a C and C++ compiler installed (e.g., gcc, gcc++)
+    - cmake
+    - libdev-ssl
+- SQL Compiler
+  - a Java Virtual Machine (at least Java 8)
+    - maven
+  - graphviz
+- Cloud and UI
+  - Python 3
+  - typescript
+  - Redpanda or Kafka
+
+Additional dependencies are automatically installed by the Rust,
+maven, Python, and typescript build tools.
+
 ## Contribution Flow
 
 ### Forking

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![CI workflow](https://github.com/feldera/dbsp/actions/workflows/ci.yml/badge.svg)](https://github.com/feldera/dbsp/actions)
+<!--
 [![codecov](https://codecov.io/gh/feldera/dbsp/branch/main/graph/badge.svg?token=0wZcmD11gt)](https://codecov.io/gh/feldera/dbsp)
+-->
 [![nightly](https://github.com/feldera/dbsp/actions/workflows/containers.yml/badge.svg)](https://github.com/feldera/dbsp/actions/workflows/containers.yml)
-
 
 The [Feldera Continuous Analytics Platform](https://www.feldera.com/), or Feldera in short, is a
 fast computational engine for *continuous analytics* over data in-motion. It
@@ -91,6 +92,11 @@ To learn more about Feldera, we recommend going through the [documentation](http
 * [Demos](https://docs.feldera.io/docs/category/demos)
 * [SQL reference](https://docs.feldera.io/docs/sql/intro)
 * [API reference](https://docs.feldera.io/docs/api/rest/)
+
+## Contributing
+
+Most of the software in this repository is governed by an open-source license.
+We welcome contributions.  Here are some [guidelines](CONTRIBUTING.md).
 
 ## Theory
 

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -43,6 +43,7 @@ uuid = { version = "1.1.2", features = ["v4"], optional = true }
 arc-swap = "1.5.1"
 mimalloc-rust-sys = "1.7.2"
 rand = "0.8.5"
+rust_decimal = "1.29"
 
     [dependencies.size-of]
     version = "0.1.5"

--- a/crates/dbsp/src/algebra/mod.rs
+++ b/crates/dbsp/src/algebra/mod.rs
@@ -17,6 +17,7 @@ pub use order::{PartialOrder, TotalOrder};
 pub use present::Present;
 pub use zset::{IndexedZSet, ZSet};
 
+use rust_decimal::Decimal;
 use size_of::SizeOf;
 use std::{
     marker::PhantomData,
@@ -327,6 +328,24 @@ impl MulByRef<isize> for F64 {
     }
 }
 
+impl MulByRef<isize> for Decimal {
+    type Output = Self;
+
+    #[inline]
+    fn mul_by_ref(&self, w: &isize) -> Self::Output {
+        *self * Decimal::from(*w)
+    }
+}
+
+impl MulByRef<isize> for Option<Decimal> {
+    type Output = Self;
+
+    #[inline]
+    fn mul_by_ref(&self, w: &isize) -> Self::Output {
+        self.as_ref().map(|x| (*x * Decimal::from(*w)))
+    }
+}
+
 impl MulByRef<isize> for Option<i32> {
     type Output = Self;
 
@@ -434,6 +453,24 @@ impl MulByRef<i64> for F64 {
     #[inline]
     fn mul_by_ref(&self, w: &i64) -> Self::Output {
         *self * ((*w) as f64)
+    }
+}
+
+impl MulByRef<i64> for Decimal {
+    type Output = Self;
+
+    #[inline]
+    fn mul_by_ref(&self, w: &i64) -> Self::Output {
+        *self * Decimal::from(*w)
+    }
+}
+
+impl MulByRef<i64> for Option<Decimal> {
+    type Output = Self;
+
+    #[inline]
+    fn mul_by_ref(&self, w: &i64) -> Self::Output {
+        self.as_ref().map(|x| (*x * Decimal::from(*w)))
     }
 }
 

--- a/docs/docs/sql/string.md
+++ b/docs/docs/sql/string.md
@@ -17,7 +17,7 @@ strings of any length.
 Trailing spaces are removed when converting a character value to one
 of the other string types.  Note that trailing spaces are semantically
 significant in character varying and text values, and when using
-pattern matching, that is LIKE and regular expressions.
+pattern matching (e.g., LIKE  and regular expressions).
 
 ## String constants (literals)
 

--- a/docs/docs/sql/types.md
+++ b/docs/docs/sql/types.md
@@ -24,6 +24,7 @@ The compiler supports the following SQL data types:
 - `INTERVAL`, a SQL interval.  Two types of intervals are supported:
   long intervals (comprising years and months), and short intervals,
   comprising days, hours, minutes, seconds.
+- `TIME`, the time of the day, with a precision of nanoseconds.
 - `TIMESTAMP`, a SQL timestamp without a timezone.  A timestamp
   represents a value containing a date and a time, with a precision up
   to a millisecond.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/DBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/DBSPCompiler.java
@@ -229,21 +229,25 @@ public class DBSPCompiler implements IWritesLogs, ICompilerComponent, IErrorRepo
         } catch (SqlParseException e) {
             this.messages.reportError(e);
             if (this.options.optimizerOptions.throwOnError) {
+                System.err.println(this.messages.toString());
                 throw new RuntimeException(e);
             }
         } catch (CalciteContextException e) {
             this.messages.reportError(e);
             if (this.options.optimizerOptions.throwOnError) {
+                System.err.println(this.messages.toString());
                 throw new RuntimeException(e);
             }
         } catch (BaseCompilerException e) {
             this.messages.reportError(e);
             if (this.options.optimizerOptions.throwOnError) {
+                System.err.println(this.messages.toString());
                 throw new RuntimeException(e);
             }
         } catch (Throwable e) {
             this.messages.reportError(e);
             if (this.options.optimizerOptions.throwOnError) {
+                System.err.println(this.messages.toString());
                 throw new RuntimeException(e);
             }
         }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -66,11 +66,7 @@ public class RustSqlRuntimeLibrary {
         this.arithmeticFunctions.put("min", DBSPOpcode.MIN);
         this.arithmeticFunctions.put("max", DBSPOpcode.MAX);
         this.arithmeticFunctions.put("is_distinct", DBSPOpcode.IS_DISTINCT);
-        this.arithmeticFunctions.put("agg_plus", DBSPOpcode.AGG_ADD);
-        this.arithmeticFunctions.put("agg_min", DBSPOpcode.AGG_MIN);
-        this.arithmeticFunctions.put("agg_max", DBSPOpcode.AGG_MAX);
         this.arithmeticFunctions.put("mul_by_ref", DBSPOpcode.MUL_WEIGHT);
-        this.arithmeticFunctions.put("if_selected", DBSPOpcode.IF_SELECTED);
 
         this.dateFunctions.put("plus", DBSPOpcode.ADD);
         this.dateFunctions.put("minus", DBSPOpcode.SUB);
@@ -85,6 +81,10 @@ public class RustSqlRuntimeLibrary {
         this.stringFunctions.put("concat", DBSPOpcode.CONCAT);
         this.stringFunctions.put("eq", DBSPOpcode.EQ);
         this.stringFunctions.put("neq", DBSPOpcode.NEQ);
+        this.stringFunctions.put("lt", DBSPOpcode.LT);
+        this.stringFunctions.put("gt", DBSPOpcode.GT);
+        this.stringFunctions.put("lte", DBSPOpcode.LTE);
+        this.stringFunctions.put("gte", DBSPOpcode.GTE);
 
         this.booleanFunctions.put("eq", DBSPOpcode.EQ);
         this.booleanFunctions.put("neq", DBSPOpcode.NEQ);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustSqlRuntimeLibrary.java
@@ -70,6 +70,7 @@ public class RustSqlRuntimeLibrary {
         this.arithmeticFunctions.put("agg_min", DBSPOpcode.AGG_MIN);
         this.arithmeticFunctions.put("agg_max", DBSPOpcode.AGG_MAX);
         this.arithmeticFunctions.put("mul_by_ref", DBSPOpcode.MUL_WEIGHT);
+        this.arithmeticFunctions.put("if_selected", DBSPOpcode.IF_SELECTED);
 
         this.dateFunctions.put("plus", DBSPOpcode.ADD);
         this.dateFunctions.put("minus", DBSPOpcode.SUB);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/ToRustInnerVisitor.java
@@ -475,6 +475,27 @@ public class ToRustInnerVisitor extends InnerVisitor {
     }
 
     @Override
+    public VisitDecision preorder(DBSPConditionalAggregateExpression expression) {
+        this.builder.append(expression.opcode.toString());
+        if (expression.condition != null)
+            this.builder.append("_conditional");
+        this.builder.append("_")
+                .append(expression.left.getType().nullableSuffix())
+                .append("_")
+                .append(expression.right.getType().nullableSuffix())
+                .append("(");
+        expression.left.accept(this);
+        this.builder.append(", ");
+        expression.right.accept(this);
+        if (expression.condition != null) {
+            this.builder.append(", ");
+            expression.condition.accept(this);
+        }
+        this.builder.append(")");
+        return VisitDecision.STOP;
+    }
+
+    @Override
     public VisitDecision preorder(DBSPBinaryExpression expression) {
         if (expression.operation.equals(DBSPOpcode.MUL_WEIGHT)) {
             expression.left.accept(this);
@@ -489,8 +510,6 @@ public class ToRustInnerVisitor extends InnerVisitor {
                 expression.left.getType(),
                 expression.right.getType());
         String func = function.function;
-        if (expression.operation.equals(DBSPOpcode.IF_SELECTED))
-            func = "if_selected" + expression.getType().nullableSuffix() + expression.left.getType().nullableSuffix();
         this.builder.append(func).append("(");
         expression.left.accept(this);
         this.builder.append(", ");

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/AggregateCompiler.java
@@ -23,7 +23,9 @@
 
 package org.dbsp.sqlCompiler.compiler.frontend;
 
+import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.*;
 import org.dbsp.sqlCompiler.compiler.ICompilerComponent;
@@ -35,6 +37,7 @@ import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.type.*;
 import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
 import org.dbsp.sqlCompiler.ir.expression.*;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeNull;
 import org.dbsp.util.*;
 
 import javax.annotation.Nullable;
@@ -67,17 +70,20 @@ public class AggregateCompiler implements ICompilerComponent {
     private final DBSPVariablePath v;
     private final boolean isDistinct;
     private final SqlAggFunction aggFunction;
-    private final int filterAgument;
+    private final int filterArgument;
     // null only for COUNT(*)
     @Nullable
     private final DBSPExpression aggArgument;
     private final NameGen generator;
+    private final RelNode aggregateNode;
+
 
     public AggregateCompiler(
-            CalciteObject node,
+            RelNode node,
             DBSPCompiler compiler,
             AggregateCall call, DBSPType resultType,
             DBSPVariablePath v) {
+        this.aggregateNode = node;
         this.compiler = compiler;
         this.resultType = resultType;
         this.nullableResultType = resultType.setMayBeNull(true);
@@ -86,7 +92,7 @@ public class AggregateCompiler implements ICompilerComponent {
         this.isDistinct = call.isDistinct();
         this.aggFunction = call.getAggregation();
         this.generator = new NameGen("a");
-        this.filterAgument = call.filterArg;
+        this.filterArgument = call.filterArg;
         List<Integer> argList = call.getArgList();
         if (argList.size() == 0) {
             this.aggArgument = null;
@@ -96,6 +102,10 @@ public class AggregateCompiler implements ICompilerComponent {
         } else {
             throw new UnimplementedException(new CalciteObject(call.getAggregation()));
         }
+    }
+
+    boolean isWindowAggregate() {
+        return !(this.aggregateNode instanceof LogicalAggregate);
     }
 
     public String genAccumulatorName() {
@@ -120,13 +130,21 @@ public class AggregateCompiler implements ICompilerComponent {
                 this.compiler.weightVar.asParameter());
     }
 
+    @Nullable
+    DBSPExpression filterArgument() {
+        if (this.filterArgument < 0)
+            return null;
+        return this.v.field(this.filterArgument);
+    }
+
     void processCount(SqlCountAggFunction function) {
         // The result of 'count' can never be null.
         CalciteObject node = new CalciteObject(function);
-        DBSPExpression zero = this.resultType.to(IsNumericType.class).getZero();
         DBSPExpression increment;
         DBSPExpression argument;
+        DBSPExpression zero = this.resultType.to(IsNumericType.class).getZero();
         DBSPExpression one = this.resultType.to(DBSPTypeInteger.class).getOne();
+
         if (this.aggArgument == null) {
             // COUNT(*)
             argument = one;
@@ -139,31 +157,28 @@ public class AggregateCompiler implements ICompilerComponent {
                 argument = one;
         }
 
-        if (this.filterAgument >= 0) {
-            argument = new DBSPBinaryExpression(node, argument.type,
-                    DBSPOpcode.IF_SELECTED, argument, this.v.field(this.filterAgument));
-        }
-
         @Nullable
         DBSPClosureExpression linear = argument.closure(this.v.asParameter());
         DBSPVariablePath accumulator = this.resultType.var(this.genAccumulatorName());
         if (this.isDistinct) {
             linear = null;
-            increment = ExpressionCompiler.aggregateOperation(
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,
-                    this.resultType, accumulator, argument);
+                    this.resultType, accumulator, argument, this.filterArgument());
         } else {
-            increment = ExpressionCompiler.aggregateOperation(
+            DBSPExpression weighted = new DBSPBinaryExpression(node, DBSPTypeInteger.SIGNED_64,
+                    DBSPOpcode.MUL_WEIGHT, argument, this.compiler.weightVar);
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD, this.resultType,
-                    accumulator, new DBSPBinaryExpression(node, DBSPTypeInteger.SIGNED_64,
-                            DBSPOpcode.MUL_WEIGHT,
-                            argument,
-                            this.compiler.weightVar));
+                    accumulator, weighted, this.filterArgument());
         }
+        if (this.filterArgument >= 0)
+            // no longer linear, since it returns 0 instead of nothing for an empty collection
+            linear = null;
         DBSPType semigroup = new DBSPTypeUser(node, USER, "DefaultSemigroup", false, this.resultType);
-        this.foldingFunction = new DBSPAggregate.Implementation(
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
                 node, zero, this.makeRowClosure(increment, accumulator),
-                zero, semigroup, linear);
+                zero, semigroup, linear));
     }
 
     private DBSPExpression getAggregatedValue() {
@@ -172,6 +187,26 @@ public class AggregateCompiler implements ICompilerComponent {
 
     private DBSPType getAggregatedValueType() {
         return this.getAggregatedValue().getType();
+    }
+
+    void setFoldingFunction(DBSPAggregate.Implementation foldingFunction) {
+        this.foldingFunction = foldingFunction;
+        if (!this.isWindowAggregate())
+            this.foldingFunction.validate();
+    }
+
+    public DBSPExpression aggregateOperation(
+            CalciteObject node, DBSPOpcode op,
+            DBSPType type, DBSPExpression left, DBSPExpression right, @Nullable DBSPExpression filter) {
+        DBSPType leftType = left.getType();
+        DBSPType rightType = right.getType();
+        DBSPType commonBase = ExpressionCompiler.reduceType(leftType, rightType);
+        if (commonBase.is(DBSPTypeNull.class)) {
+            return DBSPLiteral.none(type);
+        }
+        DBSPType resultType = commonBase.setMayBeNull(leftType.mayBeNull || rightType.mayBeNull);
+        DBSPExpression binOp = new DBSPConditionalAggregateExpression(node, op, resultType, left, right, filter);
+        return binOp.cast(type);
     }
 
     void processMinMax(SqlMinMaxAggFunction function) {
@@ -192,16 +227,12 @@ public class AggregateCompiler implements ICompilerComponent {
                 throw new UnimplementedException(node);
         }
         DBSPExpression aggregatedValue = this.getAggregatedValue();
-        if (this.filterAgument >= 0) {
-            aggregatedValue = new DBSPBinaryExpression(node, aggregatedValue.type,
-                    DBSPOpcode.IF_SELECTED, aggregatedValue, this.v.field(this.filterAgument));
-        }
         DBSPVariablePath accumulator = this.nullableResultType.var(this.genAccumulatorName());
-        DBSPExpression increment = ExpressionCompiler.aggregateOperation(
-                node, call, this.nullableResultType, accumulator, aggregatedValue);
+        DBSPExpression increment = this.aggregateOperation(
+                node, call, this.nullableResultType, accumulator, aggregatedValue, this.filterArgument());
         DBSPType semigroup = new DBSPTypeUser(node, USER, semigroupName, false, accumulator.getType());
-        this.foldingFunction = new DBSPAggregate.Implementation(
-                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, null);
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
+                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, null));
     }
 
     void processSum(SqlSumAggFunction function) {
@@ -209,29 +240,24 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression zero = DBSPLiteral.none(this.nullableResultType);
         DBSPExpression increment;
         DBSPExpression aggregatedValue = this.getAggregatedValue();
-        if (this.filterAgument >= 0) {
-            aggregatedValue = new DBSPBinaryExpression(node, aggregatedValue.type,
-                    DBSPOpcode.IF_SELECTED, aggregatedValue, this.v.field(this.filterAgument));
-        }
         DBSPVariablePath accumulator = this.nullableResultType.var(this.genAccumulatorName());
 
         if (this.isDistinct) {
-            increment = ExpressionCompiler.aggregateOperation(
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,
-                    this.nullableResultType, accumulator, aggregatedValue);
+                    this.nullableResultType, accumulator, aggregatedValue, this.filterArgument());
         } else {
-            increment = ExpressionCompiler.aggregateOperation(
+            DBSPExpression weighted = new DBSPBinaryExpression(node,
+                    aggregatedValue.getType(), DBSPOpcode.MUL_WEIGHT,
+                    aggregatedValue, this.compiler.weightVar);
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD, this.nullableResultType,
-                    accumulator, new DBSPBinaryExpression(node,
-                            aggregatedValue.getType(),
-                            DBSPOpcode.MUL_WEIGHT,
-                            aggregatedValue,
-                            this.compiler.weightVar));
+                    accumulator, weighted, this.filterArgument());
         }
         DBSPType semigroup = new DBSPTypeUser(CalciteObject.EMPTY, USER, "DefaultOptSemigroup",
                 false, accumulator.getType().setMayBeNull(false));
-        this.foldingFunction = new DBSPAggregate.Implementation(
-                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, null);
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
+                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, null));
     }
 
     void processSumZero(SqlSumEmptyIsZeroAggFunction function) {
@@ -239,33 +265,54 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression zero = this.resultType.to(IsNumericType.class).getZero();
         DBSPExpression increment;
         DBSPExpression aggregatedValue = this.getAggregatedValue();
-        if (this.filterAgument >= 0) {
-            aggregatedValue = new DBSPBinaryExpression(node, aggregatedValue.type,
-                    DBSPOpcode.IF_SELECTED, aggregatedValue, this.v.field(this.filterAgument));
-        }
         DBSPVariablePath accumulator = this.resultType.var(this.genAccumulatorName());
 
         @Nullable
         DBSPClosureExpression linear = null;
         if (this.isDistinct) {
-            increment = ExpressionCompiler.aggregateOperation(
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,
-                    this.resultType, accumulator, aggregatedValue);
+                    this.resultType, accumulator, aggregatedValue, this.filterArgument());
         } else {
             linear = aggregatedValue.closure(this.v.asParameter());
-            increment = ExpressionCompiler.aggregateOperation(
+            DBSPExpression weighted = new DBSPBinaryExpression(
+                    node, aggregatedValue.getType(),
+                    DBSPOpcode.MUL_WEIGHT, aggregatedValue, this.compiler.weightVar);
+            increment = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD, this.resultType,
-                    accumulator, new DBSPBinaryExpression(
-                            node, aggregatedValue.getType(),
-                            DBSPOpcode.MUL_WEIGHT, aggregatedValue, this.compiler.weightVar));
+                    accumulator, weighted, this.filterArgument());
         }
         String semigroupName = "DefaultSemigroup";
+        if (this.filterArgument >= 0)
+            // If we are filtering the sum is no longer linear
+            linear = null;
         if (accumulator.getType().mayBeNull)
             semigroupName = "DefaultOptSemigroup";
         DBSPType semigroup = new DBSPTypeUser(node, USER, semigroupName, false,
                 accumulator.getType().setMayBeNull(false));
-        this.foldingFunction = new DBSPAggregate.Implementation(
-                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, linear);
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
+                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, linear));
+    }
+
+    void processSingle(SqlSingleValueAggFunction function) {
+        CalciteObject node = new CalciteObject(function);
+        DBSPExpression zero = DBSPLiteral.none(this.nullableResultType);
+        DBSPExpression aggregatedValue = this.getAggregatedValue();
+        if (this.filterArgument >= 0) {
+            throw new UnimplementedException(node);
+            //aggregatedValue = new DBSPBinaryExpression(node, aggregatedValue.type,
+            //        DBSPOpcode.IF_SELECTED, aggregatedValue, this.v.field(this.filterArgument));
+        }
+        DBSPVariablePath accumulator = this.nullableResultType.var(this.genAccumulatorName());
+        // Single is supposed to be applied to a single value, and should return a runtime
+        // error otherwise.  We approximate this behavior by returning the last value seen.
+        DBSPExpression increment = aggregatedValue;
+        if (!increment.getType().mayBeNull)
+            increment = increment.some();
+        DBSPType semigroup = new DBSPTypeUser(CalciteObject.EMPTY, USER, "DefaultOptSemigroup",
+                false, accumulator.getType().setMayBeNull(false));
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
+                node, zero, this.makeRowClosure(increment, accumulator), zero, semigroup, null));
     }
 
     void processAvg(SqlAvgAggFunction function) {
@@ -282,35 +329,32 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPExpression countAccumulator = accumulator.field(countIndex);
         DBSPExpression sumAccumulator = accumulator.field(sumIndex);
         DBSPExpression aggregatedValue = this.getAggregatedValue().cast(i64);
-        if (this.filterAgument >= 0) {
-            aggregatedValue = new DBSPBinaryExpression(node, aggregatedValue.type,
-                    DBSPOpcode.IF_SELECTED, aggregatedValue, this.v.field(this.filterAgument));
-        }
         DBSPExpression plusOne = new DBSPI64Literal(1L);
 
         if (aggregatedValueType.mayBeNull)
             plusOne = new DBSPUnaryExpression(node, DBSPTypeInteger.SIGNED_64,
                     DBSPOpcode.INDICATOR, aggregatedValue);
         if (this.isDistinct) {
-            count = ExpressionCompiler.aggregateOperation(
+            count = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,
-                    i64, countAccumulator, plusOne);
-            sum = ExpressionCompiler.aggregateOperation(
+                    i64, countAccumulator, plusOne, this.filterArgument());
+            sum = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD,
-                    i64, sumAccumulator, aggregatedValue);
+                    i64, sumAccumulator, aggregatedValue, this.filterArgument());
         } else {
-            count = ExpressionCompiler.aggregateOperation(
+            DBSPExpression weightedCount = new DBSPBinaryExpression(
+                    node, DBSPTypeInteger.SIGNED_64.setMayBeNull(plusOne.getType().mayBeNull),
+                    DBSPOpcode.MUL_WEIGHT, plusOne,
+                    this.compiler.weightVar);
+            count = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD, i64,
-                    countAccumulator, new DBSPBinaryExpression(
-                            node, DBSPTypeInteger.SIGNED_64.setMayBeNull(plusOne.getType().mayBeNull),
-                            DBSPOpcode.MUL_WEIGHT, plusOne,
-                            this.compiler.weightVar));
-            sum = ExpressionCompiler.aggregateOperation(
+                    countAccumulator, weightedCount, this.filterArgument());
+            DBSPExpression weightedSum = new DBSPBinaryExpression(
+                    node, i64, DBSPOpcode.MUL_WEIGHT,
+                    aggregatedValue, this.compiler.weightVar);
+            sum = this.aggregateOperation(
                     node, DBSPOpcode.AGG_ADD, i64,
-                    sumAccumulator, new DBSPBinaryExpression(
-                            node,
-                            i64, DBSPOpcode.MUL_WEIGHT,
-                            aggregatedValue, this.compiler.weightVar));
+                    sumAccumulator, weightedSum, this.filterArgument());
         }
         DBSPExpression increment = new DBSPRawTupleExpression(sum, count);
 
@@ -325,8 +369,8 @@ public class AggregateCompiler implements ICompilerComponent {
         DBSPType semigroup = new DBSPTypeUser(node, USER, "PairSemigroup", false, i64, i64,
                 new DBSPTypeUser(node, USER, "DefaultOptSemigroup", false, DBSPTypeInteger.SIGNED_64),
                 new DBSPTypeUser(node, USER, "DefaultOptSemigroup", false, DBSPTypeInteger.SIGNED_64));
-        this.foldingFunction = new DBSPAggregate.Implementation(
-                node, zero, this.makeRowClosure(increment, accumulator), post, postZero, semigroup, null);
+        this.setFoldingFunction(new DBSPAggregate.Implementation(
+                node, zero, this.makeRowClosure(increment, accumulator), post, postZero, semigroup, null));
     }
 
     public DBSPAggregate.Implementation compile() {
@@ -335,7 +379,8 @@ public class AggregateCompiler implements ICompilerComponent {
                 this.process(this.aggFunction, SqlMinMaxAggFunction.class, this::processMinMax) ||
                 this.process(this.aggFunction, SqlSumAggFunction.class, this::processSum) ||
                 this.process(this.aggFunction, SqlSumEmptyIsZeroAggFunction.class, this::processSumZero) ||
-                this.process(this.aggFunction, SqlAvgAggFunction.class, this::processAvg);
+                this.process(this.aggFunction, SqlAvgAggFunction.class, this::processAvg) ||
+                this.process(this.aggFunction, SqlSingleValueAggFunction.class, this::processSingle);
         if (!success || this.foldingFunction == null)
             throw new UnimplementedException(new CalciteObject(this.aggFunction));
         return this.foldingFunction;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/CalciteToDBSPCompiler.java
@@ -179,7 +179,7 @@ public class CalciteToDBSPCompiler extends RelVisitor
 
         for (AggregateCall call: aggregates) {
             DBSPType resultFieldType = resultType.getFieldType(aggIndex + groupCount);
-            AggregateCompiler compiler = new AggregateCompiler(new CalciteObject(node),
+            AggregateCompiler compiler = new AggregateCompiler(node,
                     this.getCompiler(), call, resultFieldType, rowVar);
             DBSPAggregate.Implementation implementation = compiler.compile();
             result.set(aggIndex, implementation);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -117,8 +117,10 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
             if (type.is(DBSPTypeInteger.class)) {
                 DBSPTypeInteger intType = type.to(DBSPTypeInteger.class);
                 switch (intType.getWidth()) {
+                    case 8:
+                        return new DBSPI8Literal(Objects.requireNonNull(literal.getValueAs(Byte.class)));
                     case 16:
-                        return new DBSPI32Literal(Objects.requireNonNull(literal.getValueAs(Short.class)));
+                        return new DBSPI16Literal(Objects.requireNonNull(literal.getValueAs(Short.class)));
                     case 32:
                         return new DBSPI32Literal(Objects.requireNonNull(literal.getValueAs(Integer.class)));
                     case 64:
@@ -220,20 +222,6 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                 return left.setMayBeNull(false);
         }
         throw new UnimplementedException("Cast from " + right + " to " + left);
-    }
-
-    public static DBSPExpression aggregateOperation(
-            CalciteObject node, DBSPOpcode op,
-            DBSPType type, DBSPExpression left, DBSPExpression right) {
-        DBSPType leftType = left.getType();
-        DBSPType rightType = right.getType();
-        DBSPType commonBase = reduceType(leftType, rightType);
-        if (commonBase.is(DBSPTypeNull.class)) {
-            return DBSPLiteral.none(type);
-        }
-        DBSPType resultType = commonBase.setMayBeNull(leftType.mayBeNull || rightType.mayBeNull);
-        DBSPExpression binOp = new DBSPBinaryExpression(node, resultType, op, left, right);
-        return binOp.cast(type);
     }
 
     // Like makeBinaryExpression, but accepts multiple operands.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/ExpressionCompiler.java
@@ -216,6 +216,8 @@ public class ExpressionCompiler extends RexVisitorImpl<DBSPExpression> implement
                 return left.setMayBeNull(false);
             if (rf != null)
                 return right.setMayBeNull(false);
+            if (rd != null)
+                return left.setMayBeNull(false);
         }
         throw new UnimplementedException("Cast from " + right + " to " + left);
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/frontend/TypeCompiler.java
@@ -129,7 +129,6 @@ public class TypeCompiler implements ICompilerComponent {
                 case COLUMN_LIST:
                 case DYNAMIC_STAR:
                 case SARG:
-                case TIME:
                 case TIME_WITH_LOCAL_TIME_ZONE:
                 case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
                     throw new UnimplementedException(node);
@@ -154,6 +153,8 @@ public class TypeCompiler implements ICompilerComponent {
                     return DBSPTypeTimestamp.INSTANCE.setMayBeNull(nullable);
                 case DATE:
                     return DBSPTypeDate.INSTANCE.setMayBeNull(nullable);
+                case TIME:
+                    return DBSPTypeTime.INSTANCE.setMayBeNull(nullable);
             }
         }
         throw new UnimplementedException(node);

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -521,24 +521,32 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
         return this.preorder((DBSPLiteral) node);
     }
 
-    public VisitDecision preorder(DBSPI16Literal node) {
+    public VisitDecision preorder(DBSPIntLiteral node) {
         return this.preorder((DBSPLiteral) node);
+    }
+
+    public VisitDecision preorder(DBSPI8Literal node) {
+        return this.preorder((DBSPIntLiteral) node);
+    }
+
+    public VisitDecision preorder(DBSPI16Literal node) {
+        return this.preorder((DBSPIntLiteral) node);
     }
 
     public VisitDecision preorder(DBSPI32Literal node) {
-        return this.preorder((DBSPLiteral) node);
+        return this.preorder((DBSPIntLiteral) node);
     }
 
     public VisitDecision preorder(DBSPU32Literal node) {
-        return this.preorder((DBSPLiteral) node);
+        return this.preorder((DBSPIntLiteral) node);
     }
 
     public VisitDecision preorder(DBSPI64Literal node) {
-        return this.preorder((DBSPLiteral) node);
+        return this.preorder((DBSPIntLiteral) node);
     }
 
     public VisitDecision preorder(DBSPU64Literal node) {
-        return this.preorder((DBSPLiteral) node);
+        return this.preorder((DBSPIntLiteral) node);
     }
 
     public VisitDecision preorder(DBSPBoolLiteral node) {
@@ -961,24 +969,32 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
         this.postorder((DBSPLiteral) node);
     }
 
-    public void postorder(DBSPI16Literal node) {
+    public void postorder(DBSPIntLiteral node) {
         this.postorder((DBSPLiteral) node);
+    }
+
+    public void postorder(DBSPI8Literal node) {
+        this.postorder((DBSPIntLiteral) node);
+    }
+
+    public void postorder(DBSPI16Literal node) {
+        this.postorder((DBSPIntLiteral) node);
     }
 
     public void postorder(DBSPI32Literal node) {
-        this.postorder((DBSPLiteral) node);
+        this.postorder((DBSPIntLiteral) node);
     }
 
     public void postorder(DBSPU32Literal node) {
-        this.postorder((DBSPLiteral) node);
+        this.postorder((DBSPIntLiteral) node);
     }
 
     public void postorder(DBSPI64Literal node) {
-        this.postorder((DBSPLiteral) node);
+        this.postorder((DBSPIntLiteral) node);
     }
 
     public void postorder(DBSPU64Literal node) {
-        this.postorder((DBSPLiteral) node);
+        this.postorder((DBSPIntLiteral) node);
     }
 
     public void postorder(DBSPBoolLiteral node) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/visitors/inner/InnerVisitor.java
@@ -360,6 +360,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
         return this.preorder((DBSPExpression) node);
     }
 
+    public VisitDecision preorder(DBSPConditionalAggregateExpression node) {
+        return this.preorder((DBSPExpression) node);
+    }
+
     public VisitDecision preorder(DBSPBorrowExpression node) {
         return this.preorder((DBSPExpression) node);
     }
@@ -809,6 +813,10 @@ public abstract class InnerVisitor implements IRTransform, IWritesLogs {
     }
 
     public void postorder(DBSPStructExpression node) {
+        this.postorder((DBSPExpression) node);
+    }
+
+    public void postorder(DBSPConditionalAggregateExpression node) {
         this.postorder((DBSPExpression) node);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPConditionalAggregateExpression.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPConditionalAggregateExpression.java
@@ -1,0 +1,74 @@
+package org.dbsp.sqlCompiler.ir.expression;
+
+import org.dbsp.sqlCompiler.compiler.errors.InternalCompilerError;
+import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
+import org.dbsp.sqlCompiler.compiler.visitors.inner.InnerVisitor;
+import org.dbsp.sqlCompiler.ir.IDBSPNode;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeBool;
+import org.dbsp.util.IIndentStream;
+
+import javax.annotation.Nullable;
+
+/**
+ * A conditional aggregate has the form
+ * (accumulator, increment, predicate) -> accumulator.
+ * The predicate is optional.
+ */
+public class DBSPConditionalAggregateExpression extends DBSPExpression {
+    public final DBSPOpcode opcode;
+    public final DBSPExpression left;
+    public final DBSPExpression right;
+    @Nullable
+    public final DBSPExpression condition;
+
+    public DBSPConditionalAggregateExpression(
+            CalciteObject node, DBSPOpcode opcode, DBSPType resultType, DBSPExpression left,
+            DBSPExpression right, @Nullable DBSPExpression condition) {
+        super(node, resultType);
+        this.opcode = opcode;
+        this.left = left;
+        this.right = right;
+        this.condition = condition;
+        if (this.condition != null && !this.condition.getType().is(DBSPTypeBool.class))
+            throw new InternalCompilerError("Expected a boolean condition type " + left + " got " +
+                    this.left.getType(), this);
+    }
+
+    @Override
+    public void accept(InnerVisitor visitor) {
+        if (visitor.preorder(this).stop()) return;
+        visitor.push(this);
+        this.type.accept(visitor);
+        this.left.accept(visitor);
+        this.right.accept(visitor);
+        if (this.condition != null)
+            this.condition.accept(visitor);
+        visitor.pop(this);
+        visitor.postorder(this);
+    }
+
+    @Override
+    public boolean sameFields(IDBSPNode other) {
+        DBSPConditionalAggregateExpression o = other.as(DBSPConditionalAggregateExpression.class);
+        if (o == null)
+            return false;
+        return this.left == o.left &&
+                this.right == o.right &&
+                this.condition == o.condition &&
+                this.hasSameType(o);
+    }
+
+    @Override
+    public IIndentStream toString(IIndentStream builder) {
+        builder.append(this.opcode.toString())
+                .append("(")
+                .append(this.left)
+                .append(", ")
+                .append(this.right);
+        if (this.condition != null)
+            builder.append(", ")
+                    .append(this.condition);
+        return builder.append(")");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -10,6 +10,7 @@ public enum DBSPOpcode {
     NEG("-", false),
     UNARY_PLUS("+", false),
     NOT("!", false),
+    // Indicator(x) = if x == null { 0 } else { 1 }
     INDICATOR("indicator", false),
     IS_FALSE("is_false", false),
     IS_TRUE("is_true", false),
@@ -41,6 +42,8 @@ public enum DBSPOpcode {
     CONCAT("||", false),
     IS_DISTINCT("is_distinct", false),
     IS_NOT_DISTINCT("is_not_distinct", false),
+    // if_selected(x, p) = if p { Some(x) } else { None }
+    IF_SELECTED("if_selected", false),
 
     // Aggregate operations
     AGG_MAX("agg_max", true),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/DBSPOpcode.java
@@ -42,8 +42,6 @@ public enum DBSPOpcode {
     CONCAT("||", false),
     IS_DISTINCT("is_distinct", false),
     IS_NOT_DISTINCT("is_not_distinct", false),
-    // if_selected(x, p) = if p { Some(x) } else { None }
-    IF_SELECTED("if_selected", false),
 
     // Aggregate operations
     AGG_MAX("agg_max", true),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI32Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI32Literal.java
@@ -33,7 +33,7 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class DBSPI32Literal extends DBSPLiteral {
+public class DBSPI32Literal extends DBSPIntLiteral {
     @Nullable
     public final Integer value;
 
@@ -62,10 +62,6 @@ public class DBSPI32Literal extends DBSPLiteral {
         visitor.push(this);
         visitor.pop(this);
         visitor.postorder(this);
-    }
-
-    public DBSPTypeInteger getIntegerType() {
-        return this.type.to(DBSPTypeInteger.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI64Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI64Literal.java
@@ -33,7 +33,7 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class DBSPI64Literal extends DBSPLiteral {
+public class DBSPI64Literal extends DBSPIntLiteral {
     @Nullable
     public final Long value;
 
@@ -66,10 +66,6 @@ public class DBSPI64Literal extends DBSPLiteral {
 
     public DBSPI64Literal(@Nullable Integer value, boolean nullable) {
         this(CalciteObject.EMPTY, value == null ? null : value.longValue(), nullable);
-    }
-
-    public DBSPTypeInteger getIntegerType() {
-        return this.type.to(DBSPTypeInteger.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI8Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPI8Literal.java
@@ -10,25 +10,25 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class DBSPI16Literal extends DBSPIntLiteral {
+public class DBSPI8Literal extends DBSPIntLiteral {
     @Nullable
-    public final Short value;
+    public final Byte value;
 
-    public DBSPI16Literal() {
+    public DBSPI8Literal() {
         this(null, true);
     }
 
-    public DBSPI16Literal(short value) {
+    public DBSPI8Literal(Byte value) {
         this(value, false);
     }
 
-    public DBSPI16Literal(CalciteObject node, DBSPType type , @Nullable Short value) {
+    public DBSPI8Literal(CalciteObject node, DBSPType type , @Nullable Byte value) {
         super(node, type, value == null);
         this.value = value;
     }
 
-    public DBSPI16Literal(@Nullable Short value, boolean nullable) {
-        this(CalciteObject.EMPTY, DBSPTypeInteger.SIGNED_16.setMayBeNull(nullable), value);
+    public DBSPI8Literal(@Nullable Byte value, boolean nullable) {
+        this(CalciteObject.EMPTY, DBSPTypeInteger.SIGNED_8.setMayBeNull(nullable), value);
         if (value == null && !nullable)
             throw new InternalCompilerError("Null value with non-nullable type", this);
     }
@@ -43,14 +43,14 @@ public class DBSPI16Literal extends DBSPIntLiteral {
 
     @Override
     public DBSPLiteral getWithNullable(boolean mayBeNull) {
-        return new DBSPI16Literal(this.checkIfNull(this.value, mayBeNull), mayBeNull);
+        return new DBSPI8Literal(this.checkIfNull(this.value, mayBeNull), mayBeNull);
     }
 
     @Override
     public boolean sameValue(@Nullable DBSPLiteral o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        DBSPI16Literal that = (DBSPI16Literal) o;
+        DBSPI8Literal that = (DBSPI8Literal) o;
         return Objects.equals(value, that.value);
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPIntLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPIntLiteral.java
@@ -1,0 +1,18 @@
+package org.dbsp.sqlCompiler.ir.expression.literal;
+
+import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
+import org.dbsp.sqlCompiler.ir.type.DBSPType;
+import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeInteger;
+
+/**
+ * Base class for all integer literal.
+ */
+public abstract class DBSPIntLiteral extends DBSPLiteral {
+    protected DBSPIntLiteral(CalciteObject node, DBSPType type, boolean isNull) {
+        super(node, type, isNull);
+    }
+
+    public DBSPTypeInteger getIntegerType() {
+        return this.type.to(DBSPTypeInteger.class);
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPLiteral.java
@@ -74,6 +74,8 @@ public abstract class DBSPLiteral extends DBSPExpression {
             if (!it.signed)
                 throw new UnimplementedException("Null of type ", type);
             switch (it.getWidth()) {
+                case 8:
+                    return new DBSPI8Literal();
                 case 16:
                     return new DBSPI16Literal();
                 case 32:

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU32Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU32Literal.java
@@ -33,7 +33,7 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class DBSPU32Literal extends DBSPLiteral {
+public class DBSPU32Literal extends DBSPIntLiteral {
     @Nullable
     public final Integer value;
 
@@ -73,10 +73,6 @@ public class DBSPU32Literal extends DBSPLiteral {
     @Override
     public DBSPLiteral getWithNullable(boolean mayBeNull) {
         return new DBSPU32Literal(this.checkIfNull(this.value, mayBeNull), mayBeNull);
-    }
-
-    public DBSPTypeInteger getIntegerType() {
-        return this.type.to(DBSPTypeInteger.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU64Literal.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/expression/literal/DBSPU64Literal.java
@@ -33,7 +33,7 @@ import org.dbsp.util.IIndentStream;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
-public class DBSPU64Literal extends DBSPLiteral {
+public class DBSPU64Literal extends DBSPIntLiteral {
     @Nullable
     public final Long value;
 
@@ -62,10 +62,6 @@ public class DBSPU64Literal extends DBSPLiteral {
 
     public DBSPU64Literal(@Nullable Long value, boolean nullable) {
         this(CalciteObject.EMPTY, value, nullable);
-    }
-
-    public DBSPTypeInteger getIntegerType() {
-        return this.type.to(DBSPTypeInteger.class);
     }
 
     @Override

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/DBSPTypeCode.java
@@ -20,7 +20,7 @@ public enum DBSPTypeCode {
     NULL("null", "()", ""),
     STR("str", "str", ""),
     STRING("s", "String", "String"),
-    TIME("time", "Time", ""),
+    TIME("Time", "Time", ""),
     TIMESTAMP("Timestamp", "Timestamp", "Timestamp"),
     TIMESTAMP_TZ("", "", ""),
     UNIT("", "()", "Unit"),  // JIT use only

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeInteger.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/ir/type/primitive/DBSPTypeInteger.java
@@ -43,6 +43,8 @@ public class DBSPTypeInteger extends DBSPTypeBaseType
     private final int width;
     public final boolean signed;
 
+    public static final DBSPTypeInteger SIGNED_8 =
+            new DBSPTypeInteger(CalciteObject.EMPTY, INT8,  8, true,false);
     public static final DBSPTypeInteger SIGNED_16 =
             new DBSPTypeInteger(CalciteObject.EMPTY, INT16, 16, true,false);
     public static final DBSPTypeInteger SIGNED_32 =

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/BaseSQLTests.java
@@ -45,6 +45,9 @@ public class BaseSQLTests {
     public static final String rustDirectory = "../temp/src";
     public static final String testFilePath = rustDirectory + "/lib.rs";
 
+    static int testsExecuted = 0;
+    static int jitTestsExecuted = 0;
+
     /**
      * Collect here all the tests to run and execute them using a single Rust compilation.
      */
@@ -80,16 +83,20 @@ public class BaseSQLTests {
                     extraArgs[0] = "--features";
                     extraArgs[1] = "jit";
                 }
+                jitTestsExecuted++;
             } else {
                 // Standard test
                 writer.add(test.circuit);
                 DBSPFunction tester = test.createTesterCode(testNumber);
                 writer.add(tester);
+                testsExecuted++;
             }
             testNumber++;
         }
         writer.writeAndClose();
         Utilities.compileAndTestRust(rustDirectory, true, extraArgs);
+        System.out.println("Executed " + testsExecuted + " Rust tests and "
+                + jitTestsExecuted + " JIT tests");
         testsToRun.clear();
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/EndToEndTests.java
@@ -340,6 +340,54 @@ public class EndToEndTests extends BaseSQLTests {
                         new DBSPTupleExpression(DBSPBoolLiteral.FALSE)));
     }
 
+    @Test
+    public void testSumFilter() {
+        String query = "SELECT T.COL3, " +
+                "SUM(T.COL1) FILTER (WHERE T.COL1 > 20)\n" +
+                "FROM T GROUP BY T.COL3";
+        this.testQuery(query, new DBSPZSetLiteral.Contents(
+                new DBSPTupleExpression(
+                        DBSPBoolLiteral.TRUE,
+                        DBSPLiteral.none(DBSPTypeInteger.SIGNED_32)
+                ),
+                new DBSPTupleExpression(DBSPBoolLiteral.FALSE,
+                        DBSPLiteral.none(DBSPTypeInteger.SIGNED_32)
+                )));
+    }
+
+    @Test
+    public void testCountFilter() {
+        String query = "SELECT T.COL3, " +
+                "COUNT(*) FILTER (WHERE T.COL1 > 20)\n" +
+                "FROM T GROUP BY T.COL3";
+        this.testQuery(query, new DBSPZSetLiteral.Contents(
+                new DBSPTupleExpression(
+                        DBSPBoolLiteral.TRUE,
+                        new DBSPI64Literal(0, false)
+                ),
+                new DBSPTupleExpression(DBSPBoolLiteral.FALSE,
+                        new DBSPI64Literal(0, false)
+                )));
+    }
+
+    @Test
+    public void testSumCountFilter() {
+        String query = "SELECT T.COL3, " +
+                "COUNT(*) FILTER (WHERE T.COL1 > 20),\n" +
+                "SUM(T.COL1) FILTER (WHERE T.COL1 > 20)\n" +
+                "FROM T GROUP BY T.COL3";
+        this.testQuery(query, new DBSPZSetLiteral.Contents(
+                new DBSPTupleExpression(
+                        DBSPBoolLiteral.TRUE,
+                        new DBSPI64Literal(0, false),
+                        DBSPLiteral.none(DBSPTypeInteger.SIGNED_32)
+                ),
+                new DBSPTupleExpression(DBSPBoolLiteral.FALSE,
+                        new DBSPI64Literal(0, false),
+                        DBSPLiteral.none(DBSPTypeInteger.SIGNED_32)
+                )));
+    }
+
     @Test @Ignore("JSON_OBJECT not yet implemented")
     public void jsonTest() {
         String query = "select JSON_OBJECT(\n" +

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/OtherTests.java
@@ -378,8 +378,11 @@ public class OtherTests extends BaseSQLTests implements IWritesLogs {
                 continue;
             String path = subdir.getPath() + "/project.sql";
             CompilerMessages messages = CompilerMain.execute("-o", BaseSQLTests.testFilePath, path);
+            System.out.println(messages);
             Assert.assertEquals(0, messages.errorCount());
-            // Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
+            if (!subdir.getName().contains("demo02"))
+                // TODO: Waiting for https://issues.apache.org/jira/browse/CALCITE-5861
+                Utilities.compileAndTestRust(BaseSQLTests.rustDirectory, false);
         }
     }
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/FoodmartBaseTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/FoodmartBaseTests.java
@@ -1,0 +1,102 @@
+package org.dbsp.sqlCompiler.compiler.foodmart;
+
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
+import org.dbsp.sqlCompiler.compiler.postgres.PostgresBaseTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class FoodmartBaseTests extends PostgresBaseTest {
+    @Override
+    public void prepareData(DBSPCompiler compiler) {
+        compiler.compileStatements("DROP TABLE IF EXISTS DEPT;\n" +
+                "CREATE TABLE DEPT(\n" +
+                "    DEPTNO TINYINT NOT NULL,\n" +
+                "    DNAME VARCHAR(50) NOT NULL,\n" +
+                "    LOC VARCHAR(20)\n" +
+                ");\n" +
+                "CREATE TABLE EMP(\n" +
+                "    EMPNO INT NOT NULL,\n" +
+                "    ENAME VARCHAR(100) NOT NULL,\n" +
+                "    JOB VARCHAR(15) NOT NULL,\n" +
+                "    AGE SMALLINT,\n" +
+                "    MGR BIGINT,\n" +
+                "    HIREDATE DATE,\n" +
+                "    SAL DECIMAL(8,2) NOT NULL,\n" +
+                "    COMM DECIMAL(6,2),\n" +
+                "    DEPTNO TINYINT,\n" +
+                "    EMAIL VARCHAR(100),\n" +
+                "    CREATE_DATETIME TIMESTAMP,\n" +
+                "    CREATE_TIME TIME,\n" +
+                "    UPSERT_TIME TIMESTAMP NOT NULL\n" +
+                ");\n" +
+                "\n" +
+                "INSERT INTO DEPT VALUES(10,'ACCOUNTING','NEW YORK');\n" +
+                "INSERT INTO DEPT VALUES(20,'RESEARCH','DALLAS');\n" +
+                "INSERT INTO DEPT VALUES(30,'SALES','CHICAGO');\n" +
+                "INSERT INTO DEPT VALUES(40,'OPERATIONS','BOSTON');\n" +
+                "\n" +
+                "INSERT INTO EMP VALUES(7369,'SMITH','CLERK',30,7902,'1980-12-17',800,NULL,20,'smith@calcite','2020-01-01 18:35:40','18:35:40','2020-01-01 18:35:40');\n" +
+                "INSERT INTO EMP VALUES(7499,'ALLEN','SALESMAN',24,7698,'1981-02-20',1600,300,30,'allen@calcite','2018-04-09 09:00:00','09:00:00','2018-04-09 09:00:00');\n" +
+                "INSERT INTO EMP VALUES(7521,'WARD','SALESMAN',41,7698,'1981-02-22',1250,500,30,'ward@calcite','2019-11-16 10:26:40','10:26:40','2019-11-16 10:26:40');\n" +
+                "INSERT INTO EMP VALUES(7566,'JONES','MANAGER',28,7839,'1981-02-04',2975,NULL,20,'jones@calcite','2015-03-09 22:16:30','22:16:30','2015-03-09 22:16:30');\n" +
+                "INSERT INTO EMP VALUES(7654,'MARTIN','SALESMAN',27,7698,'1981-09-28',1250,1400,30,'martin@calcite','2018-09-02 12:12:56','12:12:56','2018-09-02 12:12:56');\n" +
+                "INSERT INTO EMP VALUES(7698,'BLAKE','MANAGER',38,7839,'1981-01-05',2850,NULL,30,'blake@calcite','2018-06-01 14:45:00','14:45:00','2018-06-01 14:45:00');\n" +
+                "INSERT INTO EMP VALUES(7782,'CLARK','MANAGER',32,7839,'1981-06-09',2450,NULL,10,NULL,'2019-09-30 02:14:56','02:14:56','2019-09-30 02:14:56');\n" +
+                "INSERT INTO EMP VALUES(7788,'SCOTT','ANALYST',45,7566,'1987-04-19',3000,NULL,20,'scott@calcite','2019-07-28 12:12:12','12:12:12','2019-07-28 12:12:12');\n" +
+                "INSERT INTO EMP VALUES(7839,'KING','PRESIDENT',22,NULL,'1981-11-17',5000,NULL,10,'king@calcite','2019-06-08 15:15:15',NULL,'2019-06-08 15:15:15');\n" +
+                "INSERT INTO EMP VALUES(7844,'TURNER','SALESMAN',54,7698,'1981-09-08',1500,0,30,'turner@calcite','2017-08-17 22:01:37','22:01:37','2017-08-17 22:01:37');\n" +
+                "INSERT INTO EMP VALUES(7876,'ADAMS','CLERK',35,7788,'1987-05-23',1100,NULL,20,'adams@calcite',NULL,'23:11:06','2017-08-18 23:11:06');\n" +
+                "INSERT INTO EMP VALUES(7900,'JAMES','CLERK',40,7698,'1981-12-03',950,NULL,30,'james@calcite','2020-01-02 12:19:00','12:19:00','2020-01-02 12:19:00');\n" +
+                "INSERT INTO EMP VALUES(7902,'FORD','ANALYST',28,7566,'1981-12-03',3000,NULL,20,'ford@calcite','2019-05-29 00:00:00',NULL,'2019-05-29 00:00:00');\n" +
+                "INSERT INTO EMP VALUES(7934,'MILLER','CLERK',32,7782,'1982-01-23',1300,NULL,10,NULL,'2016-09-02 23:15:01','23:15:01','2016-09-02 23:15:01')\n");
+    }
+    
+    @Test
+    public void testSelect() {
+        this.q("SELECT * FROM DEPT;\n" +
+                "DEPT NO | DNAME | LOC\n" +
+                "---------------------\n" +
+                "10 |ACCOUNTING|NEW YORK\n" +
+                "20 |RESEARCH|DALLAS\n" +
+                "30 |SALES|CHICAGO\n" +
+                "40 |OPERATIONS|BOSTON");
+    }
+
+    @Test
+    public void testSelect1() {
+        this.q("select deptno, (select min(empno) from emp where deptno = dept.deptno) as x from dept;\n" +
+                "+--------+------+\n" +
+                "| DEPTNO | X    |\n" +
+                "+--------+------+\n" +
+                "|     10 | 7782 |\n" +
+                "|     20 | 7369 |\n" +
+                "|     30 | 7499 |\n" +
+                "|     40 |      |");
+    }
+
+    @Test
+    public void testCount() {
+        this.q("select deptno, (select count(*) from emp where deptno = dept.deptno) as x from dept;\n" +
+                "+--------+---+\n" +
+                "| DEPTNO | X |\n" +
+                "+--------+---+\n" +
+                "|     10 | 3 |\n" +
+                "|     20 | 5 |\n" +
+                "|     30 | 6 |\n" +
+                "|     40 | 0 |");
+    }
+
+    @Test @Ignore("This seems to be the wrong input or output")
+    public void testPivot() {
+        this.q("SELECT *\n" +
+                "FROM   (SELECT deptno, job, sal\n" +
+                "        FROM   emp)\n" +
+                "PIVOT  (SUM(sal) AS sum_sal, COUNT(*) AS \"COUNT\"\n" +
+                "        FOR (job) IN ('CLERK', 'MANAGER' mgr, 'ANALYST' AS \"a\"));\n" +
+                "| DEPTNO | 'CLERK'_SUM_SAL | 'CLERK'_COUNT | MGR_SUM_SAL | MGR_COUNT | a_SUM_SAL | a_COUNT |\n" +
+                "+--------+-----------------+---------------+-------------+-----------+-----------+---------+\n" +
+                "|     10 |         1300.00 |             1 |     2450.00 |         1 |           |       0 |\n" +
+                "|     20 |         1900.00 |             2 |     2975.00 |         1 |   6000.00 |       2 |\n" +
+                "|     30 |          950.00 |             1 |     2850.00 |         1 |           |       0 |");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/FoodmartPivotTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/FoodmartPivotTests.java
@@ -1,0 +1,569 @@
+package org.dbsp.sqlCompiler.compiler.foodmart;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class FoodmartPivotTests extends FoodmartBaseTests {
+    @Test
+    public void testPivot() {
+        this.qs("SELECT *\n" +
+                "FROM   (SELECT deptno, job, sal\n" +
+                "        FROM   emp)\n" +
+                "PIVOT  (SUM(sal) AS sum_sal, COUNT(*) AS \"COUNT\"\n" +
+                "        FOR (job) IN ('CLERK', 'MANAGER' mgr, 'ANALYST' AS \"a\"));\n" +
+                "+--------+-----------------+---------------+-------------+-----------+-----------+---------+\n" +
+                "| DEPTNO | 'CLERK'_SUM_SAL | 'CLERK'_COUNT | MGR_SUM_SAL | MGR_COUNT | a_SUM_SAL | a_COUNT |\n" +
+                "+--------+-----------------+---------------+-------------+-----------+-----------+---------+\n" +
+                "|     10 |         1300.00 |             1 |     2450.00 |         1 |           |       0 |\n" +
+                "|     20 |         1900.00 |             2 |     2975.00 |         1 |   6000.00 |       2 |\n" +
+                "|     30 |          950.00 |             1 |     2850.00 |         1 |           |       0 |\n" +
+                "+--------+-----------------+---------------+-------------+-----------+-----------+---------+\n" +
+                "(3 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT job, deptno FROM emp)\n" +
+                "PIVOT (COUNT(*) AS \"COUNT\" FOR deptno IN (10, 50, 20));\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "| JOB       | 10_COUNT | 50_COUNT | 20_COUNT |\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "|ANALYST|        0 |        0 |        2 |\n" +
+                "|CLERK|        1 |        0 |        2 |\n" +
+                "|MANAGER|        1 |        0 |        1 |\n" +
+                "|PRESIDENT|        1 |        0 |        0 |\n" +
+                "|SALESMAN|        0 |        0 |        0 |\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "(5 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT job, deptno FROM emp)\n" +
+                "PIVOT (COUNT(*) AS \"COUNT\" FOR deptno IN (10, 50, 20)) AS e\n" +
+                "WHERE e.job <> 'MANAGER';\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "| JOB       | 10_COUNT | 50_COUNT | 20_COUNT |\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "|ANALYST|        0 |        0 |        2 |\n" +
+                "|CLERK|        1 |        0 |        2 |\n" +
+                "|PRESIDENT|        1 |        0 |        0 |\n" +
+                "|SALESMAN|        0 |        0 |        0 |\n" +
+                "+-----------+----------+----------+----------+\n" +
+                "(4 rows)\n" +
+                "\n" +
+                "SELECT job, SUM(\"10_COUNT\") AS sum10, SUM(\"20_COUNT\" + \"50_COUNT\") AS sum20\n" +
+                "FROM (SELECT job, deptno FROM emp)\n" +
+                "PIVOT (COUNT(*) AS \"COUNT\" FOR deptno IN (10, 50, 20)) AS e\n" +
+                "WHERE e.job <> 'MANAGER'\n" +
+                "GROUP BY job;\n" +
+                "+-----------+-------+-------+\n" +
+                "| JOB       | SUM10 | SUM20 |\n" +
+                "+-----------+-------+-------+\n" +
+                "|ANALYST|     0 |     2 |\n" +
+                "|CLERK|     1 |     2 |\n" +
+                "|PRESIDENT|     1 |     0 |\n" +
+                "|SALESMAN|     0 |     0 |\n" +
+                "+-----------+-------+-------+\n" +
+                "(4 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT mgr, deptno, job, sal FROM emp)\n" +
+                "PIVOT (SUM(sal) AS ss, COUNT(*) AS cc\n" +
+                "   FOR (job, deptno)\n" +
+                "   IN (('CLERK', 20) AS c20, ('MANAGER', 10) AS m10))\n" +
+                "-- ORDER BY 1 NULLS FIRST" +
+                ";\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "| MGR  | C20_SS  | C20_C | M10_SS  | M10_C |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "|      |         |     0 |         |     0 |\n" +
+                "| 7566 |         |     0 |         |     0 |\n" +
+                "| 7698 |         |     0 |         |     0 |\n" +
+                "| 7782 |         |     0 |         |     0 |\n" +
+                "| 7788 | 1100.00 |     1 |         |     0 |\n" +
+                "| 7839 |         |     0 | 2450.00 |     1 |\n" +
+                "| 7902 |  800.00 |     1 |         |     0 |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "(7 rows)\n" +
+                "\n" +
+                "SELECT mgr,\n" +
+                "  SUM(sal) FILTER (WHERE job = 'CLERK' AND deptno = 20) AS c20_ss,\n" +
+                "  COUNT(*) FILTER (WHERE job = 'CLERK' AND deptno = 20) AS c20_c,\n" +
+                "  SUM(sal) FILTER (WHERE job = 'MANAGER' AND deptno = 10) AS m10_ss,\n" +
+                "  COUNT(*) FILTER (WHERE job = 'MANAGER' AND deptno = 10) AS m10_c\n" +
+                "FROM emp\n" +
+                "GROUP BY mgr\n" +
+                "-- ORDER BY 1 NULLS FIRST" +
+                ";\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "| MGR  | C20_SS  | C20_C | M10_SS  | M10_C |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "|      |         |     0 |         |     0 |\n" +
+                "| 7566 |         |     0 |         |     0 |\n" +
+                "| 7698 |         |     0 |         |     0 |\n" +
+                "| 7782 |         |     0 |         |     0 |\n" +
+                "| 7788 | 1100.00 |     1 |         |     0 |\n" +
+                "| 7839 |         |     0 | 2450.00 |     1 |\n" +
+                "| 7902 |  800.00 |     1 |         |     0 |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "(7 rows)\n" +
+                "\n" +
+                "SELECT mgr,\n" +
+                "  SUM(CASE WHEN job = 'CLERK' AND deptno = 20 THEN sal END) c20_ss,\n" +
+                "  COUNT(CASE WHEN job = 'CLERK' AND deptno = 20 THEN 1 END) c20_c,\n" +
+                "  SUM(CASE WHEN job = 'MANAGER' AND deptno = 10 THEN sal END) m10_ss,\n" +
+                "  COUNT(CASE WHEN job = 'MANAGER' AND deptno = 10 THEN 1 END) m10_c\n" +
+                "FROM emp\n" +
+                "GROUP BY mgr\n" +
+                "-- ORDER BY 1 NULLS FIRST" +
+                ";\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "| MGR  | C20_SS  | C20_C | M10_SS  | M10_C |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "|      |         |     0 |         |     0 |\n" +
+                "| 7566 |         |     0 |         |     0 |\n" +
+                "| 7698 |         |     0 |         |     0 |\n" +
+                "| 7782 |         |     0 |         |     0 |\n" +
+                "| 7788 | 1100.00 |     1 |         |     0 |\n" +
+                "| 7839 |         |     0 | 2450.00 |     1 |\n" +
+                "| 7902 |  800.00 |     1 |         |     0 |\n" +
+                "+------+---------+-------+---------+-------+\n" +
+                "(7 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT deptno, mgr FROM   emp)\n" +
+                "PIVOT (COUNT(*) AS cc FOR mgr IN (7839, null, 7698))\n" +
+                "-- ORDER BY deptno" +
+                ";\n" +
+                "+--------+--------+--------+--------+\n" +
+                "| DEPTNO | 7839_C | NULL_C | 7698_C |\n" +
+                "+--------+--------+--------+--------+\n" +
+                "|     10 |      1 |      0 |      0 |\n" +
+                "|     20 |      1 |      0 |      0 |\n" +
+                "|     30 |      1 |      0 |      5 |\n" +
+                "+--------+--------+--------+--------+\n" +
+                "(3 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM   (SELECT job, deptno FROM emp)\n" +
+                "PIVOT  (COUNT(*) AS cc FOR (deptno,deptno) IN ((10,10), (30,20)));\n" +
+                "+-----------+---------+---------+\n" +
+                "| JOB       | 10_10_C | 30_20_C |\n" +
+                "+-----------+---------+---------+\n" +
+                "|ANALYST|       0 |       0 |\n" +
+                "|CLERK|       1 |       0 |\n" +
+                "|MANAGER|       1 |       0 |\n" +
+                "|PRESIDENT|       1 |       0 |\n" +
+                "|SALESMAN|       0 |       0 |\n" +
+                "+-----------+---------+---------+\n" +
+                "(5 rows)\n" +
+                "\n" +
+                "SELECT \"20\"\n" +
+                "FROM (SELECT deptno, sal FROM emp)\n" +
+                "PIVOT (SUM(sal) FOR (deptno) IN (10, 10, 20));\n" +
+                "+----------+\n" +
+                "| 20       |\n" +
+                "+----------+\n" +
+                "| 10875.00 |\n" +
+                "+----------+\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT deptno, sal FROM emp)\n" +
+                "PIVOT (SUM(sal) FOR (deptno) IN (10, 10 as ten, 20));\n" +
+                "+---------+---------+----------+\n" +
+                "| 10      | TEN     | 20       |\n" +
+                "+---------+---------+----------+\n" +
+                "| 8750.00 | 8750.00 | 10875.00 |\n" +
+                "+---------+---------+----------+\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT a_cc, a_b_b_c\n" +
+                "FROM (SELECT sal, deptno FROM emp)\n" +
+                "PIVOT (SUM(sal) AS b_c, COUNT(*) AS cc FOR deptno IN (10 as a, 20 as a_b));\n" +
+                "+-----+----------+\n" +
+                "| A_C | A_B_B_C  |\n" +
+                "+-----+----------+\n" +
+                "|   3 | 10875.00 |\n" +
+                "+-----+----------+\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (SELECT sal, CAST(empno as integer) as empno, deptno FROM emp)\n" +
+                "PIVOT (SUM(sal), SUM(empno) AS sum_empno FOR deptno IN (10, 20));\n" +
+                "+---------+--------------+----------+--------------+\n" +
+                "| 10      | 10_SUM_EMPNO | 20       | 20_SUM_EMPNO |\n" +
+                "+---------+--------------+----------+--------------+\n" +
+                "| 8750.00 |        23555 | 10875.00 |        38501 |\n" +
+                "+---------+--------------+----------+--------------+\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT \"10_SUM_EMPNO\"\n" +
+                "FROM (SELECT sal, empno, deptno FROM emp)\n" +
+                "PIVOT (SUM(sal), COUNT(*), SUM(empno) AS sum_empno FOR deptno IN (10, 20));\n" +
+                "+--------------+\n" +
+                "| 10_SUM_EMPNO |\n" +
+                "+--------------+\n" +
+                "|        23555 |\n" +
+                "+--------------+\n" +
+                "(1 row)\n" +
+                "\n" +
+                "SELECT * FROM (SELECT sal, deptno, job, mgr FROM Emp)\n" +
+                "PIVOT (sum(sal + deptno + 1)\n" +
+                "   FOR job in ('CLERK' AS cc, 'ANALYST' AS a));\n" +
+                "+------+---------+---------+\n" +
+                "| MGR  | C       | A       |\n" +
+                "+------+---------+---------+\n" +
+                "| 7566 |         | 6042.00 |\n" +
+                "| 7698 |  981.00 |         |\n" +
+                "| 7782 | 1311.00 |         |\n" +
+                "| 7788 | 1121.00 |         |\n" +
+                "| 7839 |         |         |\n" +
+                "| 7902 |  821.00 |         |\n" +
+                "|      |         |         |\n" +
+                "+------+---------+---------+\n" +
+                "(7 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                " SELECT deptno, job, sal,\n" +
+                "   CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                " FROM emp)\n" +
+                "PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "     FOR (job, deptno) IN (('CLERK', 10) AS C10,\n" +
+                "                           ('CLERK', 20) AS C20,\n" +
+                "                           ('ANALYST', 20) AS A20));\n" +
+                "+--------+---------+-------+---------+-------+---------+-------+\n" +
+                "| GENDER | C10_SS  | C10_C | C20_SS  | C20_C | A20_SS  | A20_C |\n" +
+                "+--------+---------+-------+---------+-------+---------+-------+\n" +
+                "|F|         |     0 | 1100.00 |     1 |         |     0 |\n" +
+                "|M| 1300.00 |     1 |  800.00 |     1 | 6000.00 |     2 |\n" +
+                "+--------+---------+-------+---------+-------+---------+-------+\n" +
+                "(2 rows)\n" +
+                "\n" +
+                "SELECT CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender,\n" +
+                "    deptno, job, sal\n" +
+                "FROM emp\n" +
+                "WHERE (job, deptno) IN (('CLERK', 10), ('CLERK', 20), ('ANALYST', 20))\n" +
+                "-- ORDER BY gender, deptno, job" +
+                ";\n" +
+                "+--------+--------+---------+---------+\n" +
+                "| GENDER | DEPTNO | JOB     | SAL     |\n" +
+                "+--------+--------+---------+---------+\n" +
+                "|F|     20 |CLERK| 1100.00 |\n" +
+                "|M|     10 |CLERK| 1300.00 |\n" +
+                "|M|     20 |ANALYST| 3000.00 |\n" +
+                "|M|     20 |ANALYST| 3000.00 |\n" +
+                "|M|     20 |CLERK|  800.00 |\n" +
+                "+--------+--------+---------+---------+\n" +
+                "(5 rows)");
+    }
+
+    @Test @Ignore("UNPIVOT not yet implemented")
+    public void unpivotTests() {
+        this.qs("SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (\n" +
+                "     SELECT deptno, job, sal,\n" +
+                "       CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                "     FROM emp)\n" +
+                "  PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "         FOR (job, deptno)\n" +
+                "         IN (('CLERK', 10) AS C10,\n" +
+                "             ('CLERK', 20) AS C20,\n" +
+                "             ('ANALYST', 20) AS A20)))\n" +
+                "UNPIVOT (\n" +
+                "  (sum_sal, count_star)\n" +
+                "  FOR (job, deptno)\n" +
+                "  IN ((c10_ss, c10_cc) AS ('CLERK', 10),\n" +
+                "      (c20_ss, c20_cc) AS ('CLERK', 20),\n" +
+                "      (a20_ss, a20_cc) AS ('ANALYST', 20)));\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| GENDER | JOB     | DEPTNO | SUM_SAL | COUNT_STAR |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| F      | ANALYST |     20 |         |          0 |\n" +
+                "| F      | CLERK   |     10 |         |          0 |\n" +
+                "| F      | CLERK   |     20 | 1100.00 |          1 |\n" +
+                "| M      | ANALYST |     20 | 6000.00 |          2 |\n" +
+                "| M      | CLERK   |     10 | 1300.00 |          1 |\n" +
+                "| M      | CLERK   |     20 |  800.00 |          1 |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "(6 rows)\n" +
+                "\n" +
+                "SELECT e.gender,\n" +
+                "    t.job,\n" +
+                "    t.deptno,\n" +
+                "    CASE\n" +
+                "      WHEN t.job = 'CLERK' AND t.deptno = 10 THEN c10_ss\n" +
+                "      WHEN t.job = 'CLERK' AND t.deptno = 20 THEN c20_ss\n" +
+                "      WHEN t.job = 'ANALYST' AND t.deptno = 20 THEN a20_ss\n" +
+                "    END AS sum_sal,\n" +
+                "    CASE\n" +
+                "      WHEN t.job = 'CLERK' AND t.deptno = 10 THEN c10_cc\n" +
+                "      WHEN t.job = 'CLERK' AND t.deptno = 20 THEN c20_cc\n" +
+                "      WHEN t.job = 'ANALYST' AND t.deptno = 20 THEN a20_cc\n" +
+                "    END AS count_star\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (\n" +
+                "    SELECT deptno, job, sal,\n" +
+                "        CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                "    FROM emp)\n" +
+                "  PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "     FOR (job, deptno) IN (('CLERK', 10) AS C10,\n" +
+                "                           ('CLERK', 20) AS C20,\n" +
+                "                           ('ANALYST', 20) AS A20))) AS e\n" +
+                "CROSS JOIN (VALUES ('CLERK', 10),\n" +
+                "                   ('CLERK', 20),\n" +
+                "                   ('ANALYST', 20)) AS t (job, deptno);\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| GENDER | JOB     | DEPTNO | SUM_SAL | COUNT_STAR |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| F      | ANALYST |     20 |         |          0 |\n" +
+                "| F      | CLERK   |     10 |         |          0 |\n" +
+                "| F      | CLERK   |     20 | 1100.00 |          1 |\n" +
+                "| M      | ANALYST |     20 | 6000.00 |          2 |\n" +
+                "| M      | CLERK   |     10 | 1300.00 |          1 |\n" +
+                "| M      | CLERK   |     20 |  800.00 |          1 |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "(6 rows)\n" +
+                "\n" +
+                "SELECT e.gender, t.*\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (\n" +
+                "    SELECT deptno, job, sal,\n" +
+                "        CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                "    FROM emp)\n" +
+                "  PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "     FOR (job, deptno) IN (('CLERK', 10) AS C10,\n" +
+                "                           ('CLERK', 20) AS C20,\n" +
+                "                           ('ANALYST', 20) AS A20))) AS e\n" +
+                "CROSS JOIN LATERAL (VALUES\n" +
+                "   ('CLERK', 10, e.c10_ss, e.c10_cc),\n" +
+                "   ('CLERK', 20, e.c20_ss, e.c20_cc),\n" +
+                "   ('ANALYST', 20, e.a20_ss, e.a20_cc)) AS t (job, deptno, sum_sal, count_star);\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| GENDER | JOB     | DEPTNO | SUM_SAL | COUNT_STAR |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "| F      | ANALYST |     20 |         |          0 |\n" +
+                "| F      | CLERK   |     10 |         |          0 |\n" +
+                "| F      | CLERK   |     20 | 1100.00 |          1 |\n" +
+                "| M      | ANALYST |     20 | 6000.00 |          2 |\n" +
+                "| M      | CLERK   |     10 | 1300.00 |          1 |\n" +
+                "| M      | CLERK   |     20 |  800.00 |          1 |\n" +
+                "+--------+---------+--------+---------+------------+\n" +
+                "(6 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (\n" +
+                "     SELECT deptno, job, sal,\n" +
+                "       CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                "     FROM emp)\n" +
+                "  PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "         FOR (job, deptno)\n" +
+                "         IN (('CLERK', 10) AS C10,\n" +
+                "             ('CLERK', 20) AS C20,\n" +
+                "             ('ANALYST', 20) AS A20)))\n" +
+                "UNPIVOT INCLUDE NULLS (\n" +
+                "  (sum_sal)\n" +
+                "  FOR (job, deptno)\n" +
+                "  IN ((c10_ss) AS ('CLERK', 10),\n" +
+                "      (c20_ss) AS ('CLERK', 20),\n" +
+                "      (c20_ss) AS ('CLERK', 20),\n" +
+                "      (c10_ss) AS ('ANALYST', 20)));\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "| GENDER | C10_C | C20_C | A20_SS  | A20_C | JOB     | DEPTNO | SUM_SAL |\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "| F      |     0 |     1 |         |     0 | ANALYST |     20 |         |\n" +
+                "| F      |     0 |     1 |         |     0 | CLERK   |     10 |         |\n" +
+                "| F      |     0 |     1 |         |     0 | CLERK   |     20 | 1100.00 |\n" +
+                "| F      |     0 |     1 |         |     0 | CLERK   |     20 | 1100.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | ANALYST |     20 | 1300.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     10 | 1300.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     20 |  800.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     20 |  800.00 |\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "(8 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (\n" +
+                "     SELECT deptno, job, sal,\n" +
+                "       CASE WHEN ename < 'F' THEN 'F' ELSE 'M' END AS gender\n" +
+                "     FROM emp)\n" +
+                "  PIVOT (sum(sal) AS ss, count(*) AS cc\n" +
+                "         FOR (job, deptno)\n" +
+                "         IN (('CLERK', 10) AS C10,\n" +
+                "             ('CLERK', 20) AS C20,\n" +
+                "             ('ANALYST', 20) AS A20)))\n" +
+                "UNPIVOT (\n" +
+                "  (sum_sal)\n" +
+                "  FOR (job, deptno)\n" +
+                "  IN ((c10_ss) AS ('CLERK', 10),\n" +
+                "      (c20_ss) AS ('CLERK', 20),\n" +
+                "      (c20_ss) AS ('CLERK', 20),\n" +
+                "      (c10_ss) AS ('ANALYST', 20)));\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "| GENDER | C10_C | C20_C | A20_SS  | A20_C | JOB     | DEPTNO | SUM_SAL |\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "| F      |     0 |     1 |         |     0 | CLERK   |     20 | 1100.00 |\n" +
+                "| F      |     0 |     1 |         |     0 | CLERK   |     20 | 1100.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | ANALYST |     20 | 1300.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     10 | 1300.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     20 |  800.00 |\n" +
+                "| M      |     1 |     1 | 6000.00 |     2 | CLERK   |     20 |  800.00 |\n" +
+                "+--------+-------+-------+---------+-------+---------+--------+---------+\n" +
+                "(6 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM emp\n" +
+                "UNPIVOT (remuneration\n" +
+                "  FOR remuneration_type IN (comm, sal));\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "| EMPNO | ENAME  | JOB       | MGR  | HIREDATE   | DEPTNO | REMUNERATION_TYPE | REMUNERATION |\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "|  7369 | SMITH  | CLERK     | 7902 | 1980-12-17 |     20 | SAL               |       800.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | COMM              |       300.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | SAL               |      1600.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | COMM              |       500.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | SAL               |      1250.00 |\n" +
+                "|  7566 | JONES  | MANAGER   | 7839 | 1981-02-04 |     20 | SAL               |      2975.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | COMM              |      1400.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | SAL               |      1250.00 |\n" +
+                "|  7698 | BLAKE  | MANAGER   | 7839 | 1981-01-05 |     30 | SAL               |      2850.00 |\n" +
+                "|  7782 | CLARK  | MANAGER   | 7839 | 1981-06-09 |     10 | SAL               |      2450.00 |\n" +
+                "|  7788 | SCOTT  | ANALYST   | 7566 | 1987-04-19 |     20 | SAL               |      3000.00 |\n" +
+                "|  7839 | KING   | PRESIDENT |      | 1981-11-17 |     10 | SAL               |      5000.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | COMM              |         0.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | SAL               |      1500.00 |\n" +
+                "|  7876 | ADAMS  | CLERK     | 7788 | 1987-05-23 |     20 | SAL               |      1100.00 |\n" +
+                "|  7900 | JAMES  | CLERK     | 7698 | 1981-12-03 |     30 | SAL               |       950.00 |\n" +
+                "|  7902 | FORD   | ANALYST   | 7566 | 1981-12-03 |     20 | SAL               |      3000.00 |\n" +
+                "|  7934 | MILLER | CLERK     | 7782 | 1982-01-23 |     10 | SAL               |      1300.00 |\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "(18 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM emp\n" +
+                "UNPIVOT INCLUDE NULLS (remuneration\n" +
+                "  FOR remuneration_type IN (comm, sal));\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "| EMPNO | ENAME  | JOB       | MGR  | HIREDATE   | DEPTNO | REMUNERATION_TYPE | REMUNERATION |\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "|  7369 | SMITH  | CLERK     | 7902 | 1980-12-17 |     20 | COMM              |              |\n" +
+                "|  7369 | SMITH  | CLERK     | 7902 | 1980-12-17 |     20 | SAL               |       800.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | COMM              |       300.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | SAL               |      1600.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | COMM              |       500.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | SAL               |      1250.00 |\n" +
+                "|  7566 | JONES  | MANAGER   | 7839 | 1981-02-04 |     20 | COMM              |              |\n" +
+                "|  7566 | JONES  | MANAGER   | 7839 | 1981-02-04 |     20 | SAL               |      2975.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | COMM              |      1400.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | SAL               |      1250.00 |\n" +
+                "|  7698 | BLAKE  | MANAGER   | 7839 | 1981-01-05 |     30 | COMM              |              |\n" +
+                "|  7698 | BLAKE  | MANAGER   | 7839 | 1981-01-05 |     30 | SAL               |      2850.00 |\n" +
+                "|  7782 | CLARK  | MANAGER   | 7839 | 1981-06-09 |     10 | COMM              |              |\n" +
+                "|  7782 | CLARK  | MANAGER   | 7839 | 1981-06-09 |     10 | SAL               |      2450.00 |\n" +
+                "|  7788 | SCOTT  | ANALYST   | 7566 | 1987-04-19 |     20 | COMM              |              |\n" +
+                "|  7788 | SCOTT  | ANALYST   | 7566 | 1987-04-19 |     20 | SAL               |      3000.00 |\n" +
+                "|  7839 | KING   | PRESIDENT |      | 1981-11-17 |     10 | COMM              |              |\n" +
+                "|  7839 | KING   | PRESIDENT |      | 1981-11-17 |     10 | SAL               |      5000.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | COMM              |         0.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | SAL               |      1500.00 |\n" +
+                "|  7876 | ADAMS  | CLERK     | 7788 | 1987-05-23 |     20 | COMM              |              |\n" +
+                "|  7876 | ADAMS  | CLERK     | 7788 | 1987-05-23 |     20 | SAL               |      1100.00 |\n" +
+                "|  7900 | JAMES  | CLERK     | 7698 | 1981-12-03 |     30 | COMM              |              |\n" +
+                "|  7900 | JAMES  | CLERK     | 7698 | 1981-12-03 |     30 | SAL               |       950.00 |\n" +
+                "|  7902 | FORD   | ANALYST   | 7566 | 1981-12-03 |     20 | COMM              |              |\n" +
+                "|  7902 | FORD   | ANALYST   | 7566 | 1981-12-03 |     20 | SAL               |      3000.00 |\n" +
+                "|  7934 | MILLER | CLERK     | 7782 | 1982-01-23 |     10 | COMM              |              |\n" +
+                "|  7934 | MILLER | CLERK     | 7782 | 1982-01-23 |     10 | SAL               |      1300.00 |\n" +
+                "+-------+--------+-----------+------+------------+--------+-------------------+--------------+\n" +
+                "(28 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM emp\n" +
+                "UNPIVOT INCLUDE NULLS (remuneration\n" +
+                "  FOR remuneration_type IN (comm, sal))\n" +
+                "WHERE deptno = 20 AND remuneration > 500;\n" +
+                "+-------+-------+---------+------+------------+--------+-------------------+--------------+\n" +
+                "| EMPNO | ENAME | JOB     | MGR  | HIREDATE   | DEPTNO | REMUNERATION_TYPE | REMUNERATION |\n" +
+                "+-------+-------+---------+------+------------+--------+-------------------+--------------+\n" +
+                "|  7369 | SMITH | CLERK   | 7902 | 1980-12-17 |     20 | SAL               |       800.00 |\n" +
+                "|  7566 | JONES | MANAGER | 7839 | 1981-02-04 |     20 | SAL               |      2975.00 |\n" +
+                "|  7788 | SCOTT | ANALYST | 7566 | 1987-04-19 |     20 | SAL               |      3000.00 |\n" +
+                "|  7876 | ADAMS | CLERK   | 7788 | 1987-05-23 |     20 | SAL               |      1100.00 |\n" +
+                "|  7902 | FORD  | ANALYST | 7566 | 1981-12-03 |     20 | SAL               |      3000.00 |\n" +
+                "+-------+-------+---------+------+------------+--------+-------------------+--------------+\n" +
+                "(5 rows)\n" +
+                "\n" +
+                "SELECT deptno,\n" +
+                "  SUM(remuneration) AS r,\n" +
+                "  SUM(remuneration) FILTER (WHERE job = 'CLERK') AS cr\n" +
+                "FROM emp\n" +
+                "UNPIVOT INCLUDE NULLS (remuneration\n" +
+                "  FOR remuneration_type IN (comm, sal))\n" +
+                "GROUP BY deptno\n" +
+                "HAVING COUNT(*) > 6\n" +
+                "-- ORDER BY deptno" +
+                ";\n" +
+                "+--------+----------+---------+\n" +
+                "| DEPTNO | R        | CR      |\n" +
+                "+--------+----------+---------+\n" +
+                "|     20 | 10875.00 | 1900.00 |\n" +
+                "|     30 | 11600.00 |  950.00 |\n" +
+                "+--------+----------+---------+\n" +
+                "(2 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM emp\n" +
+                "UNPIVOT (remuneration\n" +
+                "  FOR sal IN (comm AS 'commission',\n" +
+                "                sal as 'salary'));\n" +
+                "+-------+--------+-----------+------+------------+--------+------------+--------------+\n" +
+                "| EMPNO | ENAME  | JOB       | MGR  | HIREDATE   | DEPTNO | SAL        | REMUNERATION |\n" +
+                "+-------+--------+-----------+------+------------+--------+------------+--------------+\n" +
+                "|  7369 | SMITH  | CLERK     | 7902 | 1980-12-17 |     20 | salary     |       800.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | commission |       300.00 |\n" +
+                "|  7499 | ALLEN  | SALESMAN  | 7698 | 1981-02-20 |     30 | salary     |      1600.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | commission |       500.00 |\n" +
+                "|  7521 | WARD   | SALESMAN  | 7698 | 1981-02-22 |     30 | salary     |      1250.00 |\n" +
+                "|  7566 | JONES  | MANAGER   | 7839 | 1981-02-04 |     20 | salary     |      2975.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | commission |      1400.00 |\n" +
+                "|  7654 | MARTIN | SALESMAN  | 7698 | 1981-09-28 |     30 | salary     |      1250.00 |\n" +
+                "|  7698 | BLAKE  | MANAGER   | 7839 | 1981-01-05 |     30 | salary     |      2850.00 |\n" +
+                "|  7782 | CLARK  | MANAGER   | 7839 | 1981-06-09 |     10 | salary     |      2450.00 |\n" +
+                "|  7788 | SCOTT  | ANALYST   | 7566 | 1987-04-19 |     20 | salary     |      3000.00 |\n" +
+                "|  7839 | KING   | PRESIDENT |      | 1981-11-17 |     10 | salary     |      5000.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | commission |         0.00 |\n" +
+                "|  7844 | TURNER | SALESMAN  | 7698 | 1981-09-08 |     30 | salary     |      1500.00 |\n" +
+                "|  7876 | ADAMS  | CLERK     | 7788 | 1987-05-23 |     20 | salary     |      1100.00 |\n" +
+                "|  7900 | JAMES  | CLERK     | 7698 | 1981-12-03 |     30 | salary     |       950.00 |\n" +
+                "|  7902 | FORD   | ANALYST   | 7566 | 1981-12-03 |     20 | salary     |      3000.00 |\n" +
+                "|  7934 | MILLER | CLERK     | 7782 | 1982-01-23 |     10 | salary     |      1300.00 |\n" +
+                "+-------+--------+-----------+------+------------+--------+------------+--------------+\n" +
+                "(18 rows)\n" +
+                "\n" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM (VALUES (0, 1, 2, 3, 4),\n" +
+                "               (10, 11, 12, 13, 14))\n" +
+                "          AS t (c0, c1, c2, c3, c4))\n" +
+                "UNPIVOT ((m0, m1, m2)\n" +
+                "    FOR (a0, a1)\n" +
+                "     IN ((c1, c2, c3) as ('col1','col2'),\n" +
+                "         (c2, c3, c4)));\n" +
+                "+----+----------+----------+----+----+----+\n" +
+                "| C0 | A0       | A1       | M0 | M1 | M2 |\n" +
+                "+----+----------+----------+----+----+----+\n" +
+                "|  0 | col1     | col2     |  1 |  2 |  3 |\n" +
+                "|  0 | C2_C3_C4 | C2_C3_C4 |  2 |  3 |  4 |\n" +
+                "| 10 | col1     | col2     | 11 | 12 | 13 |\n" +
+                "| 10 | C2_C3_C4 | C2_C3_C4 | 12 | 13 | 14 |\n" +
+                "+----+----------+----------+----+----+----+\n" +
+                "(4 rows)");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/package-info.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/foodmart/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Package that doesn't allow null values as method parameters.
+ */
+
+/**
+ * Examples using the 'foodmart' database from Calcite.
+ */
+@ParametersAreNonnullByDefault
+@FieldsAreNonnullByDefault
+@MethodsAreNonnullByDefault
+package org.dbsp.sqlCompiler.compiler.foodmart;
+
+import org.dbsp.util.FieldsAreNonnullByDefault;
+import org.dbsp.util.MethodsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/jit/JitTests.java
@@ -6,18 +6,14 @@ import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
 import org.dbsp.sqlCompiler.compiler.frontend.CalciteObject;
 import org.dbsp.sqlCompiler.ir.expression.DBSPExpression;
 import org.dbsp.sqlCompiler.ir.expression.DBSPTupleExpression;
-import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDecimalLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPDoubleLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPGeoPointLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI32Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPI64Literal;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPVecLiteral;
 import org.dbsp.sqlCompiler.ir.expression.literal.DBSPZSetLiteral;
-import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeDecimal;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.math.BigDecimal;
 
 /**
  * Runs tests using the JIT compiler backend and runtime.

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PivotTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PivotTests.java
@@ -1,0 +1,90 @@
+package org.dbsp.sqlCompiler.compiler.postgres;
+
+import org.dbsp.sqlCompiler.compiler.backend.DBSPCompiler;
+import org.junit.Test;
+
+/**
+ * From <a href="https://www.geeksforgeeks.org/pivot-and-unpivot-in-sql/">
+ * Geeks for Geeks</a> and <a href="https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-pivot.html">
+ * The SPARK documentation</a>
+ */
+public class PivotTests extends PostgresBaseTest {
+    @Override
+    public void prepareData(DBSPCompiler compiler) {
+        compiler.compileStatements("Create Table GG (\n" +
+                "CourseName varchar,\n" +
+                "CourseCategory varchar,\n" +
+                "Price int\n" +
+                "); \n" +
+                "\n" +
+                "Insert into GG  values('C', 'PROGRAMMING', 5000);\n" +
+                "Insert into GG  values('JAVA', 'PROGRAMMING', 6000);\n" +
+                "Insert into GG  values('PYTHON', 'PROGRAMMING', 8000);\n" +
+                "Insert into GG  values('PLACEMENT 100', 'INTERVIEWPREPARATION', 5000);\n" +
+
+                "CREATE TABLE person (id INT, name STRING, age INT, class INT, address STRING);\n" +
+                "INSERT INTO person VALUES\n" +
+                "    (100, 'John', 30, 1, 'Street 1'),\n" +
+                "    (200, 'Mary', NULL, 1, 'Street 2'),\n" +
+                "    (300, 'Mike', 80, 3, 'Street 3'),\n" +
+                "    (400, 'Dan', 50, 4, 'Street 4');");
+    }
+
+    @Test
+    public void testGroupby() {
+        this.q("SELECT CourseName, Sum(Price)\n" +
+                "FROM GG \n" +
+                "GROUP BY CourseName;\n" +
+                "CourseName | Price\n" +
+                "-----------------\n" +
+                "C| 5000\n" +
+                "JAVA| 6000\n" +
+                "PLACEMENT 100| 5000\n" +
+                "PYTHON| 8000");
+    }
+
+    @Test
+    public void testGGPivot() {
+        this.q("SELECT CourseName, \"PG\", \"IV\"\n" +
+                "FROM GG \n" +
+                "PIVOT (\n" +
+                "  SUM(Price) FOR CourseCategory IN (" +
+                "         'PROGRAMMING' AS PG, " +
+                "         'INTERVIEWPREPARATION' AS IV) \n" +
+                ") AS PivotTable;\n" +
+                "CourseName | PG | IV\n" +
+                "-----------------\n" +
+                "C| 5000 | NULL\n" +
+                "JAVA| 6000 | NULL\n" +
+                "PLACEMENT 100| NULL | 5000\n" +
+                "PYTHON| 8000 | NULL");
+    }
+
+    @Test
+    public void testSparkPivot() {
+        this.q("SELECT * FROM person\n" +
+                "    PIVOT (\n" +
+                "        SUM(age) AS a, AVG(class) AS cc\n" +
+                "        FOR name IN ('John' AS john, 'Mike' AS mike)\n" +
+                "    );\n" +
+                "+------+-----------+---------+---------+---------+---------+\n" +
+                "|  id  |  address  | john_a  | john_cc | mike_a  | mike_cc |\n" +
+                "+------+-----------+---------+---------+---------+---------+\n" +
+                "| 200  |Street 2| NULL    | NULL    | NULL    | NULL    |\n" +
+                "| 100  |Street 1| 30      | 1       | NULL    | NULL    |\n" +
+                "| 300  |Street 3| NULL    | NULL    | 80      | 3       |\n" +
+                "| 400  |Street 4| NULL    | NULL    | NULL    | NULL    |");
+        this.q("SELECT * FROM person\n" +
+                "    PIVOT (\n" +
+                "        SUM(age) AS a, AVG(class) AS cc\n" +
+                "        FOR (name, age) IN (('John', 30) AS c1, ('Mike', 40) AS c2)\n" +
+                "    );\n" +
+                "+------+-----------+-------+-------+-------+-------+\n" +
+                "|  id  |  address  | c1_a  | c1_cc | c2_a  | c2_cc |\n" +
+                "+------+-----------+-------+-------+-------+-------+\n" +
+                "| 200  |Street 2| NULL  | NULL  | NULL  | NULL  |\n" +
+                "| 100  |Street 1| 30    | 1     | NULL  | NULL  |\n" +
+                "| 300  |Street 3| NULL  | NULL  | NULL  | NULL  |\n" +
+                "| 400  |Street 4| NULL  | NULL  | NULL  | NULL  |");
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PivotTests.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/test/java/org/dbsp/sqlCompiler/compiler/postgres/PivotTests.java
@@ -27,7 +27,19 @@ public class PivotTests extends PostgresBaseTest {
                 "    (100, 'John', 30, 1, 'Street 1'),\n" +
                 "    (200, 'Mary', NULL, 1, 'Street 2'),\n" +
                 "    (300, 'Mike', 80, 3, 'Street 3'),\n" +
-                "    (400, 'Dan', 50, 4, 'Street 4');");
+                "    (400, 'Dan', 50, 4, 'Street 4');\n" +
+                "" +
+                "CREATE TABLE FURNITURE(" +
+                "   type VARCHAR," +
+                "   year INTEGER," +
+                "   count INTEGER);\n" +
+                "INSERT INTO FURNITURE VALUES\n" +
+                "('chair', 2020, 4)," +
+                "('table', 2021, 3)," +
+                "('chair', 2021, 4)," +
+                "('desk', 2023, 1)," +
+                "('table', 2023, 2)");
+                // "('bed', 2020, 5);");
     }
 
     @Test
@@ -73,7 +85,8 @@ public class PivotTests extends PostgresBaseTest {
                 "| 200  |Street 2| NULL    | NULL    | NULL    | NULL    |\n" +
                 "| 100  |Street 1| 30      | 1       | NULL    | NULL    |\n" +
                 "| 300  |Street 3| NULL    | NULL    | 80      | 3       |\n" +
-                "| 400  |Street 4| NULL    | NULL    | NULL    | NULL    |");
+                "| 400  |Street 4| NULL    | NULL    | NULL    | NULL    |\n" +
+                "+------+-----------+---------+---------+---------+---------+\n");
         this.q("SELECT * FROM person\n" +
                 "    PIVOT (\n" +
                 "        SUM(age) AS a, AVG(class) AS cc\n" +
@@ -85,6 +98,29 @@ public class PivotTests extends PostgresBaseTest {
                 "| 200  |Street 2| NULL  | NULL  | NULL  | NULL  |\n" +
                 "| 100  |Street 1| 30    | 1     | NULL  | NULL  |\n" +
                 "| 300  |Street 3| NULL  | NULL  | NULL  | NULL  |\n" +
-                "| 400  |Street 4| NULL  | NULL  | NULL  | NULL  |");
+                "| 400  |Street 4| NULL  | NULL  | NULL  | NULL  |\n" +
+                "+------+-----------+-------+-------+-------+-------+");
+    }
+
+    @Test
+    public void testPivotDoc() {
+        this.q("SELECT year, type, SUM(count) FROM FURNITURE GROUP BY year, type;\n" +
+                "year | type  | sum\n" +
+                "-----------------\n" +
+                "2020 |chair| 4 \n" +
+                "2021 |table| 3 \n" +
+                "2021 |chair| 4 \n" +
+                "2023 |desk| 1 \n" +
+                "2023 |table| 2 ");
+        this.q("SELECT * FROM FURNITURE\n" +
+                "PIVOT (\n" +
+                "    SUM(count) AS ct\n" +
+                "    FOR type IN ('desk' AS desks, 'table' AS tables, 'chair' as chairs)\n" +
+                ");\n" +
+                "year | desks | tables | chairs\n" +
+                "------------------------------\n" +
+                "2020 |       |        |    4  \n" +
+                "2021 |       |     3  |    4  \n" +
+                "2023 |     1 |     2  |       ");
     }
 }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -8,7 +8,7 @@ pub mod string;
 pub mod timestamp;
 
 use crate::interval::ShortInterval;
-use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64, HasZero};
+use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64};
 use geopoint::GeoPoint;
 use num::{Signed, ToPrimitive};
 use rust_decimal::{Decimal, MathematicalOps};
@@ -496,24 +496,6 @@ pub fn indicator<T>(value: Option<T>) -> i64 {
     }
 }
 
-#[inline(always)]
-pub fn if_selected<T>(value: T, predicate: bool) -> T
-where
-    T: HasZero
-{
-    if predicate { value } else { T::zero() }
-}
-
-#[inline(always)]
-pub fn if_selectedN<T>(value: T, predicate: bool) -> Option<T> {
-    if predicate { Some(value) } else { None }
-}
-
-#[inline(always)]
-pub fn if_selectedNN<T>(value: Option<T>, predicate: bool) -> Option<T> {
-    if predicate { value } else { None }
-}
-
 pub fn agg_max_N_N<T>(left: Option<T>, right: Option<T>) -> Option<T>
 where
     T: Ord + Copy,
@@ -606,6 +588,107 @@ where
     T: Add<T, Output = T> + Copy,
 {
     left + right
+}
+
+pub fn agg_max_conditional_N_N<T>(left: Option<T>, right: Option<T>, predicate: bool) -> Option<T>
+where
+    T: Ord + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => right,
+        (_, None, _) => left,
+        (Some(x), Some(y), _) => Some(x.max(y)),
+    }
+}
+
+pub fn agg_min_conditional_N_N<T>(left: Option<T>, right: Option<T>, predicate: bool) -> Option<T>
+where
+    T: Ord + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => right,
+        (_, None, _) => left,
+        (Some(x), Some(y), _) => Some(x.min(y)),
+    }
+}
+
+pub fn agg_max_conditional_N_<T>(left: Option<T>, right: T, predicate: bool) -> Option<T>
+where
+    T: Ord + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => Some(right),
+        (Some(x), y, _) => Some(x.max(y)),
+    }
+}
+
+pub fn agg_min_conditional_N_<T>(left: Option<T>, right: T, predicate: bool) -> Option<T>
+where
+    T: Ord + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => Some(right),
+        (Some(x), y, _) => Some(x.min(y)),
+    }
+}
+
+pub fn agg_max_conditional__<T>(left: T, right: T, predicate: bool) -> T
+where
+    T: Ord + Copy,
+{
+    if predicate { left.max(right) } else { left }
+}
+
+pub fn agg_min_conditional__<T>(left: T, right: T, predicate: bool) -> T
+where
+    T: Ord + Copy,
+{
+    if predicate { left.min(right) } else { left }
+}
+
+pub fn agg_plus_conditional_N_N<T>(left: Option<T>, right: Option<T>, predicate: bool) -> Option<T>
+where
+    T: Add<T, Output = T> + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => right,
+        (_, None, _) => left,
+        (Some(x), Some(y), _) => Some(x + y),
+    }
+}
+
+pub fn agg_plus_conditional_N_<T>(left: Option<T>, right: T, predicate: bool) -> Option<T>
+where
+    T: Add<T, Output = T> + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => left,
+        (None, _, _) => Some(right),
+        (Some(x), y, _) => Some(x + y),
+    }
+}
+
+pub fn agg_plus_conditional__N<T>(left: T, right: Option<T>, predicate: bool) -> Option<T>
+where
+    T: Add<T, Output = T> + Copy,
+{
+    match (left, right, predicate) {
+        (_, _, false) => Some(left),
+        (_, None, _) => Some(left),
+        (x, Some(y), _) => Some(x + y),
+    }
+}
+
+pub fn agg_plus_conditional__<T>(left: T, right: T, predicate: bool) -> T
+where
+    T: Add<T, Output = T> + Copy,
+{
+    if predicate { left + right } else { left }
 }
 
 #[inline(always)]

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -8,7 +8,7 @@ pub mod string;
 pub mod timestamp;
 
 use crate::interval::ShortInterval;
-use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64};
+use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64, HasZero};
 use geopoint::GeoPoint;
 use num::{Signed, ToPrimitive};
 use rust_decimal::{Decimal, MathematicalOps};
@@ -332,6 +332,7 @@ macro_rules! some_operator {
 #[macro_export]
 macro_rules! for_all_int_compare {
     ($func_name: ident, $ret_type: ty) => {
+        some_operator!($func_name, i8, i8, bool);
         some_operator!($func_name, i16, i16, bool);
         some_operator!($func_name, i32, i32, bool);
         some_operator!($func_name, i64, i64, bool);
@@ -360,6 +361,7 @@ macro_rules! for_all_compare {
 #[macro_export]
 macro_rules! for_all_int_operator {
     ($func_name: ident) => {
+        some_operator!($func_name, i8, i8, i8);
         some_operator!($func_name, i16, i16, i16);
         some_operator!($func_name, i32, i32, i32);
         some_operator!($func_name, i64, i64, i64);
@@ -494,6 +496,24 @@ pub fn indicator<T>(value: Option<T>) -> i64 {
     }
 }
 
+#[inline(always)]
+pub fn if_selected<T>(value: T, predicate: bool) -> T
+where
+    T: HasZero
+{
+    if predicate { value } else { T::zero() }
+}
+
+#[inline(always)]
+pub fn if_selectedN<T>(value: T, predicate: bool) -> Option<T> {
+    if predicate { Some(value) } else { None }
+}
+
+#[inline(always)]
+pub fn if_selectedNN<T>(value: Option<T>, predicate: bool) -> Option<T> {
+    if predicate { value } else { None }
+}
+
 pub fn agg_max_N_N<T>(left: Option<T>, right: Option<T>) -> Option<T>
 where
     T: Ord + Copy,
@@ -589,6 +609,11 @@ where
 }
 
 #[inline(always)]
+pub fn abs_i8(left: i8) -> i8 {
+    left.abs()
+}
+
+#[inline(always)]
 pub fn abs_i16(left: i16) -> i16 {
     left.abs()
 }
@@ -618,6 +643,7 @@ pub fn abs_decimal(left: Decimal) -> Decimal {
     left.abs()
 }
 
+some_polymorphic_function1!(abs, i8, i8, i8);
 some_polymorphic_function1!(abs, i16, i16, i16);
 some_polymorphic_function1!(abs, i32, i32, i32);
 some_polymorphic_function1!(abs, i64, i64, i64);

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -33,28 +33,28 @@ pub(crate) fn lt<T>(left: T, right: T) -> bool
 where T: Ord
 { left < right }
 
-for_all_numeric_compare!(lt, bool);
+for_all_compare!(lt, bool);
 
 #[inline(always)]
 pub(crate) fn gt<T>(left: T, right: T) -> bool
 where T: Ord
 { left > right }
 
-for_all_numeric_compare!(gt, bool);
+for_all_compare!(gt, bool);
 
 #[inline(always)]
 pub(crate) fn lte<T>(left: T, right: T) -> bool
 where T: Ord
 { left <= right }
 
-for_all_numeric_compare!(lte, bool);
+for_all_compare!(lte, bool);
 
 #[inline(always)]
 pub(crate) fn gte<T>(left: T, right: T) -> bool
 where T: Ord
 { left >= right }
 
-for_all_numeric_compare!(gte, bool);
+for_all_compare!(gte, bool);
 
 #[inline(always)]
 fn plus<T>(left: T, right: T) -> T


### PR DESCRIPTION
This started as a simple effort to document the PIVOT operation, but snowballed.
The example tests I found required support for Time and I8 (TINYINT). 
So I added these too.
In the process I realized that the work done to add new types grows quadratically, since casts need to go from any type to any type, so I used more Rust macros to simplify the process.
We don't yet have time functions, but I didn't claim that we are done with Time yet.