### PR TITLE
dbsp: Add newtypes for ArcStr and Decimal for bincode support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,6 @@ dependencies = [
  "pretty",
  "proptest",
  "proptest-derive",
- "rust_decimal",
  "schemars",
  "serde",
  "serde_json",
@@ -2390,7 +2389,6 @@ dependencies = [
  "rand",
  "regex",
  "rstest",
- "rust_decimal",
  "serde",
  "serde_with",
  "size-of",
@@ -5590,6 +5588,7 @@ dependencies = [
 name = "sqllib"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "chrono",
  "dbsp",
  "geo",
@@ -5598,7 +5597,6 @@ dependencies = [
  "num",
  "paste",
  "regex",
- "rust_decimal",
  "serde",
  "size-of",
 ]
@@ -5608,7 +5606,6 @@ name = "sqlvalue"
 version = "0.1.0"
 dependencies = [
  "dbsp",
- "rust_decimal",
  "sqllib",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,6 @@ name = "arcstr"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "arrayvec"
@@ -2379,7 +2376,6 @@ name = "dbsp_nexmark"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arcstr",
  "ascii_table",
  "bincode",
  "cached 0.38.0",
@@ -4716,6 +4712,7 @@ name = "readers"
 version = "0.1.0"
 dependencies = [
  "async-std",
+ "bincode",
  "csv",
  "dbsp",
  "derive_more",

--- a/crates/dataflow-jit/Cargo.toml
+++ b/crates/dataflow-jit/Cargo.toml
@@ -25,7 +25,7 @@ cranelift-jit = "0.96.2"
 target-lexicon = "0.12.5"
 cranelift-module = "0.96.2"
 unicode-normalization = "0.1.22"
-dbsp = { path = "../dbsp", features = ["serde"] }
+dbsp = { path = "../dbsp", features = ["serde", "decimal_maths"] }
 bitvec = { version = "1.0.1", features = ["serde"] }
 bitflags = { version = "2.0.1", features = ["serde"] }
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
@@ -69,10 +69,6 @@ clap = { version = "4.1.8", features = ["derive"], optional = true }
     version = "1.6.0"
     features = ["std", "rustc_1_57"]
 
-    [dependencies.rust_decimal]
-    version = "1.29"
-    features = ["maths", "c-repr"]
-
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"
 features = ["winnt"]
@@ -83,12 +79,9 @@ is-terminal = "0.4.7"
 num-integer = "0.1.45"
 proptest-derive = "0.3.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+dbsp = { path = "../dbsp", features = ["serde", "decimal_maths", "decimal_proptest" ] }
 
     [dev-dependencies.chrono]
     version = "0.4.23"
     default-features = false
     features = ["std", "clock"]
-
-    [dev-dependencies.rust_decimal]
-    version = "1.29"
-    features = ["maths", "c-repr", "proptest"]

--- a/crates/dataflow-jit/src/codegen/intrinsics.rs
+++ b/crates/dataflow-jit/src/codegen/intrinsics.rs
@@ -16,7 +16,7 @@ use cranelift::{
 use cranelift_jit::{JITBuilder, JITModule};
 use cranelift_module::{FuncId, Linkage, Module};
 use csv::StringRecord;
-use rust_decimal::Decimal;
+use dbsp::algebra::Decimal;
 use std::{
     alloc::Layout,
     cell::RefCell,

--- a/crates/dataflow-jit/src/codegen/vtable/tests.rs
+++ b/crates/dataflow-jit/src/codegen/vtable/tests.rs
@@ -400,7 +400,7 @@ mod proptests {
         strategy::Strategy, test_runner::TestCaseResult,
     };
     use proptest_derive::Arbitrary;
-    use rust_decimal::Decimal;
+    use dbsp::algebra::Decimal;
     use size_of::SizeOf;
     use std::{
         cmp::Ordering,
@@ -892,6 +892,6 @@ mod proptests {
             Nonnull(U16(40022)), Nullable(I64(6376951496006352246), true), Nonnull(F32(-8.540973e-39)), Nullable(String("\"*wⷎ".to_owned()), false),
             Nullable(F64(0.0), false),
         ],
-        decimal = [Nullable(Decimal(rust_decimal::Decimal::from_str("-418972098951.06177358336234255").unwrap()), false)],
+        decimal = [Nullable(Decimal(dbsp::algebra::Decimal::from_str("-418972098951.06177358336234255").unwrap()), false)],
     }
 }

--- a/crates/dataflow-jit/src/facade.rs
+++ b/crates/dataflow-jit/src/facade.rs
@@ -17,7 +17,7 @@ use dbsp::{
     trace::{BatchReader, Cursor},
     DBSPHandle, Error, Runtime,
 };
-use rust_decimal::Decimal;
+use dbsp::algebra::Decimal;
 use std::{collections::BTreeMap, mem::transmute, ops::Not, path::Path, thread, time::Instant};
 
 // TODO: A lot of this still needs fleshing out, mainly the little tweaks that

--- a/crates/dataflow-jit/src/ir/exprs/constant.rs
+++ b/crates/dataflow-jit/src/ir/exprs/constant.rs
@@ -3,7 +3,7 @@ use crate::ir::{
     ColumnType, RowLayoutCache,
 };
 use chrono::{NaiveDate, NaiveDateTime};
-use rust_decimal::Decimal;
+use dbsp::algebra::Decimal;
 use schemars::{
     gen::SchemaGenerator,
     schema::{InstanceType, Schema, SchemaObject},

--- a/crates/dataflow-jit/src/utils.rs
+++ b/crates/dataflow-jit/src/utils.rs
@@ -1,4 +1,4 @@
-use rust_decimal::Decimal;
+use dbsp::algebra::Decimal;
 
 #[cfg(test)]
 pub(crate) fn test_logger() {

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -44,10 +44,8 @@ arc-swap = "1.5.1"
 mimalloc-rust-sys = "1.7.2"
 rand = "0.8.5"
 rust_decimal = "1.29"
-
-    [dependencies.size-of]
-    version = "0.1.5"
-    features = ["hashbrown", "time-std", "xxhash-xxh3"]
+arcstr = { version = "1.1.4" }
+size-of = { version = "0.1.5", features = ["hashbrown", "time-std", "xxhash-xxh3", "arcstr"] }
 
 [dev-dependencies]
 csv = "1.2.2"
@@ -63,7 +61,6 @@ indicatif = "0.17.0-rc.11"
 clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 serde_json = "1.0.87"
-arcstr = { version = "1.1.4" }
 
 [dependencies.time]
 version = "0.3.20"

--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -16,6 +16,8 @@ persistence = ["rocksdb", "uuid"]
 with-serde = ["serde"]
 with-csv = ["csv"]
 __gdelt = ["size-of/arcstr"]
+decimal_maths = ["rust_decimal/maths"]
+decimal_proptest = ["rust_decimal/proptest", "dep:proptest", "dep:proptest-derive"]
 
 [dependencies]
 num = "0.4.0"
@@ -43,9 +45,11 @@ uuid = { version = "1.1.2", features = ["v4"], optional = true }
 arc-swap = "1.5.1"
 mimalloc-rust-sys = "1.7.2"
 rand = "0.8.5"
-rust_decimal = "1.29"
+rust_decimal = { version = "1.29", features = ["c-repr"] }
 arcstr = { version = "1.1.4" }
-size-of = { version = "0.1.5", features = ["hashbrown", "time-std", "xxhash-xxh3", "arcstr"] }
+size-of = { version = "0.1.5", features = ["hashbrown", "time-std", "xxhash-xxh3", "rust_decimal", "arcstr"] }
+proptest = { default-features = false, optional = true, version = "1.0" }
+proptest-derive = { default-features = false, optional = true, version = "0.3.0" }
 
 [dev-dependencies]
 csv = "1.2.2"

--- a/crates/dbsp/src/algebra/arcstr.rs
+++ b/crates/dbsp/src/algebra/arcstr.rs
@@ -1,0 +1,101 @@
+use std::{ops::Deref, fmt::{Display, Formatter, Result as FmtResult, Debug}};
+
+use arcstr::ArcStr as Inner;
+use bincode::{Encode, Decode, enc::Encoder, error::{EncodeError, DecodeError}, de::{Decoder, BorrowDecoder}, BorrowDecode};
+use size_of::SizeOf;
+
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Default, SizeOf)]
+pub struct ArcStr(pub Inner);
+
+impl ArcStr {
+    pub fn new() -> Self { Self(Inner::new()) }
+}
+
+impl Deref for ArcStr {
+    type Target = Inner;
+    fn deref(&self) -> &Self::Target { &self.0 }
+}
+
+impl Display for ArcStr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{}", &self.0)
+    }
+}
+
+impl Debug for ArcStr {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        write!(f, "{:?}", &self.0)
+    }
+}
+
+impl From<String> for ArcStr {
+    fn from(source: String) -> Self {
+        ArcStr(Inner::from(source))
+    }
+}
+
+impl From<&str> for ArcStr {
+    fn from(source: &str) -> Self {
+        ArcStr(Inner::from(source))
+    }
+}
+
+impl bincode::Encode for ArcStr {
+    fn encode<E: Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), EncodeError> {
+        Encode::encode(self.0.as_str(), encoder)?;
+        Ok(())
+    }
+}
+
+impl PartialEq<&str> for ArcStr {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
+
+impl Decode for ArcStr {
+    fn decode<D: Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let str: String = Decode::decode(decoder)?;
+        Ok(str.into())
+    }
+}
+
+impl<'de> BorrowDecode<'de> for ArcStr {
+    fn borrow_decode<D: BorrowDecoder<'de>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let str: String = Decode::decode(decoder)?;
+        Ok(str.into())
+    }
+}
+
+// Import and rename the macros from `arcstr` for wrapping.
+//
+// If we instead wrap the macros directly, e.g. if we use `::arcstr::literal` in
+// the definition below, then code that depends on us needs to add a direct
+// dependency on `arcstr`, but `cargo machete` will report that the dependency
+// is unused because the only reference appears in a macro expansion.
+//
+// The imports need to be `pub` because names in macro expansions aren't
+// privileged.
+pub use arcstr::literal as arcstr_inner_literal;
+pub use arcstr::format as arcstr_inner_format;
+
+#[macro_export]
+macro_rules! arcstr_literal {
+    ($text:expr $(,)?) => {{
+        $crate::algebra::ArcStr($crate::algebra::arcstr::arcstr_inner_literal!($text))
+    }};
+}
+
+#[macro_export]
+macro_rules! arcstr_format {
+    ($($toks:tt)*) => {
+        $crate::algebra::ArcStr($crate::algebra::arcstr::arcstr_inner_format!($($toks)*))
+    };
+}

--- a/crates/dbsp/src/algebra/decimal.rs
+++ b/crates/dbsp/src/algebra/decimal.rs
@@ -1,0 +1,715 @@
+// Newtype for rust_decimal::Decimal because it doesn't implement Encode and
+// Decode
+
+use ::serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
+use num::{traits::Inv, Num, One, Zero};
+use size_of::*;
+
+#[cfg(feature = "decimal_maths")]
+use num::traits::Pow;
+#[cfg(feature = "decimal_proptest")]
+use proptest_derive::Arbitrary;
+#[cfg(feature = "decimal_maths")]
+use rust_decimal::MathematicalOps;
+
+use rust_decimal::{
+    prelude::{FromPrimitive, Signed, ToPrimitive},
+    Decimal as RustDecimal, Error as RustDecimalError, RoundingStrategy,
+};
+use std::{
+    fmt::{Display, Formatter, LowerExp, UpperExp},
+    iter::{Product, Sum},
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
+    str::FromStr,
+};
+
+#[derive(
+    Copy,
+    Default,
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    SizeOf,
+    Serialize,
+    Deserialize,
+    Debug,
+    Encode,
+    Decode,
+)]
+#[cfg_attr(feature = "decimal_proptest", derive(Arbitrary))]
+pub struct Decimal(#[bincode(with_serde)] RustDecimal);
+
+impl<T> From<T> for Decimal
+where
+    RustDecimal: From<T>,
+{
+    fn from(value: T) -> Self {
+        Self(RustDecimal::from(value))
+    }
+}
+
+impl Decimal {
+    pub const MIN: Decimal = Self(RustDecimal::MIN);
+    pub const MAX: Decimal = Self(RustDecimal::MAX);
+    pub const ZERO: Decimal = Self(RustDecimal::ZERO);
+    pub const ONE: Decimal = Self(RustDecimal::ONE);
+    pub const NEGATIVE_ONE: Decimal = Self(RustDecimal::NEGATIVE_ONE);
+    pub const TWO: Decimal = Self(RustDecimal::TWO);
+    pub const TEN: Decimal = Self(RustDecimal::TEN);
+    pub const ONE_HUNDRED: Decimal = Self(RustDecimal::ONE_HUNDRED);
+    pub const ONE_THOUSAND: Decimal = Self(RustDecimal::ONE_THOUSAND);
+
+    pub fn new(num: i64, scale: u32) -> Decimal {
+        Self(RustDecimal::new(num, scale))
+    }
+
+    pub fn try_new(num: i64, scale: u32) -> Result<Decimal, RustDecimalError> {
+        Ok(Self(RustDecimal::try_new(num, scale)?))
+    }
+
+    pub fn from_i128_with_scale(num: i128, scale: u32) -> Decimal {
+        Self(RustDecimal::from_i128_with_scale(num, scale))
+    }
+
+    pub fn try_from_i128_with_scale(num: i128, scale: u32) -> Result<Decimal, RustDecimalError> {
+        Ok(Self(RustDecimal::try_from_i128_with_scale(num, scale)?))
+    }
+
+    pub const fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
+        Self(RustDecimal::from_parts(lo, mid, hi, negative, scale))
+    }
+
+    pub fn from_scientific(value: &str) -> Result<Decimal, RustDecimalError> {
+        Ok(Self(RustDecimal::from_scientific(value)?))
+    }
+
+    pub fn from_str_radix(str: &str, radix: u32) -> Result<Self, RustDecimalError> {
+        Ok(Self(RustDecimal::from_str_radix(str, radix)?))
+    }
+
+    pub fn from_str_exact(str: &str) -> Result<Self, RustDecimalError> {
+        Ok(Self(RustDecimal::from_str_exact(str)?))
+    }
+
+    pub const fn scale(&self) -> u32 {
+        self.0.scale()
+    }
+    pub const fn mantissa(&self) -> i128 {
+        self.0.mantissa()
+    }
+
+    pub const fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+    pub fn is_integer(&self) -> bool {
+        self.0.is_integer()
+    }
+
+    pub fn set_sign_positive(&mut self, positive: bool) {
+        self.0.set_sign_positive(positive)
+    }
+    pub fn set_sign_negative(&mut self, negative: bool) {
+        self.0.set_sign_negative(negative)
+    }
+    pub fn set_scale(&mut self, scale: u32) -> Result<(), RustDecimalError> {
+        self.0.set_scale(scale)
+    }
+    pub fn rescale(&mut self, scale: u32) {
+        self.0.rescale(scale);
+    }
+
+    pub const fn serialize(&self) -> [u8; 16] {
+        self.0.serialize()
+    }
+    pub fn deserialize(bytes: [u8; 16]) -> Decimal {
+        Self(RustDecimal::deserialize(bytes))
+    }
+    pub const fn is_sign_negative(&self) -> bool {
+        self.0.is_sign_negative()
+    }
+    pub const fn is_sign_positive(&self) -> bool {
+        self.0.is_sign_positive()
+    }
+
+    pub fn trunc(&self) -> Decimal {
+        Self(self.0.trunc())
+    }
+
+    pub fn trunc_with_scale(&self, scale: u32) -> Decimal {
+        Self(self.0.trunc_with_scale(scale))
+    }
+
+    pub fn fract(&self) -> Decimal {
+        Self(self.0.fract())
+    }
+
+    pub fn floor(&self) -> Self {
+        Self(self.0.floor())
+    }
+
+    pub fn ceil(&self) -> Self {
+        Self(self.0.ceil())
+    }
+
+    pub fn max(self, other: Decimal) -> Decimal {
+        Self(self.0.max(other.0))
+    }
+    pub fn min(self, other: Decimal) -> Decimal {
+        Self(self.0.min(other.0))
+    }
+
+    pub fn normalize(&self) -> Decimal {
+        Self(self.0.normalize())
+    }
+    pub fn normalize_assign(&mut self) {
+        self.0.normalize_assign()
+    }
+
+    pub fn round(&self) -> Decimal {
+        Self(self.0.round())
+    }
+
+    pub fn round_dp_with_strategy(&self, dp: u32, strategy: RoundingStrategy) -> Decimal {
+        Self(self.0.round_dp_with_strategy(dp, strategy))
+    }
+
+    pub fn round_dp(&self, dp: u32) -> Decimal {
+        Self(self.0.round_dp(dp))
+    }
+
+    pub fn round_sf(&self, digits: u32) -> Option<Decimal> {
+        self.0.round_sf(digits).map(Self)
+    }
+
+    pub fn round_sf_with_strategy(
+        &self,
+        digits: u32,
+        strategy: RoundingStrategy,
+    ) -> Option<Decimal> {
+        self.0.round_sf_with_strategy(digits, strategy).map(Self)
+    }
+
+    pub fn from_f32_retain(n: f32) -> Option<Self> {
+        RustDecimal::from_f32_retain(n).map(Self)
+    }
+
+    pub fn from_f64_retain(n: f64) -> Option<Self> {
+        RustDecimal::from_f64_retain(n).map(Self)
+    }
+
+    pub fn checked_add(self, other: Decimal) -> Option<Decimal> {
+        self.0.checked_add(other.0).map(Self)
+    }
+    pub fn checked_sub(self, other: Decimal) -> Option<Decimal> {
+        self.0.checked_sub(other.0).map(Self)
+    }
+    pub fn checked_mul(self, other: Decimal) -> Option<Decimal> {
+        self.0.checked_mul(other.0).map(Self)
+    }
+    pub fn checked_div(self, other: Decimal) -> Option<Decimal> {
+        self.0.checked_div(other.0).map(Self)
+    }
+    pub fn checked_rem(self, other: Decimal) -> Option<Decimal> {
+        self.0.checked_rem(other.0).map(Self)
+    }
+
+    pub fn saturating_add(self, other: Decimal) -> Decimal {
+        Self(self.0.saturating_add(other.0))
+    }
+    pub fn saturating_sub(self, other: Decimal) -> Decimal {
+        Self(self.0.saturating_sub(other.0))
+    }
+    pub fn saturating_mul(self, other: Decimal) -> Decimal {
+        Self(self.0.saturating_mul(other.0))
+    }
+}
+
+impl Signed for Decimal {
+    fn abs(&self) -> Self {
+        Self(self.0.abs())
+    }
+
+    fn abs_sub(&self, other: &Self) -> Self {
+        Self(self.0.abs_sub(&other.0))
+    }
+
+    fn signum(&self) -> Self {
+        Self(self.0.signum())
+    }
+
+    fn is_positive(&self) -> bool {
+        self.0.is_sign_positive()
+    }
+    fn is_negative(&self) -> bool {
+        self.0.is_sign_negative()
+    }
+}
+
+impl Inv for Decimal {
+    type Output = Decimal;
+    fn inv(self) -> Self {
+        Self(self.0.inv())
+    }
+}
+
+impl Sum for Decimal {
+    fn sum<I: Iterator<Item = Decimal>>(iter: I) -> Self {
+        Self(iter.map(|d| d.0).sum())
+    }
+}
+
+impl<'a> Sum<&'a Decimal> for Decimal {
+    fn sum<I: Iterator<Item = &'a Decimal>>(iter: I) -> Self {
+        Self(iter.map(|d| d.0).sum())
+    }
+}
+
+impl Product for Decimal {
+    fn product<I: Iterator<Item = Decimal>>(iter: I) -> Self {
+        Self(iter.map(|d| d.0).product())
+    }
+}
+
+impl<'a> Product<&'a Decimal> for Decimal {
+    fn product<I: Iterator<Item = &'a Decimal>>(iter: I) -> Self {
+        Self(iter.map(|d| d.0).product())
+    }
+}
+
+#[cfg(feature = "decimal_maths")]
+impl Decimal {
+    pub const PI: Decimal = Self(RustDecimal::PI);
+    pub const HALF_PI: Decimal = Self(RustDecimal::HALF_PI);
+    pub const QUARTER_PI: Decimal = Self(RustDecimal::QUARTER_PI);
+    pub const TWO_PI: Decimal = Self(RustDecimal::TWO_PI);
+    pub const E: Decimal = Self(RustDecimal::E);
+    pub const E_INVERSE: Decimal = Self(RustDecimal::E_INVERSE);
+
+    pub fn exp(&self) -> Decimal {
+        Self(self.0.exp())
+    }
+
+    pub fn checked_exp(&self) -> Option<Decimal> {
+        self.0.checked_exp().map(Self)
+    }
+
+    pub fn exp_with_tolerance(&self, tolerance: Decimal) -> Decimal {
+        Self(self.0.exp_with_tolerance(tolerance.0))
+    }
+
+    pub fn checked_exp_with_tolerance(&self, tolerance: Decimal) -> Option<Decimal> {
+        self.0
+            .checked_exp_with_tolerance(tolerance.0)
+            .map(Self)
+    }
+
+    pub fn powi(&self, exp: i64) -> Decimal {
+        Self(self.0.powi(exp))
+    }
+
+    pub fn checked_powi(&self, exp: i64) -> Option<Decimal> {
+        self.0.checked_powi(exp).map(Self)
+    }
+
+    pub fn powu(&self, exp: u64) -> Decimal {
+        Self(self.0.powu(exp))
+    }
+
+    pub fn checked_powu(&self, exp: u64) -> Option<Decimal> {
+        self.0.checked_powu(exp).map(Self)
+    }
+
+    pub fn powf(&self, exp: f64) -> Decimal {
+        Self(self.0.powf(exp))
+    }
+
+    pub fn checked_powf(&self, exp: f64) -> Option<Decimal> {
+        self.0.checked_powf(exp).map(Self)
+    }
+
+    pub fn powd(&self, exp: Decimal) -> Decimal {
+        Self(self.0.powd(exp.0))
+    }
+
+    pub fn checked_powd(&self, exp: Decimal) -> Option<Decimal> {
+        self.0.checked_powd(exp.0).map(Self)
+    }
+
+    pub fn sqrt(&self) -> Option<Decimal> {
+        self.0.sqrt().map(Self)
+    }
+
+    pub fn ln(&self) -> Decimal {
+        Self(self.0.ln())
+    }
+
+    pub fn checked_ln(&self) -> Option<Decimal> {
+        self.0.checked_ln().map(Self)
+    }
+
+    pub fn log10(&self) -> Decimal {
+        Self(self.0.log10())
+    }
+
+    pub fn checked_log10(&self) -> Option<Decimal> {
+        self.0.checked_log10().map(Self)
+    }
+
+    pub fn erf(&self) -> Decimal {
+        Self(self.0.erf())
+    }
+
+    pub fn norm_cdf(&self) -> Decimal {
+        Self(self.0.norm_cdf())
+    }
+
+    pub fn norm_pdf(&self) -> Decimal {
+        Self(self.0.norm_pdf())
+    }
+
+    pub fn checked_norm_pdf(&self) -> Option<Decimal> {
+        self.0.checked_norm_pdf().map(Self)
+    }
+
+    pub fn sin(&self) -> Decimal {
+        Self(self.0.sin())
+    }
+
+    pub fn checked_sin(&self) -> Option<Decimal> {
+        self.0.checked_sin().map(Self)
+    }
+
+    pub fn cos(&self) -> Decimal {
+        Self(self.0.cos())
+    }
+
+    pub fn checked_cos(&self) -> Option<Decimal> {
+        self.0.checked_cos().map(Self)
+    }
+
+    pub fn tan(&self) -> Decimal {
+        Self(self.0.tan())
+    }
+
+    pub fn checked_tan(&self) -> Option<Decimal> {
+        self.0.checked_tan().map(Self)
+    }
+}
+
+impl Display for Decimal {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl LowerExp for Decimal {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        LowerExp::fmt(&self.0, f)
+    }
+}
+
+impl UpperExp for Decimal {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        UpperExp::fmt(&self.0, f)
+    }
+}
+
+impl FromPrimitive for Decimal {
+    fn from_i64(n: i64) -> Option<Decimal> {
+        RustDecimal::from_i64(n).map(Self)
+    }
+
+    fn from_u64(n: u64) -> Option<Decimal> {
+        RustDecimal::from_u64(n).map(Self)
+    }
+
+    fn from_u128(n: u128) -> Option<Decimal> {
+        RustDecimal::from_u128(n).map(Self)
+    }
+
+    fn from_i128(n: i128) -> Option<Decimal> {
+        RustDecimal::from_i128(n).map(Self)
+    }
+
+    fn from_f64(n: f64) -> Option<Decimal> {
+        RustDecimal::from_f64(n).map(Self)
+    }
+}
+
+impl ToPrimitive for Decimal {
+    fn to_i64(&self) -> Option<i64> {
+        self.0.to_i64()
+    }
+    fn to_u64(&self) -> Option<u64> {
+        self.0.to_u64()
+    }
+    fn to_i128(&self) -> Option<i128> {
+        self.0.to_i128()
+    }
+    fn to_u128(&self) -> Option<u128> {
+        self.0.to_u128()
+    }
+    fn to_f64(&self) -> Option<f64> {
+        self.0.to_f64()
+    }
+}
+
+impl FromStr for Decimal {
+    type Err = <RustDecimal as FromStr>::Err;
+
+    fn from_str(value: &str) -> Result<Decimal, <RustDecimal as FromStr>::Err> {
+        Ok(Decimal(RustDecimal::from_str(value)?))
+    }
+}
+
+impl Add for Decimal {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.add(rhs.0))
+    }
+}
+
+impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
+    type Output = Decimal;
+
+    fn add(self, rhs: &Decimal) -> Decimal {
+        Decimal(self.0.add(rhs.0))
+    }
+}
+
+impl<'a> AddAssign<&'a Decimal> for &'a mut Decimal {
+    fn add_assign(&mut self, other: &'a Decimal) {
+        self.0.add_assign(other.0)
+    }
+}
+
+impl<'a> AddAssign<&'a Decimal> for Decimal {
+    fn add_assign(&mut self, other: &'a Decimal) {
+        self.0.add_assign(other.0)
+    }
+}
+
+impl<'a> AddAssign<Decimal> for &'a mut Decimal {
+    fn add_assign(&mut self, other: Decimal) {
+        self.0.add_assign(other.0)
+    }
+}
+
+impl AddAssign<Decimal> for Decimal {
+    fn add_assign(&mut self, other: Decimal) {
+        self.0.add_assign(other.0)
+    }
+}
+
+impl Sub for Decimal {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0.sub(rhs.0))
+    }
+}
+
+impl<'a, 'b> Sub<&'b Decimal> for &'a Decimal {
+    type Output = Decimal;
+
+    fn sub(self, rhs: &Decimal) -> Decimal {
+        Decimal(self.0.sub(rhs.0))
+    }
+}
+
+impl<'a> SubAssign<&'a Decimal> for &'a mut Decimal {
+    fn sub_assign(&mut self, other: &'a Decimal) {
+        self.0.sub_assign(other.0)
+    }
+}
+
+impl<'a> SubAssign<&'a Decimal> for Decimal {
+    fn sub_assign(&mut self, other: &'a Decimal) {
+        self.0.sub_assign(other.0)
+    }
+}
+
+impl<'a> SubAssign<Decimal> for &'a mut Decimal {
+    fn sub_assign(&mut self, other: Decimal) {
+        self.0.sub_assign(other.0)
+    }
+}
+
+impl SubAssign<Decimal> for Decimal {
+    fn sub_assign(&mut self, other: Decimal) {
+        self.0.sub_assign(other.0)
+    }
+}
+
+impl Mul for Decimal {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0.mul(rhs.0))
+    }
+}
+
+impl<'a, 'b> Mul<&'b Decimal> for &'a Decimal {
+    type Output = Decimal;
+
+    fn mul(self, rhs: &Decimal) -> Decimal {
+        Decimal(self.0.mul(rhs.0))
+    }
+}
+
+impl<'a> MulAssign<&'a Decimal> for &'a mut Decimal {
+    fn mul_assign(&mut self, other: &'a Decimal) {
+        self.0.mul_assign(other.0)
+    }
+}
+
+impl<'a> MulAssign<&'a Decimal> for Decimal {
+    fn mul_assign(&mut self, other: &'a Decimal) {
+        self.0.mul_assign(other.0)
+    }
+}
+
+impl<'a> MulAssign<Decimal> for &'a mut Decimal {
+    fn mul_assign(&mut self, other: Decimal) {
+        self.0.mul_assign(other.0)
+    }
+}
+
+impl MulAssign<Decimal> for Decimal {
+    fn mul_assign(&mut self, other: Decimal) {
+        self.0.mul_assign(other.0)
+    }
+}
+
+impl Div for Decimal {
+    type Output = Self;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        Self(self.0.div(rhs.0))
+    }
+}
+
+impl<'a, 'b> Div<&'b Decimal> for &'a Decimal {
+    type Output = Decimal;
+
+    fn div(self, rhs: &Decimal) -> Decimal {
+        Decimal(self.0.div(rhs.0))
+    }
+}
+
+impl<'a> DivAssign<&'a Decimal> for &'a mut Decimal {
+    fn div_assign(&mut self, other: &'a Decimal) {
+        self.0.div_assign(other.0)
+    }
+}
+
+impl<'a> DivAssign<&'a Decimal> for Decimal {
+    fn div_assign(&mut self, other: &'a Decimal) {
+        self.0.div_assign(other.0)
+    }
+}
+
+impl<'a> DivAssign<Decimal> for &'a mut Decimal {
+    fn div_assign(&mut self, other: Decimal) {
+        self.0.div_assign(other.0)
+    }
+}
+
+impl DivAssign<Decimal> for Decimal {
+    fn div_assign(&mut self, other: Decimal) {
+        self.0.div_assign(other.0)
+    }
+}
+
+impl Rem for Decimal {
+    type Output = Self;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        Self(self.0.rem(rhs.0))
+    }
+}
+
+impl<'a, 'b> Rem<&'b Decimal> for &'a Decimal {
+    type Output = Decimal;
+
+    fn rem(self, rhs: &Decimal) -> Decimal {
+        Decimal(self.0.rem(rhs.0))
+    }
+}
+
+impl<'a> RemAssign<&'a Decimal> for &'a mut Decimal {
+    fn rem_assign(&mut self, other: &'a Decimal) {
+        self.0.rem_assign(other.0)
+    }
+}
+
+impl<'a> RemAssign<&'a Decimal> for Decimal {
+    fn rem_assign(&mut self, other: &'a Decimal) {
+        self.0.rem_assign(other.0)
+    }
+}
+
+impl<'a> RemAssign<Decimal> for &'a mut Decimal {
+    fn rem_assign(&mut self, other: Decimal) {
+        self.0.rem_assign(other.0)
+    }
+}
+
+impl RemAssign<Decimal> for Decimal {
+    fn rem_assign(&mut self, other: Decimal) {
+        self.0.rem_assign(other.0)
+    }
+}
+
+impl Neg for Decimal {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self(self.0.neg())
+    }
+}
+
+impl Neg for &Decimal {
+    type Output = Decimal;
+
+    fn neg(self) -> Self::Output {
+        Decimal(self.0.neg())
+    }
+}
+
+impl Zero for Decimal {
+    fn zero() -> Self {
+        Decimal(RustDecimal::ZERO)
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
+impl One for Decimal {
+    fn one() -> Self {
+        Decimal(RustDecimal::ONE)
+    }
+}
+
+impl Num for Decimal {
+    type FromStrRadixErr = RustDecimalError;
+    fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        Decimal::from_str_radix(str, radix)
+    }
+}
+
+#[cfg(feature = "decimal_maths")]
+impl Pow<Decimal> for Decimal {
+    type Output = Decimal;
+
+    fn pow(self, rhs: Decimal) -> Self::Output {
+        Self::powd(&self, rhs)
+    }
+}

--- a/crates/dbsp/src/algebra/mod.rs
+++ b/crates/dbsp/src/algebra/mod.rs
@@ -1,8 +1,8 @@
 //! This module contains declarations of abstract algebraic concepts:
 //! monoids, groups, rings, etc.
 
-#[macro_use]
 mod checked_int;
+mod decimal;
 mod floats;
 mod lattice;
 mod order;
@@ -14,13 +14,13 @@ pub mod arcstr;
 pub use self::arcstr::ArcStr;
 
 pub use checked_int::CheckedInt;
+pub use decimal::Decimal;
 pub use floats::{F32, F64};
 pub use lattice::Lattice;
 pub use order::{PartialOrder, TotalOrder};
 pub use present::Present;
 pub use zset::{IndexedZSet, ZSet};
 
-use rust_decimal::Decimal;
 use size_of::SizeOf;
 use std::{
     marker::PhantomData,

--- a/crates/dbsp/src/algebra/mod.rs
+++ b/crates/dbsp/src/algebra/mod.rs
@@ -10,6 +10,9 @@ mod present;
 
 pub mod zset;
 
+pub mod arcstr;
+pub use self::arcstr::ArcStr;
+
 pub use checked_int::CheckedInt;
 pub use floats::{F32, F64};
 pub use lattice::Lattice;

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 dbsp = { path = "../dbsp" }
 anyhow = "1.0.57"
 csv = "1.2.2"
-arcstr = { version = "1.1.4", features = ["serde"] }
 rust_decimal = { version = "1.26.1" }
 regex = { version = "1.6.0" }
 time = { version = "0.3.14", features = ["formatting"] }

--- a/crates/nexmark/Cargo.toml
+++ b/crates/nexmark/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT OR Apache-2.0"
 dbsp = { path = "../dbsp" }
 anyhow = "1.0.57"
 csv = "1.2.2"
-rust_decimal = { version = "1.26.1" }
 regex = { version = "1.6.0" }
 time = { version = "0.3.14", features = ["formatting"] }
 paste = { version = "1.0.9" }

--- a/crates/nexmark/src/generator/auctions.rs
+++ b/crates/nexmark/src/generator/auctions.rs
@@ -148,6 +148,7 @@ mod tests {
     use super::super::tests::make_test_generator;
     use super::*;
     use rstest::rstest;
+    use dbsp::arcstr_literal;
 
     #[test]
     fn test_next_auction() {
@@ -170,8 +171,8 @@ mod tests {
         assert_eq!(
             Auction {
                 id: FIRST_AUCTION_ID as u64,
-                item_name: arcstr::literal!("AAA"),
-                description: arcstr::literal!("AAA"),
+                item_name: arcstr_literal!("AAA"),
+                description: arcstr_literal!("AAA"),
                 initial_bid: 100,
                 reserve: 200,
                 date_time: 0,

--- a/crates/nexmark/src/generator/bids.rs
+++ b/crates/nexmark/src/generator/bids.rs
@@ -7,7 +7,7 @@ use super::{
     config::{FIRST_AUCTION_ID, FIRST_PERSON_ID},
     strings::next_string,
 };
-use arcstr::ArcStr;
+use dbsp::{algebra::ArcStr, arcstr_format, arcstr_literal};
 use cached::Cached;
 use rand::Rng;
 use std::mem::size_of;
@@ -21,16 +21,16 @@ const HOT_CHANNELS_RATIO: usize = 100;
 pub const CHANNELS_NUMBER: u32 = 10_000;
 
 static HOT_CHANNELS: [ArcStr; 4] = [
-    arcstr::literal!("Google"),
-    arcstr::literal!("Facebook"),
-    arcstr::literal!("Baidu"),
-    arcstr::literal!("Apple"),
+    arcstr_literal!("Google"),
+    arcstr_literal!("Facebook"),
+    arcstr_literal!("Baidu"),
+    arcstr_literal!("Apple"),
 ];
 static HOT_URLS: [ArcStr; 4] = [
-    arcstr::literal!("https://www.nexmark.com/googl/item.htm?query=1"),
-    arcstr::literal!("https://www.nexmark.com/meta/item.htm?query=1"),
-    arcstr::literal!("https://www.nexmark.com/bidu/item.htm?query=1"),
-    arcstr::literal!("https://www.nexmark.com/aapl/item.htm?query=1"),
+    arcstr_literal!("https://www.nexmark.com/googl/item.htm?query=1"),
+    arcstr_literal!("https://www.nexmark.com/meta/item.htm?query=1"),
+    arcstr_literal!("https://www.nexmark.com/bidu/item.htm?query=1"),
+    arcstr_literal!("https://www.nexmark.com/aapl/item.htm?query=1"),
 ];
 
 const BASE_URL_PATH_LENGTH: usize = 5;
@@ -116,7 +116,7 @@ impl<R: Rng> NexmarkGenerator<R> {
 }
 
 fn get_base_url<R: Rng>(rng: &mut R) -> ArcStr {
-    arcstr::format!(
+    arcstr_format!(
         "https://www.nexmark.com/{}/item.htm?query=1",
         next_string(rng, BASE_URL_PATH_LENGTH),
     )
@@ -153,8 +153,8 @@ pub mod tests {
                 auction: expected_auction_id,
                 bidder: expected_bidder_id,
                 price: 100,
-                channel: arcstr::literal!("Google"),
-                url: arcstr::literal!("https://www.nexmark.com/googl/item.htm?query=1"),
+                channel: arcstr_literal!("Google"),
+                url: arcstr_literal!("https://www.nexmark.com/googl/item.htm?query=1"),
                 date_time: 1_000_000_000_000,
                 extra: "A".repeat(expected_size).into(),
             },
@@ -190,8 +190,8 @@ pub mod tests {
         ng.bid_channel_cache.cache_set(
             1234,
             (
-                arcstr::literal!("Google"),
-                arcstr::literal!("https://google.example.com"),
+                arcstr_literal!("Google"),
+                arcstr_literal!("https://google.example.com"),
             ),
         );
 

--- a/crates/nexmark/src/generator/mod.rs
+++ b/crates/nexmark/src/generator/mod.rs
@@ -5,7 +5,7 @@
 use self::config::Config;
 use super::model::Event;
 use anyhow::Result;
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use bids::CHANNELS_NUMBER;
 use cached::SizedCache;
 use rand::Rng;

--- a/crates/nexmark/src/generator/people.rs
+++ b/crates/nexmark/src/generator/people.rs
@@ -6,7 +6,7 @@ use super::{
     super::{config as nexmark_config, model::Person},
     config, NexmarkGenerator,
 };
-use arcstr::ArcStr;
+use dbsp::{algebra::ArcStr, arcstr_literal};
 use rand::{seq::SliceRandom, Rng};
 use std::{
     cmp::min,
@@ -16,25 +16,25 @@ use std::{
 // Keep the number of states small so that the example queries will find
 // results even with a small batch of events.
 static US_STATES: [ArcStr; 6] = [
-    arcstr::literal!("AZ"),
-    arcstr::literal!("CA"),
-    arcstr::literal!("ID"),
-    arcstr::literal!("OR"),
-    arcstr::literal!("WA"),
-    arcstr::literal!("WY"),
+    arcstr_literal!("AZ"),
+    arcstr_literal!("CA"),
+    arcstr_literal!("ID"),
+    arcstr_literal!("OR"),
+    arcstr_literal!("WA"),
+    arcstr_literal!("WY"),
 ];
 
 static US_CITIES: [ArcStr; 10] = [
-    arcstr::literal!("Phoenix"),
-    arcstr::literal!("Los Angeles"),
-    arcstr::literal!("San Francisco"),
-    arcstr::literal!("Boise"),
-    arcstr::literal!("Portland"),
-    arcstr::literal!("Bend"),
-    arcstr::literal!("Redmond"),
-    arcstr::literal!("Seattle"),
-    arcstr::literal!("Kent"),
-    arcstr::literal!("Cheyenne"),
+    arcstr_literal!("Phoenix"),
+    arcstr_literal!("Los Angeles"),
+    arcstr_literal!("San Francisco"),
+    arcstr_literal!("Boise"),
+    arcstr_literal!("Portland"),
+    arcstr_literal!("Bend"),
+    arcstr_literal!("Redmond"),
+    arcstr_literal!("Seattle"),
+    arcstr_literal!("Kent"),
+    arcstr_literal!("Cheyenne"),
 ];
 
 const FIRST_NAMES: &[&str] = &[

--- a/crates/nexmark/src/generator/strings.rs
+++ b/crates/nexmark/src/generator/strings.rs
@@ -3,7 +3,7 @@
 //! API based on the equivalent [Nexmark Flink StringsGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/StringsGenerator.java).
 
 use super::NexmarkGenerator;
-use arcstr::ArcStr;
+use dbsp::{algebra::ArcStr, arcstr_literal};
 use rand::{distributions::Alphanumeric, distributions::DistString, Rng};
 
 const MIN_STRING_LENGTH: usize = 3;
@@ -18,13 +18,13 @@ pub(super) fn next_string<R: Rng>(rng: &mut R, max_length: usize) -> ArcStr {
 /// average the desired average size.
 fn next_extra<R: Rng>(rng: &mut R, current_size: usize, desired_average_size: usize) -> ArcStr {
     if current_size > desired_average_size {
-        return arcstr::literal!("");
+        return arcstr_literal!("");
     }
 
     let avg_extra_size = desired_average_size - current_size;
     let delta = (avg_extra_size as f32 * 0.2).round() as usize;
     if delta == 0 {
-        return arcstr::literal!("");
+        return arcstr_literal!("");
     }
 
     let desired_size =

--- a/crates/nexmark/src/model.rs
+++ b/crates/nexmark/src/model.rs
@@ -2,7 +2,7 @@
 //!
 //! Based on the equivalent [Nexmark Flink Java model classes](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model).
 
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use bincode::{Decode, Encode};
 use size_of::SizeOf;
 
@@ -13,18 +13,12 @@ use size_of::SizeOf;
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf, Encode, Decode)]
 pub struct Person {
     pub id: u64,
-    #[bincode(with_serde)]
     pub name: ArcStr,
-    #[bincode(with_serde)]
     pub email_address: ArcStr,
-    #[bincode(with_serde)]
     pub credit_card: ArcStr,
-    #[bincode(with_serde)]
     pub city: ArcStr,
-    #[bincode(with_serde)]
     pub state: ArcStr,
     pub date_time: u64,
-    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 
@@ -35,9 +29,7 @@ pub struct Person {
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf, Encode, Decode)]
 pub struct Auction {
     pub id: u64,
-    #[bincode(with_serde)]
     pub item_name: ArcStr,
-    #[bincode(with_serde)]
     pub description: ArcStr,
     pub initial_bid: usize,
     pub reserve: usize,
@@ -45,7 +37,6 @@ pub struct Auction {
     pub expires: u64,
     pub seller: u64,
     pub category: usize,
-    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 
@@ -62,16 +53,13 @@ pub struct Bid {
     /// Price of bid, in cents.
     pub price: usize,
     /// The channel that introduced this bidding.
-    #[bincode(with_serde)]
     pub channel: ArcStr,
     /// The url of this channel.
-    #[bincode(with_serde)]
     pub url: ArcStr,
     /// Instant at which this bid was made. NOTE: This may be earlier than teh
     /// system's event time.
     pub date_time: u64,
     /// Additional arbitrary payload for performance testing.
-    #[bincode(with_serde)]
     pub extra: ArcStr,
 }
 

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -1,7 +1,7 @@
 use super::NexmarkStream;
 use crate::model::Event;
 use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use rust_decimal::Decimal;
 use size_of::SizeOf;
 use std::hash::Hash;
@@ -53,7 +53,7 @@ pub struct Q14Output(
     BincodeDecimal,
     BidTimeType,
     u64,
-    #[bincode(with_serde)] ArcStr,
+     ArcStr,
     usize,
 );
 

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -1,11 +1,10 @@
 use super::NexmarkStream;
 use crate::model::Event;
+use bincode::{Decode, Encode};
 use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
-use dbsp::algebra::ArcStr;
-use rust_decimal::Decimal;
+use dbsp::algebra::{ArcStr, Decimal};
 use size_of::SizeOf;
 use std::hash::Hash;
-use std::ops::Deref;
 
 /// Query 14: Calculation (Not in original suite)
 ///
@@ -45,12 +44,12 @@ use std::ops::Deref;
 /// ```
 
 #[derive(
-    Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode,
+    Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, Decode, Encode,
 )]
 pub struct Q14Output(
     u64,
     u64,
-    BincodeDecimal,
+    Decimal,
     BidTimeType,
     u64,
      ArcStr,
@@ -59,62 +58,7 @@ pub struct Q14Output(
 
 type Q14Stream = Stream<RootCircuit, OrdZSet<Q14Output, isize>>;
 
-/// Wrapper type for `Decimal` that implements Decode and Encode.
-///
-/// # Note
-/// Since the query doesn't use spine we don't actually end up
-/// serializing/deserializing Decimals but we still need to implement it to
-/// satisfy trait constraints.
-///
-/// For the future we can submit a PR to `rust_decimal` to implement `Decode`
-/// and `Encode` for `Decimal` directly or if we end up using rykv anyways
-/// `rust_decimal` has support for it already.
-#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord)]
-struct BincodeDecimal(Decimal);
-
-impl bincode::Encode for BincodeDecimal {
-    fn encode<E: bincode::enc::Encoder>(
-        &self,
-        encoder: &mut E,
-    ) -> core::result::Result<(), bincode::error::EncodeError> {
-        bincode::Encode::encode(&self.0.to_string(), encoder)?;
-        Ok(())
-    }
-}
-
-impl bincode::Decode for BincodeDecimal {
-    fn decode<D: bincode::de::Decoder>(
-        decoder: &mut D,
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let s: String = bincode::Decode::decode(decoder)?;
-        Ok(Self(Decimal::from_str_exact(&s).unwrap()))
-    }
-}
-
-impl<'de> bincode::BorrowDecode<'de> for BincodeDecimal {
-    fn borrow_decode<D: bincode::de::BorrowDecoder<'de>>(
-        decoder: &mut D
-    ) -> Result<Self, bincode::error::DecodeError> {
-        let s: String = bincode::BorrowDecode::borrow_decode(decoder)?;
-        Ok(Self(Decimal::from_str_exact(&s).unwrap()))
-    }
-}
-
-impl Deref for BincodeDecimal {
-    type Target = Decimal;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl SizeOf for BincodeDecimal {
-    fn size_of_children(&self, context: &mut size_of::Context) {
-        self.0.size_of_children(context);
-    }
-}
-
-#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode)]
+#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, Decode, Encode)]
 enum BidTimeType {
     Day,
     Night,
@@ -137,7 +81,7 @@ pub fn q14(input: NexmarkStream) -> Q14Stream {
                 Some(Q14Output(
                     b.auction,
                     b.bidder,
-                    BincodeDecimal(new_price),
+                    new_price,
                     match hour_for_millis(b.date_time) {
                         8..=18 => BidTimeType::Day,
                         20..=23 | 0..=6 => BidTimeType::Night,
@@ -163,14 +107,14 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case::decimal_price_converted(2_000_000, 0, "", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Night, 0, ArcStr::new(), 0) => 1])]
+    #[case::decimal_price_converted(2_000_000, 0, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 0, ArcStr::new(), 0) => 1])]
     #[case::decimal_price_converted_outside_range(1_000_000, 0, "", zset![])]
     #[case::decimal_price_converted_on_exclusive_boundary(1_000_000, 0, "", zset![])]
-    #[case::date_time_is_nighttime(2_000_000, 20*60*60*1000 + 1, "", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Night, 20*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
-    #[case::date_time_is_daytime(2_000_000, 8*60*60*1000 + 1, "", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Day, 8*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
-    #[case::date_time_is_daytime_2022(2_000_000, 52*366*24*60*60*1000 + 8*60*60*1000 + 1, "", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Day, 52*366*24*60*60*1000 + 8*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
-    #[case::date_time_is_othertime(2_000_000, 8*60*60*1000 - 1, "", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Other, 8*60*60*1000 - 1, ArcStr::new(), 0) => 1])]
-    #[case::counts_cs_in_extra(2_000_000, 0, "cause I can't calculate has four of them.", zset![Q14Output(1, 1, BincodeDecimal(Decimal::new(1_816_000_000, 3)), BidTimeType::Night, 0, String::from("cause I can't calculate has four of them.").into(), 4) => 1])]
+    #[case::date_time_is_nighttime(2_000_000, 20*60*60*1000 + 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 20*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
+    #[case::date_time_is_daytime(2_000_000, 8*60*60*1000 + 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Day, 8*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
+    #[case::date_time_is_daytime_2022(2_000_000, 52*366*24*60*60*1000 + 8*60*60*1000 + 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Day, 52*366*24*60*60*1000 + 8*60*60*1000 + 1, ArcStr::new(), 0) => 1])]
+    #[case::date_time_is_othertime(2_000_000, 8*60*60*1000 - 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Other, 8*60*60*1000 - 1, ArcStr::new(), 0) => 1])]
+    #[case::counts_cs_in_extra(2_000_000, 0, "cause I can't calculate has four of them.", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 0, String::from("cause I can't calculate has four of them.").into(), 4) => 1])]
     fn test_q14(
         #[case] price: usize,
         #[case] date_time: u64,

--- a/crates/nexmark/src/queries/q16.rs
+++ b/crates/nexmark/src/queries/q16.rs
@@ -1,10 +1,11 @@
 use super::NexmarkStream;
 use crate::{model::Event, queries::OrdinalDate};
+use bincode::{Encode, Decode};
 use dbsp::{
     operator::{FilterMap, Max},
     RootCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use size_of::SizeOf;
 use std::{
     hash::Hash,
@@ -78,15 +79,12 @@ use time::{
     PartialOrd,
     Ord,
     SizeOf,
-    bincode::Encode,
-    bincode::Decode,
+    Encode,
+    Decode,
 )]
 pub struct Q16Output {
-    #[bincode(with_serde)]
     channel: ArcStr,
-    #[bincode(with_serde)]
     day: ArcStr,
-    #[bincode(with_serde)]
     minute: ArcStr,
     total_bids: usize,
     rank1_bids: usize,

--- a/crates/nexmark/src/queries/q17.rs
+++ b/crates/nexmark/src/queries/q17.rs
@@ -4,7 +4,7 @@ use dbsp::{
     RootCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
 use crate::{model::Event, queries::OrdinalDate};
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use std::time::{Duration, SystemTime};
 use time::{
     format_description::well_known::{iso8601, iso8601::FormattedComponents, Iso8601},

--- a/crates/nexmark/src/queries/q21.rs
+++ b/crates/nexmark/src/queries/q21.rs
@@ -1,7 +1,7 @@
 use super::NexmarkStream;
 use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
-use arcstr::ArcStr;
+use dbsp::{algebra::ArcStr, arcstr_literal};
 use regex::Regex;
 
 ///
@@ -45,10 +45,10 @@ pub fn q21(input: NexmarkStream) -> Q21Stream {
     input.flat_map(move |event| match event {
         Event::Bid(b) => {
             let channel_id = match b.channel.to_lowercase().as_str() {
-                "apple" => Some(arcstr::literal!("0")),
-                "google" => Some(arcstr::literal!("1")),
-                "facebook" => Some(arcstr::literal!("2")),
-                "baidu" => Some(arcstr::literal!("3")),
+                "apple" => Some(arcstr_literal!("0")),
+                "google" => Some(arcstr_literal!("1")),
+                "facebook" => Some(arcstr_literal!("2")),
+                "baidu" => Some(arcstr_literal!("3")),
                 _ => channel_regex
                     .captures(b.channel.as_str())
                     .and_then(|caps| match caps.len() {
@@ -73,47 +73,47 @@ mod tests {
     #[case::bids_with_known_channel_ids(
         vec![vec![
             Event::Bid(Bid {
-                channel: arcstr::literal!("ApPlE"),
+                channel: arcstr_literal!("ApPlE"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("FaceBook"),
+                channel: arcstr_literal!("FaceBook"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("GooGle"),
+                channel: arcstr_literal!("GooGle"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("Baidu"),
+                channel: arcstr_literal!("Baidu"),
                 ..make_bid()
             }),
         ]],
         vec![zset!{
-            (1, 1, 99, arcstr::literal!("ApPlE"), arcstr::literal!("0")) => 1,
-            (1, 1, 99, arcstr::literal!("GooGle"), arcstr::literal!("1")) => 1,
-            (1, 1, 99, arcstr::literal!("FaceBook"), arcstr::literal!("2")) => 1,
-            (1, 1, 99, arcstr::literal!("Baidu"), arcstr::literal!("3")) => 1,
+            (1, 1, 99, arcstr_literal!("ApPlE"), arcstr_literal!("0")) => 1,
+            (1, 1, 99, arcstr_literal!("GooGle"), arcstr_literal!("1")) => 1,
+            (1, 1, 99, arcstr_literal!("FaceBook"), arcstr_literal!("2")) => 1,
+            (1, 1, 99, arcstr_literal!("Baidu"), arcstr_literal!("3")) => 1,
         }],
     )]
     #[case::bids_with_unknown_channel_ids(
         vec![vec![
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/?channel_id=ubuntu"),
+                channel: arcstr_literal!("https://example.com/?channel_id=ubuntu"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/?channel_id=cherry-pie"),
+                channel: arcstr_literal!("https://example.com/?channel_id=cherry-pie"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/?not_channelid=should-not-appear"),
+                channel: arcstr_literal!("https://example.com/?not_channelid=should-not-appear"),
                 ..make_bid()
             }),
         ]],
         vec![zset!{
-            (1, 1, 99, arcstr::literal!("https://example.com/?channel_id=ubuntu"), arcstr::literal!("ubuntu")) => 1,
-            (1, 1, 99, arcstr::literal!("https://example.com/?channel_id=cherry-pie"), arcstr::literal!("cherry-pie")) => 1,
+            (1, 1, 99, arcstr_literal!("https://example.com/?channel_id=ubuntu"), arcstr_literal!("ubuntu")) => 1,
+            (1, 1, 99, arcstr_literal!("https://example.com/?channel_id=cherry-pie"), arcstr_literal!("cherry-pie")) => 1,
         }],
     )]
     fn test_q21(#[case] input_event_batches: Vec<Vec<Event>>, #[case] expected_zsets: Vec<Q21Set>) {

--- a/crates/nexmark/src/queries/q22.rs
+++ b/crates/nexmark/src/queries/q22.rs
@@ -1,7 +1,7 @@
 use super::NexmarkStream;
 use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 
 ///
 /// Query 22: Get URL Directories (Not in original suite)
@@ -61,45 +61,45 @@ pub fn q22(input: NexmarkStream) -> Q22Stream {
 mod tests {
     use super::*;
     use crate::{generator::tests::make_bid, model::Bid};
-    use dbsp::zset;
+    use dbsp::{zset, arcstr_literal};
     use rstest::rstest;
 
     #[rstest]
     #[case::bids_with_well_formed_urls(
         vec![vec![
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/foo/bar/zed"),
+                channel: arcstr_literal!("https://example.com/foo/bar/zed"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/dir1/dir2/dir3/dir4/dir5"),
+                channel: arcstr_literal!("https://example.com/dir1/dir2/dir3/dir4/dir5"),
                 ..make_bid()
             }),
         ]],
         vec![zset!{
-            (1, 1, 99, arcstr::literal!("https://example.com/foo/bar/zed"), arcstr::literal!("foo"), arcstr::literal!("bar"), arcstr::literal!("zed")) => 1,
-            (1, 1, 99, arcstr::literal!("https://example.com/dir1/dir2/dir3/dir4/dir5"), arcstr::literal!("dir1"), arcstr::literal!("dir2"), arcstr::literal!("dir3")) => 1,
+            (1, 1, 99, arcstr_literal!("https://example.com/foo/bar/zed"), arcstr_literal!("foo"), arcstr_literal!("bar"), arcstr_literal!("zed")) => 1,
+            (1, 1, 99, arcstr_literal!("https://example.com/dir1/dir2/dir3/dir4/dir5"), arcstr_literal!("dir1"), arcstr_literal!("dir2"), arcstr_literal!("dir3")) => 1,
         }],
     )]
     #[case::bids_mixed_with_non_urls(
         vec![vec![
             Event::Bid(Bid {
-                channel: arcstr::literal!("https://example.com/foo/bar/zed"),
+                channel: arcstr_literal!("https://example.com/foo/bar/zed"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("Google"),
+                channel: arcstr_literal!("Google"),
                 ..make_bid()
             }),
             Event::Bid(Bid {
-                channel: arcstr::literal!("https:badly.formed/dir1/dir2/dir3"),
+                channel: arcstr_literal!("https:badly.formed/dir1/dir2/dir3"),
                 ..make_bid()
             }),
         ]],
         vec![zset!{
-            (1, 1, 99, arcstr::literal!("https://example.com/foo/bar/zed"), arcstr::literal!("foo"), arcstr::literal!("bar"), arcstr::literal!("zed")) => 1,
-            (1, 1, 99, arcstr::literal!("Google"), arcstr::literal!(""), arcstr::literal!(""), arcstr::literal!("")) => 1,
-            (1, 1, 99, arcstr::literal!("https:badly.formed/dir1/dir2/dir3"), arcstr::literal!("dir3"), arcstr::literal!(""), arcstr::literal!("")) => 1,
+            (1, 1, 99, arcstr_literal!("https://example.com/foo/bar/zed"), arcstr_literal!("foo"), arcstr_literal!("bar"), arcstr_literal!("zed")) => 1,
+            (1, 1, 99, arcstr_literal!("Google"), arcstr_literal!(""), arcstr_literal!(""), arcstr_literal!("")) => 1,
+            (1, 1, 99, arcstr_literal!("https:badly.formed/dir1/dir2/dir3"), arcstr_literal!("dir3"), arcstr_literal!(""), arcstr_literal!("")) => 1,
         }],
     )]
     fn test_q22(#[case] input_event_batches: Vec<Vec<Event>>, #[case] expected_zsets: Vec<Q22Set>) {

--- a/crates/nexmark/src/queries/q7.rs
+++ b/crates/nexmark/src/queries/q7.rs
@@ -4,7 +4,7 @@ use dbsp::{
     operator::{FilterMap, Min},
     RootCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 
 ///
 /// Query 7: Highest Bid

--- a/crates/nexmark/src/queries/q8.rs
+++ b/crates/nexmark/src/queries/q8.rs
@@ -1,7 +1,7 @@
 use super::NexmarkStream;
 use crate::model::Event;
 use dbsp::{operator::FilterMap, RootCircuit, OrdIndexedZSet, OrdZSet, Stream};
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 
 ///
 /// Query 8: Monitor New Users
@@ -98,7 +98,8 @@ mod tests {
         model::{Auction, Event, Person},
     };
     use dbsp::{zset, RootCircuit};
-    use arcstr::ArcStr;
+    use dbsp::algebra::ArcStr;
+    use dbsp::arcstr_literal;
     use rstest::rstest;
 
     #[rstest]
@@ -108,10 +109,10 @@ mod tests {
     // in the next.
     #[case::people_with_auction(
         vec![vec![
-            (1, arcstr::literal!("James Potter"), 9_000),
-            (2, arcstr::literal!("Lily Potter"), 12_000),
-            (3, arcstr::literal!("Harry Potter"), 15_000),
-            (4, arcstr::literal!("Albus D"), 18_000)]],
+            (1, arcstr_literal!("James Potter"), 9_000),
+            (2, arcstr_literal!("Lily Potter"), 12_000),
+            (3, arcstr_literal!("Harry Potter"), 15_000),
+            (4, arcstr_literal!("Albus D"), 18_000)]],
         vec![vec![
             (1, 11_000),
             (2, 15_000),

--- a/crates/nexmark/src/queries/q9.rs
+++ b/crates/nexmark/src/queries/q9.rs
@@ -1,10 +1,11 @@
 use super::NexmarkStream;
 use crate::model::Event;
+use bincode::{Decode, Encode};
 use dbsp::{
     operator::{FilterMap, Max},
     RootCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
-use arcstr::ArcStr;
+use dbsp::algebra::ArcStr;
 use size_of::SizeOf;
 
 /// Query 9: Winning Bids (Not in original suite)
@@ -56,12 +57,10 @@ use size_of::SizeOf;
 /// WHERE rownum <= 1;
 /// ```
 
-#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode)]
+#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, Decode, Encode)]
 pub struct Q9Output(
     u64,
-    #[bincode(with_serde)]
     ArcStr,
-    #[bincode(with_serde)]
     ArcStr,
     usize,
     usize,
@@ -69,13 +68,11 @@ pub struct Q9Output(
     u64,
     u64,
     usize,
-    #[bincode(with_serde)]
     ArcStr,
     u64,
     u64,
     usize,
     u64,
-    #[bincode(with_serde)]
     ArcStr,
 );
 

--- a/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
+++ b/sql-to-dbsp-compiler/SQL-compiler/src/main/java/org/dbsp/sqlCompiler/compiler/backend/rust/RustFileWriter.java
@@ -102,7 +102,7 @@ public class RustFileWriter implements ICompilerComponent {
             "use dbsp::{\n" +
             "    algebra::{ZSet, MulByRef, F32, F64, Semigroup, SemigroupValue, ZRingValue,\n" +
             "         UnimplementedSemigroup, DefaultSemigroup, HasZero, AddByRef, NegByRef,\n" +
-            "         AddAssignByRef,\n" +
+            "         AddAssignByRef, Decimal,\n" +
             "    },\n" +
             "    circuit::{Circuit, Stream},\n" +
             "    operator::{\n" +
@@ -123,6 +123,7 @@ public class RustFileWriter implements ICompilerComponent {
             "};\n" +
             "use dbsp_adapters::Catalog;\n" +
             "use size_of::*;\n" +
+            "use bincode::{Decode, Encode};\n" +
             "use ::serde::{Deserialize,Serialize};\n" +
             "use compare::{Compare, Extract};\n" +
             "use std::{\n" +
@@ -135,7 +136,6 @@ public class RustFileWriter implements ICompilerComponent {
             "    marker::PhantomData,\n" +
             "    str::FromStr,\n" +
             "};\n" +
-            "use rust_decimal::Decimal;\n" +
             "use tuple::declare_tuples;\n" +
             "use sqllib::{\n" +
             "    *,\n" +
@@ -184,7 +184,7 @@ public class RustFileWriter implements ICompilerComponent {
             "#[cfg(test)]\n" +
             "use chrono::{NaiveDate, NaiveDateTime};\n" +
             "#[cfg(test)]\n" +
-            "use rust_decimal::Decimal;\n" +
+            "use dbsp::algebra::Decimal;\n" +
             "#[cfg(test)]\n" +
             "use std::str::FromStr;\n"
             ;

--- a/sql-to-dbsp-compiler/lib/readers/Cargo.toml
+++ b/sql-to-dbsp-compiler/lib/readers/Cargo.toml
@@ -14,3 +14,4 @@ dbsp = { path = "../../../crates/dbsp", features = ["with-serde"], default-featu
 size-of = { version = "0.1.5", features = ["rust_decimal"] }
 sqlx = { version = "0.6", features = [ "runtime-async-std-native-tls", "sqlite", "postgres", "any" ] }
 async-std = { version = "1.12.0", features = ["attributes"]}
+bincode = { version = "2.0.0-rc.2", features = ["serde"] }

--- a/sql-to-dbsp-compiler/lib/readers/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/readers/src/lib.rs
@@ -22,6 +22,7 @@ use sqlx::{
 };
 use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::{fs::File, io::BufReader, path::Path};
+use bincode::{Encode, Decode};
 
 pub fn read_csv<T, Weight>(source_file_path: &str) -> OrdZSet<T, Weight>
 where

--- a/sql-to-dbsp-compiler/lib/sqllib/Cargo.toml
+++ b/sql-to-dbsp-compiler/lib/sqllib/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dbsp = { path = "../../../crates/dbsp" }
-rust_decimal = { version = "1.29", features = ["maths"] }
+dbsp = { path = "../../../crates/dbsp", features = ["decimal_maths"] }
 geo = { version = "0.23" }
 geo-types = { version = "0.7" }
 size-of = { version = "0.1.5", features = ["rust_decimal"] }
@@ -15,3 +14,4 @@ chrono = { version = "0.4.23" }
 like = { version = "0.3.1" }
 paste = { version = "1.0.12" }
 regex = { version = "1.9.1" }
+bincode = { version = "2.0.0-rc.2", features = ["serde"] }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/casts.rs
@@ -6,9 +6,8 @@ use std::cmp::Ordering;
 
 use crate::{geopoint::*, interval::*, timestamp::*};
 use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike, NaiveTime};
-use dbsp::algebra::{HasOne, HasZero, F32, F64};
+use dbsp::algebra::{HasOne, HasZero, F32, F64, Decimal};
 use num::{FromPrimitive, One, ToPrimitive, Zero};
-use rust_decimal::Decimal;
 
 /////////// cast to b
 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/geopoint.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/geopoint.rs
@@ -1,13 +1,27 @@
 // I cannot use the standard geopoint object because it doesn't implement Ord
 
 use ::serde::{Deserialize, Serialize};
+use bincode::Decode;
+use bincode::Encode;
 use dbsp::algebra::F64;
 use geo::EuclideanDistance;
 use geo::Point;
 use size_of::*;
 
 #[derive(
-    Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, SizeOf, Serialize, Deserialize, Debug,
+    Default,
+    Eq,
+    Ord,
+    Clone,
+    Hash,
+    PartialEq,
+    PartialOrd,
+    SizeOf,
+    Serialize,
+    Deserialize,
+    Debug,
+    Encode,
+    Decode,
 )]
 pub struct GeoPoint(F64, F64);
 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/interval.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/interval.rs
@@ -6,11 +6,14 @@
 //! - Long intervals, representing differences between months. These are
 //!   represented as days.
 
+use bincode::{Decode, Encode};
 use num::PrimInt;
 use size_of::SizeOf;
 use std::ops::Mul;
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Encode, Decode,
+)]
 pub struct ShortInterval {
     milliseconds: i64,
 }
@@ -52,7 +55,9 @@ where
 
 /////////////////////////
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Encode, Decode,
+)]
 pub struct LongInterval {
     days: i32,
 }

--- a/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/lib.rs
@@ -7,11 +7,10 @@ pub mod operators;
 pub mod string;
 pub mod timestamp;
 
-use crate::interval::ShortInterval;
-use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64};
+use crate::{interval::ShortInterval};
+use dbsp::algebra::{Semigroup, SemigroupValue, ZRingValue, F32, F64, Decimal};
 use geopoint::GeoPoint;
-use num::{Signed, ToPrimitive};
-use rust_decimal::{Decimal, MathematicalOps};
+use num::{ToPrimitive, Signed};
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::{Add, Index};

--- a/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/operators.rs
@@ -10,7 +10,7 @@ use crate::{
     some_existing_operator
 };
 
-use rust_decimal::{Decimal};
+use dbsp::algebra::Decimal;
 use num::PrimInt;
 use core::ops::{Add,Sub,Mul};
 

--- a/sql-to-dbsp-compiler/lib/sqllib/src/timestamp.rs
+++ b/sql-to-dbsp-compiler/lib/sqllib/src/timestamp.rs
@@ -1,6 +1,7 @@
 //! Support for SQL Timestamp and Date data types.
 
 use crate::interval::{LongInterval, ShortInterval};
+use bincode::{Decode, Encode};
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Timelike, Utc};
 use serde::{de::Error as _, ser::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use size_of::SizeOf;
@@ -18,7 +19,7 @@ use crate::{
 /// Similar to a unix timestamp: a positive time interval between Jan 1 1970 and
 /// the current time. The supported range is limited (e.g., up to 2038 in
 /// MySQL). We use milliseconds to represent the interval.
-#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Encode, Decode)]
 pub struct Timestamp {
     // since unix epoch
     milliseconds: i64,
@@ -314,7 +315,9 @@ some_polymorphic_function1!(floor_week, Timestamp, Timestamp, Timestamp);
 
 //////////////////////////// Date
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf)]
+#[derive(
+    Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Encode, Decode,
+)]
 pub struct Date {
     // since unix epoch
     days: i32,

--- a/sql-to-dbsp-compiler/lib/sqlvalue/Cargo.toml
+++ b/sql-to-dbsp-compiler/lib/sqlvalue/Cargo.toml
@@ -5,5 +5,4 @@ edition = "2021"
 
 [dependencies]
 dbsp = { path = "../../../crates/dbsp", default-features = false }
-rust_decimal = { version = "1.29" }
 sqllib = { path = "../sqllib" }

--- a/sql-to-dbsp-compiler/lib/sqlvalue/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/sqlvalue/src/lib.rs
@@ -4,9 +4,8 @@
 //! Tuple* types are used for computations, and they are converted
 //! to SqlRow objects when they need to be serialized as strings.
 
-use dbsp::algebra::{F32, F64};
-use rust_decimal::Decimal;
-use sqllib::casts::*;
+use dbsp::algebra::{F32, F64, Decimal};
+use sqllib::{casts::*};
 
 #[derive(Debug)]
 pub enum SqlValue {

--- a/sql-to-dbsp-compiler/lib/tuple/src/lib.rs
+++ b/sql-to-dbsp-compiler/lib/tuple/src/lib.rs
@@ -13,7 +13,7 @@ macro_rules! declare_tuples {
         $(,)?
     ) => {
         $(
-            #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, SizeOf, Add, Neg, AddAssign)]
+            #[derive(Default, Eq, Ord, Clone, Hash, PartialEq, PartialOrd, Serialize, Deserialize, SizeOf, Add, Neg, AddAssign, Encode, Decode)]
             pub struct $tuple_name<$($element,)*>($(pub $element,)*);
 
             /*

--- a/sql-to-dbsp-compiler/temp/Cargo.toml
+++ b/sql-to-dbsp-compiler/temp/Cargo.toml
@@ -20,9 +20,9 @@ compare = { version = "0.1.0" }
 size-of = { version = "0.1.1" }
 geo = { version = "0.25.1" }
 geo-types = { version = "0.7" }
-rust_decimal = { version = "1.29" }
 serde_json = { version = "1.0.89" }
 chrono = { version = "0.4.23" }
+bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 
 [dev-dependencies]
 hashing = { path = "../lib/hashing" }


### PR DESCRIPTION
For persistence and distribution, we will need to be able to serialize
and deserialize all of our data.  We're currently using `bincode` for this,
which doesn't support all of the types that we need.
For some purposes, we can use `#[bincode(with_serde)]` for this data.  That
works for fields on structs that we declare, but breaks in a lot of other
contexts.  To work around the problem in those contexts, we need newtype
wrappers.  This commit adds such wrappers.

Other options that don't work yet:

* Get upstream type implementations to add support for `bincode`.  This
  would be ideal, but `bincode` v2 has been in beta for a long time and
  upstream maintainers don't want to support it before its final release.

* Switch to `rkyv`, which is stable and which crate maintainers are more
  willing to accept patches for.  I failed to get DBSP to work with this
  because it requires elaborating type bounds on its `Deserialize` trait
  into every trait and struct that uses it.  Over the DBSP source tree,
  this added up to hundreds of new trait bounds that I just couldn't make
  work.  If Rust ever stabilizes implied trait bounds or trait aliases,
  then `rkyv` will become more viable.

See https://github.com/feldera/dbsp/issues/420 for discussion.