### PR TITLE
deploy: Don't warn about missing `SECOPS_DEMO_ARGS` with `docker comp…

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -71,8 +71,9 @@ services:
     environment:
       - RUST_BACKTRACE=1
       - REDPANDA_BROKERS=redpanda:9092
+      - SECOPS_DEMO_ARGS
     command:
       - bash
       - -c
       # Run the SecOps demo
-      - "cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://dbsp:8080 --actions prepare create compile ${SECOPS_DEMO_ARGS}"
+      - "cd demo/project_demo00-SecOps && python3 run.py --dbsp_url http://dbsp:8080 --actions prepare create compile $${SECOPS_DEMO_ARGS}"


### PR DESCRIPTION
…ose`.

Before this commit, `docker compose --profile demo up` printed a warning on startup if `SECOPS_DEMO_ARGS` wasn't defined in the environment:

```
WARN[0000] The "SECOPS_DEMO_ARGS" variable is not set. Defaulting to a blank string.
```

The reason is that Docker Compose does this for expanding an undefined variable.  By writing `${SECOPS_DEMO_ARGS}` in the `command` for our container, Docker Compose expands and warns.

The shell does not warn about undefined variables, so we can use shell expansion instead, by adding an extra `$`: `$${SECOPS_DEMO_ARGS}`. However, Docker Compose does not pass this variable into the shell's environment by default, so we also need to add SECOPS_DEMO_ARGS to the container's list of passthrough environment variables.  This commit does both.

Fixes https://github.com/feldera/dbsp/issues/452.