### PR TITLE
ci: fix earthly 'project name cannot be empty' issue

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -543,6 +543,7 @@ build-demo-container:
 
 test-docker-compose:
     FROM earthly/dind:alpine
+    WORKDIR /root
     COPY deploy/docker-compose.yml .
     WITH DOCKER --pull postgres \
                 --pull docker.redpanda.com/vectorized/redpanda:v23.1.13 \
@@ -564,6 +565,7 @@ integration-test-container:
 # Runs the integration test container against the docker compose setup
 integration-tests:
     FROM earthly/dind:alpine
+    WORKDIR /root
     COPY deploy/docker-compose.yml .
     COPY deploy/.env .
     WITH DOCKER --pull postgres \
@@ -572,7 +574,7 @@ integration-tests:
                 --service db \
                 --service dbsp \
                 --load itest:latest=+integration-test-container
-        RUN sleep 5 && docker run --env-file .env --network default_default itest:latest
+        RUN sleep 5 && docker run --env-file .env --network root_default itest:latest
     END
 
 all-tests:


### PR DESCRIPTION
There seems to have been a regression in the latest earthly/dind images. Temporarily patching it by forcing a WORKDIR for now.