### PR TITLE
Handle compiler restarts with potential volume refreshes

### DIFF
--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -832,18 +832,6 @@ fn convert_bigint_to_time(created_secs: i64) -> Result<DateTime<Utc>, DBError> {
 // possible and if not, use transactions
 #[async_trait]
 impl Storage for ProjectDB {
-    async fn reset_program_status(&self) -> Result<(), DBError> {
-        self.pool
-            .get()
-            .await?
-            .execute(
-                "UPDATE program SET status = NULL, error = NULL, schema = NULL",
-                &[],
-            )
-            .await?;
-        Ok(())
-    }
-
     async fn list_programs(
         &self,
         tenant_id: TenantId,

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -1048,7 +1048,7 @@ impl Storage for ProjectDB {
         }
     }
 
-    async fn set_program_status(
+    async fn set_program_for_compilation(
         &self,
         tenant_id: TenantId,
         program_id: ProgramId,

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -91,8 +91,13 @@ pub(crate) trait Storage {
             return Ok(());
         }
 
-        self.set_program_for_compilation(tenant_id, program_id, ProgramStatus::Pending)
-            .await?;
+        self.set_program_for_compilation(
+            tenant_id,
+            program_id,
+            expected_version,
+            ProgramStatus::Pending,
+        )
+        .await?;
 
         Ok(())
     }
@@ -145,6 +150,7 @@ pub(crate) trait Storage {
         &self,
         tenant_id: TenantId,
         program_id: ProgramId,
+        version: Version,
         status: ProgramStatus,
     ) -> Result<(), DBError>;
 
@@ -186,6 +192,10 @@ pub(crate) trait Storage {
         tenant_id: TenantId,
         program_id: ProgramId,
     ) -> Result<(), DBError>;
+
+    /// Retrieves all programs in the DB. Intended to be used by
+    /// reconciliation loops.
+    async fn all_programs(&self) -> Result<Vec<(TenantId, ProgramDescr)>, DBError>;
 
     /// Retrieves the first pending program from the queue.
     ///

--- a/crates/pipeline_manager/src/db/storage.rs
+++ b/crates/pipeline_manager/src/db/storage.rs
@@ -15,8 +15,6 @@ use uuid::Uuid;
 /// We use a trait so we can mock the storage layer in tests.
 #[async_trait]
 pub(crate) trait Storage {
-    async fn reset_program_status(&self) -> Result<(), DBError>;
-
     async fn list_programs(
         &self,
         tenant_id: TenantId,

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -435,12 +435,12 @@ async fn project_pending() {
 
     handle
         .db
-        .set_program_status(tenant_id, uid2, ProgramStatus::Pending)
+        .set_program_for_compilation(tenant_id, uid2, ProgramStatus::Pending)
         .await
         .unwrap();
     handle
         .db
-        .set_program_status(tenant_id, uid1, ProgramStatus::Pending)
+        .set_program_for_compilation(tenant_id, uid1, ProgramStatus::Pending)
         .await
         .unwrap();
     let (_, id, _version) = handle.db.next_job().await.unwrap().unwrap();
@@ -475,7 +475,7 @@ async fn update_status() {
     assert_eq!(ProgramStatus::None, desc.status);
     handle
         .db
-        .set_program_status(tenant_id, program_id, ProgramStatus::CompilingRust)
+        .set_program_for_compilation(tenant_id, program_id, ProgramStatus::CompilingRust)
         .await
         .unwrap();
     let desc = handle
@@ -1248,9 +1248,9 @@ fn db_impl_behaves_like_model() {
                             StorageAction::SetProgramStatus(tenant_id, program_id, status) => {
                                 create_tenants_if_not_exists(&model, &handle, tenant_id).await.unwrap();
                                 let model_response =
-                                    model.set_program_status(tenant_id, program_id, status.clone()).await;
+                                    model.set_program_for_compilation(tenant_id, program_id, status.clone()).await;
                                 let impl_response =
-                                    handle.db.set_program_status(tenant_id, program_id, status.clone()).await;
+                                    handle.db.set_program_for_compilation(tenant_id, program_id, status.clone()).await;
                                 check_responses(i, model_response, impl_response);
                             }
                             StorageAction::SetProgramStatusGuarded(tenant_id, program_id, version, status) => {
@@ -1600,7 +1600,7 @@ impl Storage for Mutex<DbModel> {
             }))
     }
 
-    async fn set_program_status(
+    async fn set_program_for_compilation(
         &self,
         tenant_id: TenantId,
         program_id: super::ProgramId,

--- a/crates/pipeline_manager/src/pipeline_manager.rs
+++ b/crates/pipeline_manager/src/pipeline_manager.rs
@@ -297,12 +297,6 @@ pub fn run(
         )
         .await?;
         let db = Arc::new(Mutex::new(db));
-
-        // Since we don't trust any file system state after restart,
-        // reset all programs to `ProgramStatus::None`, which will force
-        // us to recompile programs before running them.
-        db.lock().await.reset_program_status().await?;
-
         let state = WebData::new(ServerState::new(manager_config, compiler_config, db).await?);
 
         if use_auth {

--- a/crates/pipeline_manager/src/pipeline_manager.rs
+++ b/crates/pipeline_manager/src/pipeline_manager.rs
@@ -889,7 +889,7 @@ async fn compile_program(
         .db
         .lock()
         .await
-        .set_program_pending(*tenant_id, program_id, body.version)
+        .prepare_program_for_compilation(*tenant_id, program_id, body.version)
         .await?;
 
     Ok(HttpResponse::Accepted().finish())


### PR DESCRIPTION
The compiler service now attempts to reconcile its local state with the program objects available in the DB. If it sees any evidence of programs without local versioned binaries, but have started or completed compilation, the service re-queues the program for compilation.

The PR also adds some tests for the compiler service to check this behavior.

Addresses the compiler issue in https://github.com/feldera/dbsp/issues/235