### PR TITLE
sql: Document that date and time literals don't allow trailing spaces.

### DIFF
--- a/docs/docs/sql/datetime.md
+++ b/docs/docs/sql/datetime.md
@@ -1,9 +1,9 @@
 # Date/time operations
 
 `TIME` literals have the form `TIME 'HH:MM:SS.FFF`, where the
-fractional part is optional, and can have between 0 and 9 digits.  A
-time represents a time within a day, limited to between 0 and 24
-hours.
+fractional part is optional, and can have between 0 and 9 digits.
+Trailing spaces are not allowed.  A time represents a time within a
+day, limited to between 0 and 24 hours.
 
 Values of type `DATE`, `TIME`, and `TIMESTAMP` can be compared
 using `=`, `<>`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`,
@@ -56,7 +56,8 @@ The following are legal time units:
 
 ## Operations on dates
 
-`DATE` literals have the form `DATE 'YYYY-MM-DD'`.
+`DATE` literals have the form `DATE 'YYYY-MM-DD'`.  Trailing spaces
+are not allowed.
 
 Date literals can only represent 4-digit year positive values.
 Values BC or values greater than 10,000 years are not supported.
@@ -96,7 +97,7 @@ For dates it always returns 0, since dates have no time component.
 
 A timestamp contains both a date and a time.  `TIMESTAMP` literals
 have the form `TIMESTAMP 'YYYY-MM-DD HH:MM:SS.FFF'`, where the
-fractional part is optional.
+fractional part is optional.  Trailing spaces are not allowed.
 
 Timestamp literals can only represent 4-digit year positive values.
 Values BC or values greater than 10,000 years are not supported.


### PR DESCRIPTION
This seems to be a Calcite limitation.

See https://github.com/feldera/dbsp/issues/443.