### PR TITLE
dbsp: Prevent ordered-float upgrade beyond v3.8.0.

### DIFF
--- a/crates/dbsp/Cargo.toml
+++ b/crates/dbsp/Cargo.toml
@@ -40,7 +40,8 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 impl-trait-for-tuples = "0.2"
 itertools = "0.10.5"
 textwrap = "0.15.0"
-ordered-float = { version = "3.0.0", features = ["serde", "rkyv"] }
+# ordered-float 3.9.0 is broken: https://github.com/reem/rust-ordered-float/issues/137
+ordered-float = { version = "~3.8", features = ["serde", "rkyv"] }
 bitvec = "1.0.1"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 crossbeam = "0.8.2"


### PR DESCRIPTION
ordered-float v3.9.0 is broken:
https://github.com/reem/rust-ordered-float/issues/137

Until it's fixed or yanked, avoid upgrade.