### PR TITLE
SLT JIT support

### DIFF
--- a/crates/dataflow-jit/src/dataflow/nodes.rs
+++ b/crates/dataflow-jit/src/dataflow/nodes.rs
@@ -27,6 +27,7 @@ pub enum DataflowNode {
     Source(Source),
     SourceMap(SourceMap),
     IndexWith(IndexWith),
+    StreamDistinct(StreamDistinct),
     Delta0(Delta0),
     DelayedFeedback(DelayedFeedback),
     Min(Min),
@@ -223,6 +224,11 @@ pub struct Max {
 
 #[derive(Debug, Clone)]
 pub struct Distinct {
+    pub input: NodeId,
+}
+
+#[derive(Debug, Clone)]
+pub struct StreamDistinct {
     pub input: NodeId,
 }
 

--- a/crates/dataflow-jit/src/ir/graph.rs
+++ b/crates/dataflow-jit/src/ir/graph.rs
@@ -9,7 +9,7 @@ use crate::ir::{
     nodes::{
         ConstantStream, DataflowNode, Differentiate, Distinct, ExportedNode, Filter, IndexWith,
         Integrate, JoinCore, Map, Node, Sink, Source, SourceMap, StreamKind, StreamLayout,
-        Subgraph as SubgraphNode,
+        StreamDistinct, Subgraph as SubgraphNode,
     },
     optimize,
     pretty::{DocAllocator, DocBuilder, Pretty},
@@ -150,6 +150,10 @@ pub trait GraphExt {
 
     fn distinct(&mut self, input: NodeId, layout: StreamLayout) -> NodeId {
         self.add_node(Distinct::new(input, layout))
+    }
+
+    fn stream_distinct(&mut self, input: NodeId, layout: StreamLayout) -> NodeId {
+        self.add_node(StreamDistinct::new(input, layout))
     }
 
     fn index_with(

--- a/crates/dataflow-jit/src/ir/validate.rs
+++ b/crates/dataflow-jit/src/ir/validate.rs
@@ -12,8 +12,8 @@ use crate::{
             Antijoin, ConstantStream, DataflowNode, DelayedFeedback, Delta0, Differentiate,
             Distinct, Export, ExportedNode, Filter, FilterMap, FlatMap, Fold, IndexByColumn,
             IndexWith, Integrate, Map, Max, Min, Minus, MonotonicJoin, Neg, Node, NodeId,
-            PartitionedRollingFold, Sink, Source, SourceMap, StreamKind, StreamLayout, Subgraph,
-            Sum, UnitMapToSet,
+            PartitionedRollingFold, Sink, Source, SourceMap, StreamKind, StreamLayout,
+            StreamDistinct, Subgraph, Sum, UnitMapToSet,
         },
         visit::NodeVisitor,
         BlockId, ColumnType, Function, Graph, InputFlags, LayoutId, RowLayoutBuilder,
@@ -382,6 +382,10 @@ impl NodeVisitor for MetaCollector<'_> {
     }
 
     fn visit_distinct(&mut self, node_id: NodeId, distinct: &Distinct) {
+        self.add_unary(node_id, distinct.input(), distinct.layout());
+    }
+
+    fn visit_stream_distinct(&mut self, node_id: NodeId, distinct: &StreamDistinct) {
         self.add_unary(node_id, distinct.input(), distinct.layout());
     }
 

--- a/crates/dataflow-jit/src/ir/visit.rs
+++ b/crates/dataflow-jit/src/ir/visit.rs
@@ -3,7 +3,7 @@ use crate::ir::{
         Antijoin, ConstantStream, DelayedFeedback, Delta0, Differentiate, Distinct, Export,
         ExportedNode, Filter, FilterMap, FlatMap, Fold, IndexByColumn, IndexWith, Integrate,
         JoinCore, Map, Max, Min, Minus, MonotonicJoin, Neg, Node, PartitionedRollingFold, Sink,
-        Source, SourceMap, Subgraph, Sum, TopK, UnitMapToSet,
+        Source, SourceMap, StreamDistinct, Subgraph, Sum, TopK, UnitMapToSet,
     },
     GraphExt, NodeId,
 };
@@ -29,6 +29,7 @@ pub trait NodeVisitor {
     fn visit_delta0(&mut self, _node_id: NodeId, _delta0: &Delta0) {}
     fn visit_delayed_feedback(&mut self, _node_id: NodeId, _delayed_feedback: &DelayedFeedback) {}
     fn visit_distinct(&mut self, _node_id: NodeId, _distinct: &Distinct) {}
+    fn visit_stream_distinct(&mut self, _node_id: NodeId, _distinct: &StreamDistinct) {}
     fn visit_join_core(&mut self, _node_id: NodeId, _join_core: &JoinCore) {}
     fn visit_export(&mut self, _node_id: NodeId, _export: &Export) {}
     fn visit_exported_node(&mut self, _node_id: NodeId, _exported_node: &ExportedNode) {}
@@ -81,6 +82,7 @@ pub trait MutNodeVisitor {
     ) {
     }
     fn visit_distinct(&mut self, _node_id: NodeId, _distinct: &mut Distinct) {}
+    fn visit_stream_distinct(&mut self, _node_id: NodeId, _distinct: &mut StreamDistinct) {}
     fn visit_join_core(&mut self, _node_id: NodeId, _join_core: &mut JoinCore) {}
     fn visit_export(&mut self, _node_id: NodeId, _export: &mut Export) {}
     fn visit_exported_node(&mut self, _node_id: NodeId, _exported_node: &mut ExportedNode) {}
@@ -137,6 +139,7 @@ impl Node {
                 visitor.visit_delayed_feedback(node_id, delayed_feedback);
             }
             Self::Distinct(distinct) => visitor.visit_distinct(node_id, distinct),
+            Self::StreamDistinct(distinct) => visitor.visit_stream_distinct(node_id, distinct),
             Self::JoinCore(join_core) => visitor.visit_join_core(node_id, join_core),
             Self::Subgraph(subgraph) => visitor.visit_subgraph(node_id, subgraph),
             Self::Export(export) => visitor.visit_export(node_id, export),
@@ -189,6 +192,7 @@ impl Node {
                 visitor.visit_delayed_feedback(node_id, delayed_feedback);
             }
             Self::Distinct(distinct) => visitor.visit_distinct(node_id, distinct),
+            Self::StreamDistinct(distinct) => visitor.visit_stream_distinct(node_id, distinct),
             Self::JoinCore(join_core) => visitor.visit_join_core(node_id, join_core),
             Self::Subgraph(subgraph) => visitor.visit_subgraph(node_id, subgraph),
             Self::Export(export) => visitor.visit_export(node_id, export),

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/operators/JITStreamDistinctOperator.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/jit/ir/operators/JITStreamDistinctOperator.java
@@ -1,0 +1,17 @@
+package org.dbsp.sqlCompiler.compiler.backend.jit.ir.operators;
+
+import com.fasterxml.jackson.databind.node.BaseJsonNode;
+import org.dbsp.sqlCompiler.compiler.backend.jit.ir.types.JITRowType;
+
+import java.util.List;
+
+public class JITStreamDistinctOperator extends JITOperator {
+    public JITStreamDistinctOperator(long id, JITRowType type, List<JITOperatorReference> inputs) {
+        super(id, "StreamDistinct", "", type, inputs, null, null);
+    }
+
+    @Override
+    public BaseJsonNode asJson() {
+        return this.asJsonWithLayout();
+    }
+}

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -17,6 +17,7 @@ import org.dbsp.sqlCompiler.ir.type.primitive.DBSPTypeWeight;
 import org.dbsp.util.IndentStream;
 import org.dbsp.util.Linq;
 import org.dbsp.util.Logger;
+import org.dbsp.util.ProgramAndTester;
 
 import java.io.FileNotFoundException;
 import java.io.PrintStream;
@@ -317,6 +318,12 @@ public class RustFileWriter implements ICompilerComponent {
             generateStructures(used, stream);
         }
         return stream.toString();
+    }
+
+    public void add(ProgramAndTester pt) {
+        if (pt.program != null)
+            this.add(pt.program);
+        this.add(pt.tester);
     }
 
     public void add(DBSPCircuit circuit) {

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/errors/CompilerMessages.java
@@ -101,6 +101,10 @@ public class CompilerMessages {
         this.messages = new ArrayList<>();
     }
 
+    public void clear() {
+        this.messages.clear();
+    }
+
     public void setExitCode(int exitCode) {
         this.exitCode = exitCode;
     }

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqllogictest/Main.java
@@ -66,7 +66,7 @@ public class Main {
         );
 
         String[] args = {
-                "-v", "-x",
+                "-v", "-x", "-j",
                 "-e", "hybrid",      // executor
                 "-inc",              // incremental (streaming) testing
         };

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ProgramAndTester.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/util/ProgramAndTester.java
@@ -1,0 +1,21 @@
+package org.dbsp.util;
+
+import org.dbsp.sqlCompiler.circuit.DBSPCircuit;
+import org.dbsp.sqlCompiler.ir.DBSPFunction;
+
+import javax.annotation.Nullable;
+
+/**
+ * A pair of a Rust circuit representation and a tester function that can
+ * exercise it.
+ */
+public class ProgramAndTester {
+    @Nullable
+    public final DBSPCircuit program;
+    public final DBSPFunction tester;
+
+    public ProgramAndTester(@Nullable DBSPCircuit program, DBSPFunction tester) {
+        this.program = program;
+        this.tester = tester;
+    }
+}


### PR DESCRIPTION
This PR makes some step towards running the SLT tests on top of the JIT infrastructure.
This compiles the SQL into JIT programs. Still missing is the code to actually compare outputs and feed inputs.
The JIT is missing some *non incremental* operators. We add the StreamDistinct operator.
We will also need non-incremental versions of the Aggregate and Join. (We could implement these by using some I and Ds, though).