### PR TITLE
Eliminate dependency on arcstr patch that isn't upstream yet.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,10 +534,11 @@ dependencies = [
 
 [[package]]
 name = "arcstr"
-version = "1.1.4"
-source = "git+https://github.com/gz/arcstr.git?rev=b43120c#b43120cd13db16a1c1f61a12d1637b047b9bcd89"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
 dependencies = [
- "bincode",
+ "serde",
 ]
 
 [[package]]
@@ -2323,6 +2324,7 @@ dependencies = [
  "rand_xoshiro",
  "reqwest",
  "rocksdb",
+ "rust_decimal",
  "serde",
  "serde_json",
  "size-of",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,3 @@ exclude = ["sql-to-dbsp-compiler/temp"]
 
 [profile.bench]
 debug = true
-
-# Waiting for bincode 2.0.0 to be released (https://github.com/thomcc/arcstr/pull/45)
-[patch.crates-io.arcstr]
-git = "https://github.com/gz/arcstr.git"
-rev = "b43120c"
-optional = true

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -63,7 +63,7 @@ indicatif = "0.17.0-rc.11"
 clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 serde_json = "1.0.87"
-arcstr = { version = "1.1.4", features = ["bincode"] }
+arcstr = { version = "1.1.4" }
 
 [dependencies.time]
 version = "0.3.20"

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 dbsp = { path = "../dbsp" }
 anyhow = "1.0.57"
 csv = { git = "https://github.com/ryzhyk/rust-csv.git" }
-arcstr = { version = "1.1.4", features = ["bincode"] }
+arcstr = { version = "1.1.4", features = ["serde"] }
 rust_decimal = { version = "1.26.1" }
 regex = { version = "1.6.0" }
 time = { version = "0.3.14", features = ["formatting"] }

--- a/crates/nexmark/src/model.rs
+++ b/crates/nexmark/src/model.rs
@@ -13,12 +13,18 @@ use size_of::SizeOf;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf, Encode, Decode)]
 pub struct Person {
     pub id: u64,
+    #[bincode(with_serde)]
     pub name: ArcStr,
+    #[bincode(with_serde)]
     pub email_address: ArcStr,
+    #[bincode(with_serde)]
     pub credit_card: ArcStr,
+    #[bincode(with_serde)]
     pub city: ArcStr,
+    #[bincode(with_serde)]
     pub state: ArcStr,
     pub date_time: u64,
+    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 
@@ -29,7 +35,9 @@ pub struct Person {
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf, Encode, Decode)]
 pub struct Auction {
     pub id: u64,
+    #[bincode(with_serde)]
     pub item_name: ArcStr,
+    #[bincode(with_serde)]
     pub description: ArcStr,
     pub initial_bid: usize,
     pub reserve: usize,
@@ -37,6 +45,7 @@ pub struct Auction {
     pub expires: u64,
     pub seller: u64,
     pub category: usize,
+    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 
@@ -53,13 +62,16 @@ pub struct Bid {
     /// Price of bid, in cents.
     pub price: usize,
     /// The channel that introduced this bidding.
+    #[bincode(with_serde)]
     pub channel: ArcStr,
     /// The url of this channel.
+    #[bincode(with_serde)]
     pub url: ArcStr,
     /// Instant at which this bid was made. NOTE: This may be earlier than teh
     /// system's event time.
     pub date_time: u64,
     /// Additional arbitrary payload for performance testing.
+    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -44,18 +44,28 @@ use std::ops::Deref;
 /// WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;
 /// ```
 
-#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode)]
-pub struct Q14Output(u64, u64, BincodeDecimal, BidTimeType, u64, ArcStr, usize);
+#[derive(
+    Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode,
+)]
+pub struct Q14Output(
+    u64,
+    u64,
+    BincodeDecimal,
+    BidTimeType,
+    u64,
+    #[bincode(with_serde)] ArcStr,
+    usize,
+);
 
 type Q14Stream = Stream<RootCircuit, OrdZSet<Q14Output, isize>>;
 
 /// Wrapper type for `Decimal` that implements Decode and Encode.
-/// 
+///
 /// # Note
 /// Since the query doesn't use spine we don't actually end up
 /// serializing/deserializing Decimals but we still need to implement it to
 /// satisfy trait constraints.
-/// 
+///
 /// For the future we can submit a PR to `rust_decimal` to implement `Decode`
 /// and `Encode` for `Decimal` directly or if we end up using rykv anyways
 /// `rust_decimal` has support for it already.

--- a/crates/nexmark/src/queries/q16.rs
+++ b/crates/nexmark/src/queries/q16.rs
@@ -82,8 +82,11 @@ use time::{
     bincode::Decode,
 )]
 pub struct Q16Output {
+    #[bincode(with_serde)]
     channel: ArcStr,
+    #[bincode(with_serde)]
     day: ArcStr,
+    #[bincode(with_serde)]
     minute: ArcStr,
     total_bids: usize,
     rank1_bids: usize,

--- a/crates/nexmark/src/queries/q9.rs
+++ b/crates/nexmark/src/queries/q9.rs
@@ -59,7 +59,9 @@ use size_of::SizeOf;
 #[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode)]
 pub struct Q9Output(
     u64,
+    #[bincode(with_serde)]
     ArcStr,
+    #[bincode(with_serde)]
     ArcStr,
     usize,
     usize,
@@ -67,11 +69,13 @@ pub struct Q9Output(
     u64,
     u64,
     usize,
+    #[bincode(with_serde)]
     ArcStr,
     u64,
     u64,
     usize,
     u64,
+    #[bincode(with_serde)]
     ArcStr,
 );
 


### PR DESCRIPTION
DBSP relies on bincode version 2.0.0-rc3, which was released at the end of March 2023.  DBSP also uses arcstr and we want to serialize and deserialize `ArcStr`s with bincode.  Unfortunately, arcstr doesn't support bincode 2.0 yet and won't until bincode 2.0 finally gets released[1], which could be a long time, so we have a patch in Cargo.toml to support that.

We'd like to publish DBSP to crates.io[2], but we can't if it depends on patches, so it seems best to avoid them.  This commit drops the patch and switches to using #[bincode(with_serde)] to serialize ArcStr fields.

[1]: https://github.com/thomcc/arcstr/pull/45
[2]: https://github.com/feldera/dbsp/issues/14


Fixes: https://github.com/feldera/dbsp/issues/395