### PR TITLE
Fix regression in `adapterss::test_server`.

### DIFF
--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -868,7 +868,6 @@ mod test_with_kafka {
     use tempfile::NamedTempFile;
 
     #[actix_web::test]
-    #[ignore = "flaky test"]
     async fn test_server() {
         // We cannot use proptest macros in `async` context, so generate
         // some random data manually.

--- a/crates/adapters/src/test/http.rs
+++ b/crates/adapters/src/test/http.rs
@@ -70,7 +70,7 @@ impl TestHttpReceiver {
                 let mut reader = builder.from_reader(if let Some(csv) = &chunk.text_data {
                     csv.as_bytes()
                 } else {
-                    panic!("not a text chunk");
+                    continue;
                 });
                 // let mut num_received = 0;
                 for (record, w) in reader


### PR DESCRIPTION
The HTTP connector can now send chunks without data.  Adjust the test to account for this.